### PR TITLE
Improve `MjRenderer`: builder, setters, getters

### DIFF
--- a/docs/guide/source/_extensions/docs-rs.py
+++ b/docs/guide/source/_extensions/docs-rs.py
@@ -95,7 +95,7 @@ class StripSpecifiers(Transform):
     def apply(self):
         for node in self.document.traverse(nodes.Text):
             text = node.astext()
-            text = re.sub(r"<(\w+)>", "", text)
+            text = re.sub(r"<\w+>(?=\w)", "", text)
             if text.startswith("~~"): # Keep the last two parts
                 text = "::".join(text.split("::")[-2:])
             elif text.startswith("~"):  # Keep the last part

--- a/docs/guide/source/_extensions/gh-example.py
+++ b/docs/guide/source/_extensions/gh-example.py
@@ -62,5 +62,5 @@ class StripSpecifiers(Transform):
     def apply(self):
         for node in self.document.traverse(nodes.Text):
             text = node.astext()
-            text = re.sub(r"<(\w+)>", "", text)
+            text = re.sub(r"<\w+>(?=\w)", "", text)
             node.parent.replace(node, nodes.Text(text))

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -11,6 +11,10 @@ Changelog
 Versioning
 =================
 This project uses `semantic versioning <https://semver.org/>`_.
+This means that any incompatible changes increase the major version (**Y**.x.x).
+This also includes breaking changes that MuJoCo itself introduced, thus even an
+update of MuJoCo alone can increase the major version.
+
 
 Unreleased
 ================================
@@ -20,9 +24,11 @@ Unreleased
   - Added module :docs-rs:`mujoco_rs::wrappers::mj_editing`.
   - Added two examples. One on basic model editing and one on terrain generation.
 
-- :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer` and :docs-rs:`~mujoco_rs::renderer::<struct>MjRenderer`:
+- :docs-rs:`~mujoco_rs::renderer::<struct>MjRenderer`:
 
-  - Increased the headroom for visual-only geoms, which aren't drawn by the user, from 100 to 2000.
+  - Added additional getters and setters.
+  - Added :docs-rs:`~mujoco_rs::renderer::<struct>MjBuilder` for purposes of better
+    configuration.
 
 - :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer`:
 
@@ -41,6 +47,8 @@ Unreleased
       - ``Z``: light,
       - ``T``: transparent,
       - ``I``: inertia.
+
+    - Increased the headroom for visual-only geoms, which aren't drawn by the user, from 100 to 2000.
 
 - :docs-rs:`~mujoco_rs::wrappers::mj_visualization::<type>MjvCamera`:
 

--- a/docs/guide/source/programming/visualization/renderer.rst
+++ b/docs/guide/source/programming/visualization/renderer.rst
@@ -9,24 +9,38 @@ Unlike the :ref:`mj_rust_viewer`, which displays the simulation's 3D scene onto 
 the renderer exists to provide users the ability to render offscreen. This includes
 rendering RGB and depth images to either an array or to a file.
 
