### PR TITLE
Change the viewer to not have generic struct parameters

### DIFF
--- a/docs/guide/source/programming/changes.rst
+++ b/docs/guide/source/programming/changes.rst
@@ -23,3 +23,7 @@ Structs with heap-allocated data are wrapped in safe Rust types that automatical
 
 Attributes not directly exposed can be accessed via the ``.ffi()`` or ``.ffi_mut()`` methods.
 For more details, see :ref:`interface_c_api`.
+
+Additionally, :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData` and
+:docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel` provide :ref:`attribute_views` to specific
+item types (joint, body, geom, etc.).

--- a/docs/guide/source/programming/visualization/drawing.rst
+++ b/docs/guide/source/programming/visualization/drawing.rst
@@ -32,7 +32,7 @@ To draw custom geoms to a scene inside a viewer or a renderer, applications need
 This example_ shows how to draw a line between two balls.
 
 In the example we start drawing by first obtaining a mutable reference the user scene and clearing
-its geoms, which are otherwise preserved between viewer syncs:
+its geoms, which are otherwise preserved between syncs:
 
 
 .. code-block:: rust

--- a/docs/guide/source/programming/visualization/renderer.rst
+++ b/docs/guide/source/programming/visualization/renderer.rst
@@ -10,15 +10,18 @@ the renderer exists to provide users the ability to render offscreen. This inclu
 rendering RGB and depth images to either an array or to a file.
 
 The renderer can be constructed via the :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>new`
-method. The method accepts a reference to :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel`
-and the two parameters representing the dimensions of rendered images.
+method. The method accepts a reference to :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel`,
+two parameters representing the dimensions of rendered images, and the maximum number of visual-only geoms,
+drawn by the user program.
 
 After construction, additional options can be set using ``with_`` methods,
-like shown below. By default, RGB rendering is enabled, while depth rendering is disabled.
+like shown below. These follow the builder pattern.
+By default, RGB rendering is enabled, while depth rendering is disabled.
 
 .. code-block:: rust
-
-    let mut renderer: MjRenderer<1280, 720> = MjRenderer::new(&model, 5).unwrap()
+    
+    /* Construct the renderer (model, width, height, max_geom) */.
+    let mut renderer = MjRenderer::new(&model, 1280, 720, 5).unwrap()
         .with_font_scale(MjtFontScale::mjFONTSCALE_100)
         .with_opts(MjvOption::default())
         .with_rgb_rendering(true)  // enabled by default.
@@ -47,7 +50,14 @@ using :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>sync`.
 
 After syncing, :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>rgb` and
 :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>depth` can be used to obtain
-a reference of the rendered image.
+a reference of the rendered image in correct shape, which needs to be specified via method's const generic parameters,
+or :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>rgb_flat` and
+:docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>depth_flat` can be used to obtain
+a flattened images.
 
 To save rendered images to a file, :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>save_rgb`
 and :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>save_depth` can be used.
