### PR TITLE
Help overlay in the viewer; Unsafe `ffi_mut`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/mujoco-rs/"
 exclude = ["src/cpp/*", ".gitignore", ".gitmodules"]
 
 [features]
-viewer = ["glfw"]
+viewer = ["glfw", "bitflags"]
 cpp-viewer = []
 
 ffi-regenerate = ["regex", "bindgen"]  # Generate the ffi bindings. Only used for updating the committed ``mujoco_c`` module. 
@@ -22,6 +22,7 @@ ffi-regenerate = ["regex", "bindgen"]  # Generate the ffi bindings. Only used fo
 default = ["viewer"]
 
 [dependencies]
+bitflags = {version = "2.9.4", optional = true}
 glfw = {version = "0.59.0", optional = true}
 
 [build-dependencies]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,31 @@
+//! The most basic example that shows how to load a model from string,
+//! create a [`MjData`] instance and step simulation.
+use std::time::Duration;
+
+use mujoco_rs::prelude::*;
+
+
+const EXAMPLE_MODEL: &str = "
+<mujoco>
+  <worldbody>
+    <light ambient=\"0.2 0.2 0.2\"/>
+    <body name=\"ball\">
+        <geom name=\"green_sphere\" pos=\".2 .2 .2\" size=\".1\" rgba=\"0 1 0 1\"/>
+        <joint type=\"free\"/>
+    </body>
+
+    <geom name=\"floor\" type=\"plane\" size=\"10 10 1\" euler=\"5 0 0\"/>
+
+  </worldbody>
+</mujoco>
+";
+
+fn main() {
+    let model = MjModel::from_xml_string(EXAMPLE_MODEL).expect("could not load the model");
+    let mut data = model.make_data();  // or MjData::new(&model);
+    for i in 0..1000 {
+        println!("Step {i}");
+        data.step();
+        std::thread::sleep(Duration::from_millis(2));
+    }
+}

--- a/src/wrappers/mj_auxiliary.rs
+++ b/src/wrappers/mj_auxiliary.rs
@@ -89,7 +89,7 @@ impl MjVfs {
     }
 
     /// Mutable reference to the wrapped FFI struct.
-    pub fn ffi_mut(&mut self) -> &mut mjVFS {
+    pub unsafe fn ffi_mut(&mut self) -> &mut mjVFS {
         &mut self.ffi
     }
 }

--- a/src/wrappers/mj_data.rs
+++ b/src/wrappers/mj_data.rs
@@ -39,7 +39,7 @@ impl<'a> MjData<'a> {
     }
 
     /// Mutable reference to the wrapped FFI struct.
-    pub fn ffi_mut(&mut self) -> &mut mjData {
+    pub unsafe fn ffi_mut(&mut self) -> &mut mjData {
         unsafe { self.data.as_mut().unwrap() }
     }
 

--- a/src/wrappers/mj_interface.rs
+++ b/src/wrappers/mj_interface.rs
@@ -384,7 +384,7 @@ impl MjUI {
         &self.ui
     }
 
-    pub fn ffi_mut(&mut self) -> &mut mjUI {
+    pub unsafe fn ffi_mut(&mut self) -> &mut mjUI {
         &mut self.ui
     }
 }

--- a/src/wrappers/mj_model.rs
+++ b/src/wrappers/mj_model.rs
@@ -125,7 +125,7 @@ impl MjModel {
     }
 
     /// Returns a mutable reference to the wrapped FFI struct.
-    pub fn ffi_mut(&mut self) -> &mut mjModel {
+    pub unsafe fn ffi_mut(&mut self) -> &mut mjModel {
         unsafe { self.0.as_mut().unwrap() }
     }
 

--- a/src/wrappers/mj_rendering.rs
+++ b/src/wrappers/mj_rendering.rs
@@ -1,5 +1,5 @@
 //! Definitions related to rendering.
-use std::mem::{MaybeUninit, zeroed};
+use std::{ffi::CString, mem::{zeroed, MaybeUninit}};
 use crate::mujoco_c::*;
 
 use super::mj_model::MjModel;
@@ -27,6 +27,15 @@ impl Default for MjrRectangle {
 }
 
 
+/***********************************************************************************************************************
+** MjtFont
+***********************************************************************************************************************/
+pub type MjtFont = mjtFont;
+
+/***********************************************************************************************************************
+** MjtFont
+***********************************************************************************************************************/
+pub type MjtGridPos = mjtGridPos;
 
 /***********************************************************************************************************************
 ** MjrContext
@@ -108,11 +117,24 @@ impl MjrContext {
         unsafe { mjr_setAux(index as i32, self.ffi_mut()); }
     }
 
+    /// Draws a text overlay.
+    pub fn overlay(&mut self, font: MjtFont, gridpos: MjtGridPos, viewport: MjrRectangle, overlay: &str, overlay2: Option<&str>) {
+        let c_overlay = CString::new(overlay).unwrap();
+        let c_overlay2 = overlay2.map(|x| CString::new(x).unwrap());
+
+        unsafe { mjr_overlay(
+            font as i32, gridpos as i32, viewport,
+            c_overlay.as_ptr(),
+            c_overlay2.as_ref().map_or(std::ptr::null(), |x| x.as_ptr()),
+            self.ffi()
+        ); }
+    }
+
     pub fn ffi(&self) -> &mjrContext {
         &self.ffi
     }
 
-    pub fn ffi_mut(&mut self) -> &mut mjrContext {
+    pub unsafe fn ffi_mut(&mut self) -> &mut mjrContext {
         &mut self.ffi
     }
 }

--- a/src/wrappers/mj_visualization.rs
+++ b/src/wrappers/mj_visualization.rs
@@ -334,7 +334,7 @@ impl<'m> MjvScene<'m> {
         &self.ffi
     }
 
-    pub fn ffi_mut(&mut self) -> &mut mjvScene {
+    pub unsafe fn ffi_mut(&mut self) -> &mut mjvScene {
         &mut self.ffi
     }
 }


### PR DESCRIPTION
This adds a help overlay to the viewer.
Additionally, it introduces some breaking changes regarding the `ffi_mut()` methods - they now need unsafe blocks as they allow users to replace internal malloc-allocated pointers.