### PR TITLE
Fix documentation wording

### DIFF
--- a/docs/guide/source/conf.py
+++ b/docs/guide/source/conf.py
@@ -18,7 +18,10 @@ with open("../../../Cargo.toml", "rb") as file:
     crate_meta = tomllib.load(file)
 
 
-release = crate_meta["package"]["version"]
+release = crate_meta["package"]["version"].split(".")
+release[-1] = 'x'  # bug fixes share the same documentation
+release = '.'.join(release)
+
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/guide/source/index.rst
+++ b/docs/guide/source/index.rst
@@ -29,7 +29,7 @@ The main features on top of MuJoCo include:
 - Safe wrappers around structs:
   
   - Automatic allocation and cleanup.
-  - Lifetime guarantees.
+  - Lifetime checks.
 
 - Methods as function wrappers.
 - Easy manipulation of simulation data via :ref:`attribute_views`.
@@ -37,7 +37,7 @@ The main features on top of MuJoCo include:
 - :ref:`visualization`:
 
   - :ref:`mj_renderer`: offscreen rendering to array or file.
-  - :ref:`mj_rust_viewer`: onscreen visualization of the 3D simulation.
+  - :ref:`mj_rust_viewer`: onscreen visualization.
 
     .. image:: ../../img_common/viewer_spot.png
         :width: 50%

--- a/docs/guide/source/installation.rst
+++ b/docs/guide/source/installation.rst
@@ -24,8 +24,9 @@ or compiled. Make sure to download or compile MuJoCo version |MUJOCO_VERSION_BOL
 
 Linking MuJoCo
 ====================
-To compile your code, you must first set some environmental variables,
-telling MuJoCo-rs where to obtain the MuJoCo library.
+Compilation of MuJoCo-rs incudes linking the MuJoCo library.
+This requires some environmental variables to be set, which tell
+MuJoCo-rs where to obtain the MuJoCo library.
 
 The linking process depends on whether you plan do dynamically link (recommended),
 statically link or statically link with the support of C++ based viewer (instead of the Rust-native one).
@@ -96,19 +97,26 @@ We also provide an option to statically link:
 
 Note that the ``/path/mujoco/lib`` needs to contain all the MuJoCo dependencies.
 
+Additionally, official MuJoCo builds include the precompiled MuJoCo library only in its shared (dynamic) form.
+To statically link, you'll need to compile the library yourself.
+MuJoCo's build system doesn't (yet) support static linking, however
+we provide a modified MuJoCo repository, which allow static linking (see :ref:`static_link_with_cpp_viewer`).
+
+
 .. _static_link_with_cpp_viewer:
 
 Static linking with C++ viewer
 ---------------------------------
-While MuJoCo-rs already provides **a Rust-native 3D viewer**, we understand that some projects wish
-to use the original C++ 3D viewer (also named Simulate).
+While MuJoCo-rs already provides a :ref:`rust_native_viewer`, we understand that some projects wish
+to use the original C++ based 3D viewer (also named Simulate).
 To enable this, we provide a modified MuJoCo repository, with modifications
 enabling static linking and a safe interface between Rust and the C++ Simulate code.
 
-To build statically linkable libs with C++ viewer included, perform the following steps:
+To build statically linkable libs with C++ based viewer included, perform the following steps:
 
-1. Clone the MuJoCo-rs repository
-2. Run commands:
+1. Clone the MuJoCo-rs repository,
+2. Change your directory to the cloned repository,
+3. Run commands:
    ::
 
        git submodule update --init --recursive
@@ -116,7 +124,7 @@ To build statically linkable libs with C++ viewer included, perform the followin
        cmake -B build -S . -DBUILD_SHARED_LIBS:BOOL=OFF -DMUJOCO_HARDEN:BOOL=OFF -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON -DMUJOCO_BUILD_EXAMPLES:BOOL=OFF -DCMAKE_EXE_LINKER_FLAGS:STRING=-Wl,--no-as-needed
        cmake --build build --parallel --target libsimulate --config=Release
 
-3. Follow instructions in the :ref:`Static linking <static_linking>` section.
+4. Follow instructions in the :ref:`Static linking <static_linking>` section.
 
 The builds are tested with the ``gcc`` compiler.
 
@@ -129,7 +137,7 @@ MuJoCo-rs should work out of the box after you provide it with the MuJoCo librar
 for additional dependencies, install them via your system package manager.
 For example, to install glfw3 on Ubuntu/Debian, this can be done like so: ``apt install libglfw3-dev``.
 
-Note that on Windows, GLFW will be compiled from scratch.
+Note that on Windows, GLFW will either be compiled from source or downloaded from GLFW's repository.
 If the build doesn't work, please `report this as a bug <https://github.com/davidhozic/mujoco-rs/issues>`_.
 
 

--- a/docs/guide/source/programming/changes.rst
+++ b/docs/guide/source/programming/changes.rst
@@ -21,7 +21,7 @@ Structs
 Most of MuJoCo's structs are plain data structs. In Rust, we mostly keep them as-is, renaming them to PascalCase. 
 Structs with heap-allocated data are wrapped in safe Rust types that automatically manage memory and provide safe attribute access. 
 