-The renderer can be constructed via the :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>new`
-method. The method accepts a reference to :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel`,
-two parameters representing the dimensions of rendered images, and the maximum number of visual-only geoms,
-drawn by the user program.
-
-After construction, additional options can be set using ``with_`` methods,
-like shown below. These follow the builder pattern.
-By default, RGB rendering is enabled, while depth rendering is disabled.
+The renderer can be constructed by its builder (:docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>builder`)
+or directly with :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>new`, however the latter offers less control.
+method. By default, RGB rendering is enabled, while depth rendering is disabled.
 
 .. code-block:: rust
     
-    /* Construct the renderer (model, width, height, max_geom) */.
-    let mut renderer = MjRenderer::new(&model, 1280, 720, 5).unwrap()
-        .with_font_scale(MjtFontScale::mjFONTSCALE_100)
-        .with_opts(MjvOption::default())
-        .with_rgb_rendering(true)  // enabled by default.
-        .with_depth_rendering(false)  // disabled by default.
-        .with_camera(MjvCamera::new_free(&model));
+    /* Build the renderer */.
+    let mut renderer = MjRenderer::builder()
+        .width(0).height(0)  // set to width(0) and height(0) to set automatically based on <global offwidth="1920" offheight="1080"/>
+        .num_visual_user_geom(5)  // maximum number of visual-only geoms as result of the user
+        .num_visual_internal_geom(0)  // maximum number of visual-only geoms not as result of the user
+        .font_scale(MjtFontScale::mjFONTSCALE_100)  // scale of the font drawn by OpenGL
+        .rgb(true)  // rgb rendering
+        .depth(true)  // depth rendering
+        .camera(MjvCamera::default())  // default free camera
+        .build(&model).expect("failed to initialize the renderer");
+
+
+.. attention::
+
+    Renderer's *width* and *depth* must be equal to or less than the offscreen buffer size,
+    configured during MuJoCo's model definition:
+
+    .. code-block:: xml
+
+        <mujoco>
+            <visual>
+                <global offwidth="1920" offheight="1080"/>
+            </visual>
+            ...
+        </mujoco>
+
 
 Much like the viewer, the renderer must also be synced with the simulation state,
 using :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>sync`.

--- a/examples/drawing_scene_renderer.rs
+++ b/examples/drawing_scene_renderer.rs
@@ -46,11 +46,15 @@ fn main() {
     let mut data = model.make_data();
 
     /* Renderer for rendering at 1280x720 px (width x height) */
-    let mut renderer: MjRenderer = MjRenderer::new(&model, 1280, 720, 5).unwrap()
-        .with_font_scale(MjtFontScale::mjFONTSCALE_100)
-        .with_opts(MjvOption::default())
-        .with_rgb_rendering(true)
-        .with_depth_rendering(true);
+    let mut renderer = MjRenderer::builder()
+        .width(0).height(0)  // set to width(0) and height(0) to set automatically based on <global offwidth="1920" offheight="1080"/>
+        .num_visual_user_geom(5)  // maximum number of visual-only geoms as result of the user
+        .num_visual_internal_geom(0)  // maximum number of visual-only geoms not as result of the user
+        .font_scale(MjtFontScale::mjFONTSCALE_100)  // scale of the font drawn by OpenGL
+        .rgb(true)  // rgb rendering
+        .depth(true)  // depth rendering
+        .camera(MjvCamera::default())  // default free camera
+        .build(&model).expect("failed to initialize the renderer");
 
     /* Make a camera that follows the ball */
     let ball_body_id = model.body("ball").unwrap().id;

--- a/examples/renderer.rs
+++ b/examples/renderer.rs
@@ -47,11 +47,15 @@ fn main() {
     let mut data = model.make_data();
 
     /* Renderer for rendering at 1280x720 px (width x height) */
-    let mut renderer = MjRenderer::new(&model, 1280, 720, 5).unwrap()
-        .with_font_scale(MjtFontScale::mjFONTSCALE_100)
-        .with_opts(MjvOption::default())
-        .with_rgb_rendering(true)  // enabled by default.
-        .with_depth_rendering(true);  // disabled by default.
+    let mut renderer = MjRenderer::builder()
+        .width(0).height(0)  // set to width(0) and height(0) to set automatically based on <global offwidth="1920" offheight="1080"/>
+        .num_visual_user_geom(5)  // maximum number of visual-only geoms as result of the user
+        .num_visual_internal_geom(0)  // maximum number of visual-only geoms not as result of the user
+        .font_scale(MjtFontScale::mjFONTSCALE_100)  // scale of the font drawn by OpenGL
+        .rgb(true)  // rgb rendering
+        .depth(true)  // depth rendering
+        .camera(MjvCamera::default())  // default free camera
+        .build(&model).expect("failed to initialize the renderer");
 
     /* Make a camera that follows the ball */
     let ball_body_id = model.body("ball").unwrap().id;

--- a/examples/renderer.rs
+++ b/examples/renderer.rs
@@ -5,34 +5,34 @@ use mujoco_rs::prelude::*;
 use std::fs;
 
 
-const EXAMPLE_MODEL: &str = "
+const EXAMPLE_MODEL: &str = stringify!(
 <mujoco>
     <!--  OpenGL buffer size  -->
     <visual>
-    <global offwidth=\"1920\" offheight=\"1080\"/>
+    <global offwidth="1920" offheight="1080"/>
     </visual>
 
     <worldbody>
-        <light ambient=\"0.2 0.2 0.2\"/>
-        <body name=\"ball\">
-            <geom name=\"green_sphere\" size=\".1\" rgba=\"0 1 0 1\" mass=\"1\"/>
-            <joint name=\"ball\" type=\"free\"/>
-            <site name=\"touch\" size=\".1 .1 .1\" pos=\"0 0 0\" rgba=\"0 0 0 0.0\" type=\"box\"/>
+        <light ambient="0.2 0.2 0.2"/>
+        <body name="ball">
+            <geom name="green_sphere" size=".1" rgba="0 1 0 1" mass="1"/>
+            <joint name="ball" type="free"/>
+            <site name="touch" size=".1 .1 .1" pos="0 0 0" rgba="0 0 0 0.0" type="box"/>
         </body>
 
-        <body pos=\"2 0 2\">
-            <geom type=\"box\" size=\"1 1 1\" rgba=\"0 1 1 1\"/>
-            <joint name=\"box\" type=\"free\"/>
+        <body pos="2 0 2">
+            <geom type="box" size="1 1 1" rgba="0 1 1 1"/>
+            <joint name="box" type="free"/>
         </body>
 
-        <geom name=\"floor\" type=\"plane\" size=\"10 10 1\" euler=\"20 0 0\"/>
+        <geom name="floor" type="plane" size="10 10 1" euler="20 0 0"/>
     </worldbody>
 
     <sensor>
-        <touch name=\"touch\" site=\"touch\"/>
+        <touch name="touch" site="touch"/>
     </sensor>
 </mujoco>
-";
+);
 
 const OUTPUT_DIRECTORY: &str = "./output_renderer/";
 const SAVE_FREQUENCY: u32 = 50;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! 
 //! ## Model editing
 //! [`MjModel`](wrappers::MjModel) can be procedurally generated through the model editing module.
-//! The specification representing the model is [wrappers::mj_editing::MjSpec]
+//! The specification representing the model is [`wrappers::mj_editing::MjSpec`]
 //! 
 //! ## Features
 //! This crate has the following public features:

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -104,7 +104,7 @@ which can be configured at the top of the model's XML like so:
         if width == 0 && height == 0 {
             let global = &model.vis().global;
             height = global.offheight as u32;
-            width = global.offheight as u32;
+            width = global.offwidth as u32;
         }
 
         let mut glfw = glfw::init_no_callbacks()
@@ -397,7 +397,7 @@ impl<'m> MjRenderer<'m> {
     }
 
     /// Save a depth image of the scene to a path. The image is 16-bit PNG, which
-    /// can be converted into depth (distance) data by dividing the grayscale values by 65535.0 an applying denormalization.
+    /// can be converted into depth (distance) data by dividing the grayscale values by 65535.0 and applying denormalization.
     /// If `normalize` is `true`, then the data is normalized with min-max normalization.
     /// Use of [`MjRenderer::save_depth_raw`] is recommended if performance is critical, as
     /// it skips PNG encoding and also saves the true depth values directly.

--- a/src/util.rs
+++ b/src/util.rs
@@ -499,6 +499,22 @@ macro_rules! getter_setter {
     };
 }
 
+
+#[doc(hidden)]
+#[macro_export]
+/// Constructs builder methods.
+macro_rules! builder_setters {
+    ($($name:ident: $type:ty; $comment:expr);* $(;)?) => {
+        $(
+            #[doc = concat!("Set ", $comment)]
+            pub fn $name(mut self, value: $type) -> Self {
+                self.$name = value;
+                self
+            }
+        )*
+    };
+}
+
 /// assert_eq!, but with tolerance for floating point rounding.
 #[doc(hidden)]
 #[macro_export]


### PR DESCRIPTION
Implements a builder (`MjRendererBuilder`) for the renderer.
Adds additional setters and getters.