+These will encode the image into a uncompressed PNG format, where the RGB image will be 8 bits and
+the depth will be 16 bits. These are meant **for visualization**.
+To save depth data in float-32 bit format, which represents **actual distance values** from the camera,
+:docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>save_depth_raw` can be used.

--- a/docs/guide/source/programming/visualization/viewer.rst
+++ b/docs/guide/source/programming/visualization/viewer.rst
@@ -4,10 +4,10 @@
 3D viewer
 =======================
 MuJoCo provides an official viewer application, written in C++, which can also be used in MuJoCo's
-Python package. To avoid C++ dependencies, MuJoCo-rs provides its own 3D viewer, written in Rust.
+Python package. To avoid C++ dependencies, MuJoCo-rs provides **its own 3D viewer, written in Rust**.
 
 We also provide the ability to use the official C++ based viewer, however this requires
-static linking, as described in :ref:`static_link_with_cpp_viewer`.
+static linking to modified MuJoCo code, as described in :ref:`static_link_with_cpp_viewer`.
 
 .. _rust_native_viewer:
 
@@ -16,7 +16,8 @@ Rust-native 3D viewer
 
 Rust-native 3D viewer supports visualization of the 3D scene, as well as interaction via mouse and keyboard.
 This also includes object perturbations.
-Currently, no user interface is provided (buttons, drop-downs, etc.), however it is planned for future development.
+Currently, no user interface is provided (buttons, drop-downs, etc.), however a sort of additional input is
+planned for future development.
 
 A screenshot of the Rust 3D viewer is shown below.
 

--- a/docs/guide/source/programming/visualization/viewer.rst
+++ b/docs/guide/source/programming/visualization/viewer.rst
@@ -85,18 +85,18 @@ MuJoCo-rs also provides a wrapper around a modified MuJoCo's C++ 3D viewer.
 Modifications to the C++ viewer are minor with the purpose of preserving future compatibility
 and to allow viewer rendering in a user-controller loop.
 
-.. warning::
+.. attention::
 
     To avoid a major rewrite of the C++ viewer,  
     the latter is given raw, mutable pointers to both :docs-rs:`mujoco_rs::mujoco_c::<type>mjModel`  
     and :docs-rs:`mujoco_rs::mujoco_c::<type>mjData`, which are wrapped inside  
     :docs-rs:`mujoco_rs::wrappers::mj_model::<struct>MjModel`  
     and :docs-rs:`mujoco_rs::wrappers::mj_data::<struct>MjData`, respectively.  
-    As a result, Rust’s borrow-checker rules are violated. Although undefined behavior is unlikely,  
-    caution is advised.  
+    As a result, Rust's borrow-checker rules are violated. Although incorrect behavior is unlikely,  
+    caution is advised.
 
     It is strongly **recommended** to use the :ref:`rust_native_viewer` when none of the  
-    C++ viewer’s features are required.
+    C++ viewer's features are required.
 
 Here is an example of using the C++ wrapper:
 
@@ -106,7 +106,7 @@ Here is an example of using the C++ wrapper:
         let model = MjModel::from_xml_string(EXAMPLE_MODEL).expect("could not load the model");
         let mut data = model.make_data();  // or MjData::new(&model);
         let mut viewer = MjViewerCpp::launch_passive(&model, &data, 100);
-        let step = model.ffi().opt.timestep;
+        let step = model.opt().timestep;
         while viewer.running() {
             viewer.sync();
             viewer.render(true);  // render on screen   and update the fps timer

--- a/examples/drawing_scene_renderer.rs
+++ b/examples/drawing_scene_renderer.rs
@@ -34,7 +34,7 @@ const EXAMPLE_MODEL: &str = "
 ";
 
 const OUTPUT_DIRECTORY: &str = "./output_renderer/";
-const SAVE_FREQUENCY: u32 = 5;
+const SAVE_FREQUENCY: u32 = 50;
 
 
 fn main() {
@@ -46,7 +46,7 @@ fn main() {
     let mut data = model.make_data();
 
     /* Renderer for rendering at 1280x720 px (width x height) */
-    let mut renderer: MjRenderer<1280, 720> = MjRenderer::new(&model, 5).unwrap()
+    let mut renderer: MjRenderer = MjRenderer::new(&model, 1280, 720, 5).unwrap()
         .with_font_scale(MjtFontScale::mjFONTSCALE_100)
         .with_opts(MjvOption::default())
         .with_rgb_rendering(true)
@@ -82,7 +82,8 @@ fn main() {
             ).connect(0.05, from, to);  // adjust size, pos and mat to make the line connect the ball and the box.
 
             renderer.sync(&mut data);
-            renderer.save_rgb(format!("{OUTPUT_DIRECTORY}/img{i}.png")).unwrap();  // save the internal buffers to file
+            renderer.save_rgb(format!("{OUTPUT_DIRECTORY}/img_rgb{i}.png")).unwrap();
+            renderer.save_depth(format!("{OUTPUT_DIRECTORY}/img_depth{i}.png"), true).unwrap();
         }
     }
 }

--- a/examples/renderer.rs
+++ b/examples/renderer.rs
@@ -35,7 +35,7 @@ const EXAMPLE_MODEL: &str = "
 ";
 
 const OUTPUT_DIRECTORY: &str = "./output_renderer/";
-const SAVE_FREQUENCY: u32 = 5;
+const SAVE_FREQUENCY: u32 = 50;
 
 
 fn main() {
@@ -47,11 +47,11 @@ fn main() {
     let mut data = model.make_data();
 
     /* Renderer for rendering at 1280x720 px (width x height) */
-    let mut renderer: MjRenderer<1280, 720> = MjRenderer::new(&model, 5).unwrap()
+    let mut renderer = MjRenderer::new(&model, 1280, 720, 5).unwrap()
         .with_font_scale(MjtFontScale::mjFONTSCALE_100)
         .with_opts(MjvOption::default())
-        .with_rgb_rendering(true)
-        .with_depth_rendering(true);
+        .with_rgb_rendering(true)  // enabled by default.
+        .with_depth_rendering(true);  // disabled by default.
 
     /* Make a camera that follows the ball */
     let ball_body_id = model.body("ball").unwrap().id;
@@ -65,7 +65,8 @@ fn main() {
         /* Save an image every SAVE_FREQUENCY step */
         if i % SAVE_FREQUENCY == 0 {
             renderer.sync(&mut data);
-            renderer.save_rgb(format!("{OUTPUT_DIRECTORY}/img{i}.png")).unwrap();
+            renderer.save_rgb(format!("{OUTPUT_DIRECTORY}/img_rgb{i}.png")).unwrap();
+            let (_min, _max) = renderer.save_depth(format!("{OUTPUT_DIRECTORY}/img_depth{i}.png"), true).unwrap();
         }
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,7 +1,6 @@
 //! Module related to implementation of the [`MjRenderer`].
 use crate::wrappers::mj_visualization::MjvScene;
 use crate::wrappers::mj_rendering::MjrContext;
-use crate::util::box_zeroed;
 use crate::prelude::*;
 
 use glfw::{Context, InitError, PWindow, WindowHint};
@@ -15,9 +14,14 @@ use std::path::Path;
 use std::fs::File;
 
 
+const RGB_NOT_FOUND_ERR_STR: &str = "RGB rendering is not enabled (renderer.with_rgb_rendering(true))";
+const DEPTH_NOT_FOUND_ERR_STR: &str = "depth rendering is not enabled (renderer.with_depth_rendering(true))";
+const INVALID_INPUT_SIZE: &str = "the input width and height don't match the renderer's configuration";
+
+
 /// A renderer for rendering 3D scenes.
 /// By default, RGB rendering is enabled and depth rendering is disabled.
-pub struct MjRenderer<'m, const WIDTH: usize, const HEIGHT: usize> {
+pub struct MjRenderer<'m> {
     scene: MjvScene<'m>,
     user_scene: MjvScene<'m>,
     context: MjrContext,
@@ -34,21 +38,24 @@ pub struct MjRenderer<'m, const WIDTH: usize, const HEIGHT: usize> {
     /* Storage */
     // Use Box to allow less space to be used
     // when rgb or depth rendering is disabled
-    rgb: Option<Box<[[[u8; 3]; WIDTH]; HEIGHT]>>,
-    depth: Option<Box<[[f32; WIDTH]; HEIGHT]>>,
+    rgb: Option<Box<[u8]>>,
+    depth: Option<Box<[f32]>>,
+
+    width: usize,
+    height: usize,
 }
 
-impl<'m, const WIDTH: usize, const HEIGHT: usize> MjRenderer<'m, WIDTH, HEIGHT> {
+impl<'m> MjRenderer<'m> {
     /// Construct a new renderer.
     /// `max_geom` represents the maximum number of geoms the [`MjvScene`] can hold, which
     /// includes both the user-drawn geoms and the required from [`MjData`] state.
-    pub fn new(model: &'m MjModel, max_geom: usize) -> Result<Self, RendererError> {
+    pub fn new(model: &'m MjModel, width: usize, height: usize, max_geom: usize) -> Result<Self, RendererError> {
         let mut glfw = glfw::init_no_callbacks()
             .map_err(|err| RendererError::GlfwInitError(err))?;
 
         /* Create window for rendering */
         glfw.window_hint(WindowHint::Visible(false));
-        let (mut _window, _) = match glfw.create_window(WIDTH as u32, HEIGHT as u32, "", glfw::WindowMode::Windowed) {
+        let (mut _window, _) = match glfw.create_window(width as u32, height as u32, "", glfw::WindowMode::Windowed) {
             Some(x) => Ok(x),
             None => Err(RendererError::WindowCreationError)
         }?;
@@ -69,7 +76,8 @@ impl<'m, const WIDTH: usize, const HEIGHT: usize> MjRenderer<'m, WIDTH, HEIGHT> 
 
         let mut s = Self {
             scene, user_scene, context, window: _window, model, camera, option,
-            flags: RendererFlags::empty(), rgb: None, depth: None
+            flags: RendererFlags::empty(), rgb: None, depth: None,
+            width, height
         };
 
         s = s.with_rgb_rendering(true);
@@ -80,14 +88,14 @@ impl<'m, const WIDTH: usize, const HEIGHT: usize> MjRenderer<'m, WIDTH, HEIGHT> 
     pub fn with_rgb_rendering(mut self, enable: bool) -> Self {
         // 1. Define the type we want to allocate
         self.flags.set(RendererFlags::RENDER_RGB, enable);
-        self.rgb = if enable { Some(box_zeroed()) } else { None } ;
+        self.rgb = if enable { Some(vec![0; 3 * self.width * self.height].into_boxed_slice()) } else { None } ;
         self
     }
 
     /// Enables/disables depth rendering. To be used on construction.
     pub fn with_depth_rendering(mut self, enable: bool) -> Self {
         self.flags.set(RendererFlags::RENDER_DEPTH, enable);
-        self.depth = if enable { Some(box_zeroed()) } else { None } ;
+        self.depth = if enable { Some(vec![0.0; self.width * self.height].into_boxed_slice()) } else { None } ;
         self
     }
 
@@ -143,12 +151,12 @@ impl<'m, const WIDTH: usize, const HEIGHT: usize> MjRenderer<'m, WIDTH, HEIGHT> 
     /// Use [`MjRenderer::rgb`] or [`MjRenderer::depth`] to obtain the rendered image.
     fn render(&mut self) {
         self.window.make_current();
-        let vp = MjrRectangle::new(0, 0, WIDTH as i32, HEIGHT as i32);
+        let vp = MjrRectangle::new(0, 0, self.width as i32, self.height as i32);
         self.scene.render(&vp, &self.context);
 
         /* Fully flatten everything */
-        let flat_rgb = self.rgb.as_deref_mut().map(|x| x.as_flattened_mut().as_flattened_mut());
-        let flat_depth = self.depth.as_deref_mut().map(|b| b.as_flattened_mut());
+        let flat_rgb = self.rgb.as_deref_mut();
+        let flat_depth = self.depth.as_deref_mut();
 
         /* Read to whatever is enabled */
         self.context.read_pixels(
@@ -156,57 +164,155 @@ impl<'m, const WIDTH: usize, const HEIGHT: usize> MjRenderer<'m, WIDTH, HEIGHT> 
             flat_depth,
             &vp
         );
+
+        /* Make depth values be the actual distance in meters */
+        if let Some(depth) = self.depth.as_deref_mut() {
+            let map = &self.model.vis().map;
+            let near = map.znear;
+            let far = map.zfar;
+            for value in depth {
+                let z_ndc = 2.0 * *value - 1.0;
+                *value = 2.0 * near * far / (far + near - z_ndc * (far - near));
+            }
+        }
     }
 
-    /// Returns an RGB image of the scene.
-    pub fn rgb(&self) -> Option<&[[[u8; 3]; WIDTH]; HEIGHT]> {
+    /// Returns a flattened RGB image of the scene.
+    pub fn rgb_flat(&self) -> Option<&[u8]> {
         self.rgb.as_deref()
     }
 
-    /// Returns a depth image of the scene.
-    pub fn depth(&self) -> Option<&[[f32; WIDTH]; HEIGHT]> {
+    /// Returns an RGB image of the scene. This methods accepts two generic parameters <WIDTH, HEIGHT>
+    /// that define the shape of the output slice.
+    pub fn rgb<const WIDTH: usize, const HEIGHT: usize>(&self) -> io::Result<&[[[u8; 3]; WIDTH]; HEIGHT]> {
+        if let Some(flat) = self.rgb_flat() {
+            if flat.len() == WIDTH * HEIGHT * 3 {
+                let p_shaped = flat.as_ptr() as *const [[[u8; 3]; WIDTH]; HEIGHT];
+
+                // SAFETY: The alignment of the output is the same as the original.
+                // The lifetime also matches  'a in &'a self, which prevents data races.
+                // Length (number of elements) matches the output's.
+                Ok(unsafe { p_shaped.as_ref().unwrap() })
+            }
+            else {
+                Err(io::Error::new(io::ErrorKind::InvalidInput, INVALID_INPUT_SIZE))
+            }
+        }
+        else {
+            Err(io::Error::new(io::ErrorKind::NotFound, RGB_NOT_FOUND_ERR_STR))
+        }
+    }
+
+    /// Returns a flattened depth image of the scene.
+    pub fn depth_flat(&self) -> Option<&[f32]> {
         self.depth.as_deref()
+    }
+
+    /// Returns a depth image of the scene. This methods accepts two generic parameters <WIDTH, HEIGHT>
+    /// that define the shape of the output slice.
+    pub fn depth<const WIDTH: usize, const HEIGHT: usize>(&self) -> io::Result<&[[f32; WIDTH]; HEIGHT]> {
+        if let Some(flat) = self.depth_flat() {
+            if flat.len() == WIDTH * HEIGHT {
+                let p_shaped = flat.as_ptr() as *const [[f32; WIDTH]; HEIGHT];
+
+                // SAFETY: The alignment of the output is the same as the original.
+                // The lifetime matches  'a in &'a self, which prevents data races.
+                // Length (number of elements) matches the output's.
+                Ok(unsafe { p_shaped.as_ref().unwrap() })
+            }
+            else {
+                Err(io::Error::new(io::ErrorKind::InvalidInput, INVALID_INPUT_SIZE))
+            }
+        }
+        else {
+            Err(io::Error::new(io::ErrorKind::NotFound, DEPTH_NOT_FOUND_ERR_STR))
+        }
     }
 
     /// Save an RGB image of the scene to a path.
     /// # Errors
-    /// - [`ErrorKind::InvalidInput`] when RGB rendering is disabled,
+    /// - [`ErrorKind::NotFound`] when RGB rendering is disabled,
     /// - other errors related to write.
     pub fn save_rgb<T: AsRef<Path>>(&self, path: T) -> io::Result<()> {
         if let Some(rgb) = &self.rgb {
             let file = File::create(path.as_ref())?;
             let w = BufWriter::new(file);
 
-            let mut encoder = Encoder::new(w, WIDTH as u32, HEIGHT as u32);
+            let mut encoder = Encoder::new(w, self.width as u32, self.height as u32);
             encoder.set_color(png::ColorType::Rgb);
             encoder.set_depth(png::BitDepth::Eight);
             encoder.set_compression(png::Compression::NoCompression);
 
             let mut writer = encoder.write_header()?;
-            let slice = rgb.as_flattened().as_flattened();
-            writer.write_image_data(slice)?;
+            writer.write_image_data(rgb)?;
             Ok(())
         }
         else {
-            Err(io::Error::new(ErrorKind::InvalidInput, "RGB rendering is not enabled (renderer.with_rgb_rendering(true))"))
+            Err(io::Error::new(ErrorKind::NotFound, RGB_NOT_FOUND_ERR_STR))
         }
     }
 
-    /// Save a depth image of the scene to a path.
+    /// Save a depth image of the scene to a path. The image is 16-bit PNG, which
+    /// can be converted into depth (distance) data by diving the grayscale values by 65535.0 an applying reverse denormalization.
+    /// If `normalize` is `true`, then the data is normalized with min-max normalization.
+    /// Use of [`MjRenderer::save_depth_raw`] is recommended if performance is critical, as
+    /// it skips PNG encoding and also saves the true depth values directly.
+    /// # Returns
+    /// An [`Ok`]`((min, max))` is returned, where min and max represent the normalization parameters.
     /// # Errors
-    /// - [`ErrorKind::InvalidInput`] when depth rendering is disabled,
+    /// - [`ErrorKind::NotFound`] when RGB rendering is disabled,
     /// - other errors related to write.
-    pub fn save_depth<T: AsRef<Path>>(&self, path: T) -> io::Result<()> {
+    pub fn save_depth<T: AsRef<Path>>(&self, path: T, normalize: bool) -> io::Result<(f32, f32)> {
+        if let Some(depth) = &self.depth {
+            let file = File::create(path.as_ref())?;
+            let w = BufWriter::new(file);
+
+            let mut encoder = Encoder::new(w, self.width as u32, self.height as u32);
+            encoder.set_color(png::ColorType::Grayscale);
+            encoder.set_depth(png::BitDepth::Sixteen);
+            encoder.set_compression(png::Compression::NoCompression);
+
+            let (norm, min, max) =
+            if normalize {
+                let max = depth.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+                let min = depth.iter().cloned().fold(f32::INFINITY, f32::min);
+                (depth.iter().flat_map(|&x| (((x - min) / (max - min) * 65535.0).min(65535.0) as u16).to_be_bytes()).collect::<Box<_>>(), min, max)
+            }
+            else {
+                (depth.iter().flat_map(|&x| ((x * 65535.0).min(65535.0) as u16).to_be_bytes()).collect::<Box<_>>(), 0.0, 1.0)
+            };
+
+            let mut writer = encoder.write_header()?;
+            writer.write_image_data(&norm)?;
+            Ok((min, max))
+        }
+        else {
+            Err(io::Error::new(ErrorKind::NotFound, RGB_NOT_FOUND_ERR_STR))
+        }
+    }
+
+    /// Save the raw depth data to the `path`. The data is encoded
+    /// as a sequence of bytes, where groups of four represent a single f32 value.
+    /// The lower bytes of individual f32 appear first (low-endianness).
+    /// # Errors
+    /// - [`ErrorKind::NotFound`] when depth rendering is disabled,
+    /// - other errors related to write.
+    pub fn save_depth_raw<T: AsRef<Path>>(&self, path: T) -> io::Result<()> {
         if let Some(depth) = &self.depth {
             let file = File::create(path.as_ref())?;
             let mut writer = BufWriter::new(file);
-            for item in depth.iter().flatten() {
-                writer.write_all(&item.to_le_bytes())?;
-            }
+
+            /* Fast conversion to a byte slice to prioritize performance */
+            let p = unsafe { std::slice::from_raw_parts(
+                depth.as_ptr() as *const u8,
+                std::mem::size_of::<f32>() * depth.len()
+            ) };
+
+            writer.write_all(p)?;
             Ok(())
         }
         else {
-            Err(io::Error::new(ErrorKind::InvalidInput, "depth rendering is not enabled (renderer.with_depth_rendering(true))"))
+            Err(io::Error::new(ErrorKind::NotFound, DEPTH_NOT_FOUND_ERR_STR))
         }
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -223,7 +223,7 @@ impl<'m> MjRenderer<'m> {
     }
 
     /// Save a depth image of the scene to a path. The image is 16-bit PNG, which
-    /// can be converted into depth (distance) data by diving the grayscale values by 65535.0 an applying reverse denormalization.
+    /// can be converted into depth (distance) data by dividing the grayscale values by 65535.0 an applying reverse denormalization.
     /// If `normalize` is `true`, then the data is normalized with min-max normalization.
     /// Use of [`MjRenderer::save_depth_raw`] is recommended if performance is critical, as
     /// it skips PNG encoding and also saves the true depth values directly.
@@ -257,7 +257,7 @@ impl<'m> MjRenderer<'m> {
             Ok((min, max))
         }
         else {
-            Err(io::Error::new(ErrorKind::NotFound, RGB_NOT_FOUND_ERR_STR))
+            Err(io::Error::new(ErrorKind::NotFound, DEPTH_NOT_FOUND_ERR_STR))
         }
     }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -147,36 +147,6 @@ impl<'m> MjRenderer<'m> {
         self.render();
     }
 
-    /// Draws the scene to internal arrays.
-    /// Use [`MjRenderer::rgb`] or [`MjRenderer::depth`] to obtain the rendered image.
-    fn render(&mut self) {
-        self.window.make_current();
-        let vp = MjrRectangle::new(0, 0, self.width as i32, self.height as i32);
-        self.scene.render(&vp, &self.context);
-
-        /* Fully flatten everything */
-        let flat_rgb = self.rgb.as_deref_mut();
-        let flat_depth = self.depth.as_deref_mut();
-
-        /* Read to whatever is enabled */
-        self.context.read_pixels(
-            flat_rgb,
-            flat_depth,
-            &vp
-        );
-
-        /* Make depth values be the actual distance in meters */
-        if let Some(depth) = self.depth.as_deref_mut() {
-            let map = &self.model.vis().map;
-            let near = map.znear;
-            let far = map.zfar;
-            for value in depth {
-                let z_ndc = 2.0 * *value - 1.0;
-                *value = 2.0 * near * far / (far + near - z_ndc * (far - near));
-            }
-        }
-    }
-
     /// Returns a flattened RGB image of the scene.
     pub fn rgb_flat(&self) -> Option<&[u8]> {
         self.rgb.as_deref()
@@ -313,6 +283,36 @@ impl<'m> MjRenderer<'m> {
         }
         else {
             Err(io::Error::new(ErrorKind::NotFound, DEPTH_NOT_FOUND_ERR_STR))
+        }
+    }
+
+    /// Draws the scene to internal arrays.
+    /// Use [`MjRenderer::rgb`] or [`MjRenderer::depth`] to obtain the rendered image.
+    fn render(&mut self) {
+        self.window.make_current();
+        let vp = MjrRectangle::new(0, 0, self.width as i32, self.height as i32);
+        self.scene.render(&vp, &self.context);
+
+        /* Fully flatten everything */
+        let flat_rgb = self.rgb.as_deref_mut();
+        let flat_depth = self.depth.as_deref_mut();
+
+        /* Read to whatever is enabled */
+        self.context.read_pixels(
+            flat_rgb,
+            flat_depth,
+            &vp
+        );
+
+        /* Make depth values be the actual distance in meters */
+        if let Some(depth) = self.depth.as_deref_mut() {
+            let map = &self.model.vis().map;
+            let near = map.znear;
+            let far = map.zfar;
+            for value in depth {
+                let z_ndc = 2.0 * *value - 1.0;
+                *value = 2.0 * near * far / (far + near - z_ndc * (far - near));
+            }
         }
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -230,7 +230,7 @@ impl<'m> MjRenderer<'m> {
     /// # Returns
     /// An [`Ok`]`((min, max))` is returned, where min and max represent the normalization parameters.
     /// # Errors
-    /// - [`ErrorKind::NotFound`] when RGB rendering is disabled,
+    /// - [`ErrorKind::NotFound`] when depth rendering is disabled,
     /// - other errors related to write.
     pub fn save_depth<T: AsRef<Path>>(&self, path: T, normalize: bool) -> io::Result<(f32, f32)> {
         if let Some(depth) = &self.depth {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,5 @@
 //! Utility related data
 use std::{marker::PhantomData, ops::{Deref, DerefMut}};
-use std::mem;
-use std::ptr;
 
 
 /// Creates a (start, length) tuple based on
@@ -371,16 +369,4 @@ macro_rules! assert_relative_eq {
         let (a, b, eps) = ($a as f64, $b as f64, $eps as f64);
         assert!((a - b).abs() <= eps, "left={:?} right={:?} eps={:?}", a, b, eps);
     }};
-}
-
-
-/// Creates data on the heap, zero initialized.
-pub(crate) fn box_zeroed<T>() -> Box<T> {
-    let mut b: Box<mem::MaybeUninit<T>> = Box::new_uninit();
-
-    unsafe {
-        let ptr = b.as_mut_ptr() as *mut u8;
-        ptr::write_bytes(ptr, 0, mem::size_of::<T>());
-        b.assume_init()
-    }
 }


### PR DESCRIPTION
Changed the viewer to not have generic struct parameters. Additionally, added extra methods to allow proper type conversion from flat arrays.