-Attributes not directly exposed can be accessed via the ``.ffi()`` or ``.ffi_mut()`` methods.
+Attributes not directly exposed can be accessed via ``.ffi()`` and ``.ffi_mut()`` methods.
 For more details, see :ref:`interface_c_api`.
 
 Additionally, :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData` and

--- a/docs/guide/source/programming/simulation/basic.rst
+++ b/docs/guide/source/programming/simulation/basic.rst
@@ -9,11 +9,11 @@ Loading
 To perform basic simulation with MuJoCo, create a :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel`
 struct by calling one of the following methods:
 
-- :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>from_xml` (loads xml from a file),
+- :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>from_xml` (loads XML from a file),
 - :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>from_xml_vfs`
-  (loads xml from a file on a virtual file system),
+  (loads XML from a file on a virtual file system),
 - :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>from_xml_string`
-  (loads xml from a model defined in a string in memory).
+  (loads XML from a model defined in a string in memory).
 - :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>from_buffer`
   (loads a compiled model from a buffer)
 
@@ -22,7 +22,7 @@ For example:
 .. code-block:: rust
 
     fn main() {
-        let model = MjModel::from_xml("model.rs").expect("could not load the model");
+        let model = MjModel::from_xml("model.xml").expect("could not load the model");
     }
 
 
@@ -38,7 +38,7 @@ For example:
     :emphasize-lines: 3
 
     fn main() {
-        let model = MjModel::from_xml("model.rs").expect("could not load the model");
+        let model = MjModel::from_xml("model.xml").expect("could not load the model");
         let mut data = model.make_data();  // or MjData::new(&model);
     }
 
@@ -53,7 +53,7 @@ method like so:
     :emphasize-lines: 5
 
     fn main() {
-        let model = MjModel::from_xml("model.rs").expect("could not load the model");
+        let model = MjModel::from_xml("model.xml").expect("could not load the model");
         let mut data = model.make_data();  // or MjData::new(&model);
         loop {
             data.step();
@@ -66,30 +66,33 @@ Similarly, :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>ste
 :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>step2` wrap
 :docs-rs:`~~mujoco_rs::mujoco_c::<fn>mj_step1` and :docs-rs:`~~mujoco_rs::mujoco_c::<fn>mj_step2`, respectively.
 
-For more information about the specific MuJoCo functions, see the
+For more information about specific MuJoCo functions, see the
 `MuJoCo documentation <https://mujoco.readthedocs.io/en/stable/APIreference/APIfunctions.html#mj-step>`_.
 
 Realtime
 ----------------------
-The above example will run the simulation as fast as possible.
-To run the simulation at slower pace, simply add a ``std::thread::sleep``
-line after the step.
+The example above runs the simulation as fast as possible.
+To slow it down, you can either add a call to
+`std::thread::sleep <https://doc.rust-lang.org/std/thread/fn.sleep.html>`_
+for an approximate delay, or use
+`std::time::Instant <https://doc.rust-lang.org/std/time/struct.Instant.html>`_
+with `Instant::elapsed <https://doc.rust-lang.org/std/time/struct.Instant.html#method.elapsed>`_
+for precise timing.
 
-To run the code in realtime, the duration in the sleep must match the simulation timestep.
-The simulation timestep can be obtained through the simulation options:
 
 .. code-block:: rust
-    :emphasize-lines: 7, 10
+    :emphasize-lines: 7, 10, 11
 
     use std::time::Duration;
     use std::thread;
 
     fn main() {
-        let model = MjModel::from_xml("model.rs").expect("could not load the model");
+        let model = MjModel::from_xml("model.xml").expect("could not load the model");
         let mut data = model.make_data();  // or MjData::new(&model);
         let timestep = model.opt().timestep;
         loop {
             data.step();
+            /* Approximate-time delay */
             thread::sleep(Duration::from_secs_f64(timestep))
         }
     }

--- a/docs/guide/source/programming/simulation/ffi.rst
+++ b/docs/guide/source/programming/simulation/ffi.rst
@@ -9,7 +9,7 @@ C language structs and functions can be used.
 
 Direct FFI bindings are available inside the :docs-rs:`mujoco_rs::mujoco_c` module.
 
-Mixing between the direct FFI bindings and the rest of MuJoCo-rs is also possible.
+Mixing between direct FFI bindings and the rest of MuJoCo-rs is also possible.
 Most of MuJoCo-rs's structs are actually just FFI structs aliased to a PascalCase name.
 To obtain a reference to the FFI type inside of a wrapped type, call either ``ffi()`` or
 ``ffi_mut()``.

--- a/docs/guide/source/programming/simulation/views.rst
+++ b/docs/guide/source/programming/simulation/views.rst
@@ -4,9 +4,9 @@
 Attribute views
 ===================
 
