### PR TITLE
Complete the virtual file system wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 This project uses [semantic versioning](https://semver.org/).
 
 ## [FUTURE RELEASE] 1.2.0 (MuJoCo 3.3.5)
-- Added function wrappers around some utility functions and both the derivative functions (available under `wrappers::fim`).
+- Added function wrappers around some utility functions and both the derivative functions (available under `wrappers::fun`).
+- Completed the virtual file system wrapper.
+  - Added methods `add_from_file` and `delete_file` to `MjVfs`.
+  - Added method `from_xml_vfs` to `MjModel`.
 
 ## 1.1.0 (MuJoCo 3.3.5)
 **Potentially breaking changes:**

--- a/src/wrappers/mj_auxiliary.rs
+++ b/src/wrappers/mj_auxiliary.rs
@@ -2,6 +2,7 @@
 use std::io::{self, Error, ErrorKind};
 use std::ffi::{c_void, CString};
 use std::mem::MaybeUninit;
+use std::ptr;
 
 
 use crate::mujoco_c::*;
@@ -69,17 +70,64 @@ impl MjVfs {
         Self { ffi }
     }
 
+    /// Adds a file to the virtual file system.
+    /// NOTE: Currently, a [bug](https://github.com/google-deepmind/mujoco/issues/2839)
+    /// exists in the MuJoCo library, where setting NULL for `directory`
+    /// results in a crash. For that purpose, always pass Some("./") if you wish to omit the directory.
+    pub fn add_from_file(&mut self, directory: Option<&str>, filename: &str) -> io::Result<()> {
+        assert!(
+            directory.is_some(),
+            "due to a bug in the MuJoCo C library, the 'directory' argument must always be given. \
+            This assertion will be removed when the bug is fixed.\
+            see https://github.com/google-deepmind/mujoco/issues/2839 for more information."
+        );
+
+        let c_directory = directory.map(|d| CString::new(d).unwrap());
+        let c_filename = CString::new(filename).unwrap();
+        Self::handle_add_result(unsafe {
+            mj_addFileVFS(
+                self.ffi_mut(),
+                c_directory.as_ref().map_or(ptr::null(), |d| d.as_ptr()),
+                c_filename.as_ptr()
+            )
+        })
+    }
+
     /// Adds a file to the virtual file system from a buffer.
     pub fn add_from_buffer(&mut self, filename: &str, buffer: &[u8]) -> io::Result<()> {
-        unsafe {
-            match mj_addBufferVFS(
-                self.ffi_mut(), CString::new(filename).unwrap().as_ptr(),
+        let c_filename = CString::new(filename).unwrap();
+        Self::handle_add_result(unsafe {
+            mj_addBufferVFS(
+                self.ffi_mut(), c_filename.as_ptr(),
                 buffer.as_ptr() as *const c_void, buffer.len() as i32
-            ) {
-                2 => Err(Error::new(ErrorKind::AlreadyExists, "repeated name")),
-                -1 => Err(Error::new(ErrorKind::InvalidData, "failed to load")),
-                _ => Ok(())
-            }
+            )
+        })
+    }
+
+    /// Removes a file from the virtual file system.
+    pub fn delete_file(&mut self, filename: &str) -> io::Result<()> {
+        let c_filename = CString::new(filename).unwrap();
+        unsafe {
+            Self::handle_remove_result(
+                mj_deleteFileVFS(self.ffi_mut(), c_filename.as_ptr())
+            )
+        }
+    }
+
+    fn handle_add_result(result: i32) -> io::Result<()> {
+        match result {
+            0 => Ok(()),
+            2 => Err(Error::new(ErrorKind::AlreadyExists, "repeated name")),
+            -1 => Err(Error::new(ErrorKind::InvalidData, "failed to load")),
+            _ => unreachable!()
+        }
+    }
+
+    fn handle_remove_result(result: i32) -> io::Result<()> {
+        match result {
+            0 => Ok(()),
+            -1 => Err(Error::new(ErrorKind::NotFound, "file not found in the VFS")),
+            _ => unreachable!()
         }
     }
 
@@ -102,3 +150,79 @@ impl Drop for MjVfs {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use crate::wrappers::MjModel;
+    use super::*;
+    use std::fs;
+
+    const RAW_FILE_DATA: &str = "
+<mujoco>
+    <worldbody>
+        <light ambient=\"0.2 0.2 0.2\"/>
+        <body name=\"ball\">
+        <geom name=\"green_sphere\" pos=\".2 .2 .2\" size=\".1\" rgba=\"0 1 0 1\"/>
+        <joint type=\"free\"/>
+        </body>
+        
+        <geom name=\"floor\" type=\"plane\" size=\"10 10 1\" euler=\"5 0 0\"/>
+    </worldbody>
+</mujoco>";
+
+    const RAW_FILE_NAME: &str = "mujoco-rs-name.txt";
+    const REAL_FILE_NAME: &str = "mujoco-rs-real-name.txt";
+
+    #[test]
+    fn test_vfs_file_add_buffer() {
+        let mut vfs = MjVfs::new();
+
+        /* Add from the buffer */
+        assert!(vfs.add_from_buffer(RAW_FILE_NAME, RAW_FILE_DATA.as_bytes()).is_ok());
+        /* Double write should error */
+        assert!(vfs.add_from_buffer(RAW_FILE_NAME, RAW_FILE_DATA.as_bytes()).is_err());
+
+        /* Test whether the model is actually loaded correctly */
+        assert!(MjModel::from_xml_vfs(RAW_FILE_NAME, &vfs).is_ok());
+    }
+
+    #[test]
+    fn test_vfs_file_add_file() {
+        let mut vfs;
+
+        /* Add from a file */
+        fs::write(REAL_FILE_NAME, RAW_FILE_DATA).expect("could not write the file to disk");
+
+        /* No directory */
+        /* 
+        ** TODO: Enable this test in the future.
+        ** It is disabled due to a segmentation fault bug at the MuJoCo's side:
+        ** https://github.com/google-deepmind/mujoco/issues/2839
+        */
+        // vfs = MjVfs::new();
+        // assert!(vfs.add_from_file(None, REAL_FILE_NAME).is_ok());
+        // drop(vfs);
+
+        /* With directory */
+        vfs = MjVfs::new();
+        assert!(vfs.add_from_file(Some("./"), REAL_FILE_NAME).is_ok());
+
+        fs::remove_file(REAL_FILE_NAME).expect("could not delete the file from disk");
+
+        /* Test whether the model is actually loaded correctly */
+        assert!(MjModel::from_xml_vfs(REAL_FILE_NAME, &vfs).is_ok());
+    }
+
+    #[test]
+    fn test_vfs_file_remove() {
+        let mut vfs = MjVfs::new();
+
+        /* Add some file */
+        assert!(vfs.add_from_buffer(RAW_FILE_NAME, RAW_FILE_DATA.as_bytes()).is_ok());
+
+        /* Remove it once (no error should occur) */
+        assert!(vfs.delete_file(RAW_FILE_NAME).is_ok());
+
+        /* Remove it once (an error should occur) */
+        assert!(vfs.delete_file(RAW_FILE_NAME).is_err());
+    }
+}

--- a/src/wrappers/mj_model.rs
+++ b/src/wrappers/mj_model.rs
@@ -66,13 +66,22 @@ unsafe impl Sync for MjModel {}
 
 
 impl MjModel {
-    /// Loads the model from an XML file.
+    /// Loads the model from an XML file. To load from a virtual file system, use [`MjModel::from_xml_vfs`].
     pub fn from_xml<T: AsRef<Path>>(path: T) -> Result<Self, Error> {
+        Self::from_xml_file(path, None)
+    }
+
+    /// Loads the model from an XML file, located in a virtual file system (`vfs`).
+    pub fn from_xml_vfs<T: AsRef<Path>>(path: T, vfs: &MjVfs) -> Result<Self, Error> {
+        Self::from_xml_file(path, Some(vfs))
+    }
+
+    fn from_xml_file<T: AsRef<Path>>(path: T, vfs: Option<&MjVfs>) -> Result<Self, Error> {
         let mut error_buffer = [0i8; 100];
         unsafe {
             let path = CString::new(path.as_ref().to_str().expect("invalid utf")).unwrap();
             let raw_ptr = mj_loadXML(
-                path.as_ptr(), ptr::null(),
+                path.as_ptr(), vfs.map_or(ptr::null(), |v| v.ffi()),
                 &mut error_buffer as *mut i8, error_buffer.len() as c_int
             );
 


### PR DESCRIPTION
Completes the virtual file system wrapper by adding:
- methods `add_from_file` and `delete_file` to `MjVfs` and
- method `from_xml_vfs` to `MjModel`.