### PR TITLE
Fix full buffer; fix example; fix unused imports

### DIFF
--- a/examples/tendon.rs
+++ b/examples/tendon.rs
@@ -43,14 +43,10 @@ fn main() {
     let mut viewer = MjViewer::launch_passive(&model, 0)
         .expect("could not launch the viewer");
 
-    // let sensor_data_info = data.sensor("touch").unwrap();
     while viewer.running() {
         /* Step the simulation and sync the viewer */
         viewer.sync(&mut data);
         data.step();
-
-        /* Print the touch sensor output, which is the contact force */
-        // println!("{}", sensor_data_info.view(&data).data[0]);
 
         std::thread::sleep(Duration::from_secs_f64(0.002));
     }

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -18,7 +18,7 @@ use crate::wrappers::mj_data::MjData;
 /****************************************** */
 const MJ_VIEWER_DEFAULT_SIZE_PX: (u32, u32) = (1280, 720);
 /// How much extra room to create in the [`MjvScene`]. Useful for drawing labels, etc.
-const MJ_VIEWER_EXTRA_SCENE_GEOM_SPACE: usize = 20;
+const MJ_VIEWER_EXTRA_SCENE_GEOM_SPACE: usize = 100;
 const DOUBLE_CLICK_WINDOW_MS: u128 = 250;
 
 const HELP_MENU_TITLES: &str = concat!(

--- a/src/wrappers/mj_data.rs
+++ b/src/wrappers/mj_data.rs
@@ -4,8 +4,6 @@ use crate::mujoco_c::*;
 use std::ffi::CString;
 
 use crate::{mj_view_indices, mj_model_nx_to_mapping, mj_model_nx_to_nitem};
-use crate::util::{PointerViewMut, PointerView};
-
 use crate::{view_creator, fixed_size_info_method, info_with_view};
 
 

--- a/src/wrappers/mj_model.rs
+++ b/src/wrappers/mj_model.rs
@@ -9,7 +9,6 @@ use super::mj_auxiliary::MjVfs;
 use super::mj_primitive::*;
 use crate::mujoco_c::*;
 
-use crate::{mj_view_indices, mj_model_nx_to_mapping, mj_model_nx_to_nitem};
 use crate::{view_creator, fixed_size_info_method, info_with_view};
 
 


### PR DESCRIPTION
Fixes the bug #19.
Fixes the tendon example unused lines.
Fixes unused imports in `mj_data` and `mj_model` modules.