-The MuJoCo library stores information about joints, bodies, etc., in a
-contiguous arrays, which can be hard to work with, especially when the
-item in question doesn't always have a fixed-size number of e. g. degrees of freedom.
+The MuJoCo library stores data about joints, bodies, and other elements in contiguous arrays.
+These can be challenging to work with, particularly when the array's length varies between elements.
+For example, different types of joints may have different number of degrees of freedom.
 `MuJoCo's Python bindings <https://mujoco.readthedocs.io/en/stable/python.html>`_ solve
 this issue by providing views to specific ranges in the corresponding arrays.
 
@@ -14,8 +14,10 @@ Like MuJoCo's Python bindings, MuJoCo-rs also provides views. Specifically, we p
 attributes of :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData` and
 :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel`.
 
-A view cannot be created directly, as that would violate Rust's borrow checker rules.
-To overcome this, the so called "info" structs must be created first.
+A view cannot be created directly, as that would require recreating the view after each simulation
+step. Allowing preservation of views between simulation steps would violate Rust's borrow checker rules. 
+To overcome this, "info" structs exist, which store required information for fast view
+creation after each step.
 
 Reading
 ======================

--- a/docs/guide/source/programming/simulation/views.rst
+++ b/docs/guide/source/programming/simulation/views.rst
@@ -7,12 +7,12 @@ Attribute views
 The MuJoCo library stores information about joints, bodies, etc., in a
 contiguous arrays, which can be hard to work with, especially when the
 item in question doesn't always have a fixed-size number of e. g. degrees of freedom.
-
-The `Python <https://mujoco.readthedocs.io/en/stable/python.html>`_ MuJoCo bindings solve
+`MuJoCo's Python bindings <https://mujoco.readthedocs.io/en/stable/python.html>`_ solve
 this issue by providing views to specific ranges in the corresponding arrays.
-MuJoCo-rs follows this and also provides views. Specifically we provide views for
-attributes of :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData` and attributes of
-:docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel`:
+
+Like MuJoCo's Python bindings, MuJoCo-rs also provides views. Specifically, we provide views for
+attributes of :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData` and
+:docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel`.
 
 A view cannot be created directly, as that would violate Rust's borrow checker rules.
 To overcome this, the so called "info" structs must be created first.
@@ -28,7 +28,7 @@ like so:
     :emphasize-lines: 4
 
     fn main() {
-        let model = MjModel::from_xml("model.rs").expect("could not load the model");
+        let model = MjModel::from_xml("model.xml").expect("could not load the model");
         let mut data = model.make_data();
         let joint_info = data.joint("football-ball").expect("name not found");
         loop {
@@ -45,7 +45,7 @@ a reference to :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData`, like so
     :emphasize-lines: 7
 
     fn main() {
-        let model = MjModel::from_xml("model.rs").expect("could not load the model");
+        let model = MjModel::from_xml("model.xml").expect("could not load the model");
         let mut data = model.make_data();
         let joint_info = data.joint("football-ball").expect("name not found");
         loop {
@@ -55,13 +55,15 @@ a reference to :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData`, like so
     }
 
 All the attributes inside views, like :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjJointDataView::<structfield>qpos`,
-are instances of :docs-rs:`mujoco_rs::util::<struct>PointerView`, which implements the ``Deref`` trait and thus
-acts like a slice. This is also true for fields that may actually be scalers, which we still treat
-like arrays for consistency and simplicity reasons.
+are instances of :docs-rs:`mujoco_rs::util::<struct>PointerView`, which implements the
+`Deref <https://doc.rust-lang.org/std/ops/trait.Deref.html>`_ trait and on deref
+acts like a slice. While some fields might be scalers, we still treat those as arrays
+for implementation simplicity reasons.
+
 
 Writing
 ==================
-The above examples show a read-only view. To be able to write to the viewed data,
+The above example shows a read-only view. For mutability, 
 :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjJointDataInfo::<method>view_mut` must be called
 and passed a mutable reference to :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData`, like so:
 
@@ -69,7 +71,7 @@ and passed a mutable reference to :docs-rs:`~mujoco_rs::wrappers::mj_data::<stru
     :emphasize-lines: 7
 
     fn main() {
-        let model = MjModel::from_xml("model.rs").expect("could not load the model");
+        let model = MjModel::from_xml("model.xml").expect("could not load the model");
         let mut data = model.make_data();
         let joint_info = data.joint("football-ball").expect("name not found");
         loop {

--- a/docs/guide/source/programming/visualization/viewer.rst
+++ b/docs/guide/source/programming/visualization/viewer.rst
@@ -83,8 +83,8 @@ For more, refer to :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer` and
 Wrapper of MuJoCo's C++ 3D viewer
 =====================================
 MuJoCo-rs also provides a wrapper around a modified MuJoCo's C++ 3D viewer.
-Modifications to the C++ viewer are minor with the purpose of preserving future compatibility
-and to allow viewer rendering in a user-controller loop.
+Modifications to the C++ viewer are minor with the purpose of preserving future compatibility.
+The changes to the viewer are made to allow viewer rendering in a user-controller loop.
 
 .. attention::
 


### PR DESCRIPTION
Fixes documentation (the guide) spelling and wording.