### PR TITLE
Fix GLFW dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ all-features = true
 
 
 [features]
-viewer = ["dep:glfw", "dep:bitflags"]
-renderer = ["dep:png", "dep:glfw"]
+viewer = ["dep:glfw-mjrc-fork", "dep:bitflags"]
+renderer = ["dep:png", "dep:glfw-mjrc-fork"]
 cpp-viewer = ["viewer"]
 
 ffi-regenerate = ["dep:regex", "dep:bindgen"]  # Generate the ffi bindings. Only used for updating the committed ``mujoco_c`` module. 
 
-glfw-build = ["glfw/src-build"]
+glfw-build = ["glfw-mjrc-fork/src-build"]
 
 default = ["viewer", "renderer"]
 
@@ -35,18 +35,14 @@ paste = "1.0.15"
 
 # Pre-built libs on Windows and build everywhere else
 [target.'cfg(unix)'.dependencies]
-glfw = {version = "0.60.0", optional = true, default-features = false, features = [
+glfw-mjrc-fork = {version = "0.60.0", optional = true, default-features = false, features = [
    "static-link", "raw-window-handle-v0-6", "x11"
 ]}
 
 [target.'cfg(windows)'.dependencies]
-glfw = {version = "0.60.0", optional = true, default-features = false, features = [
+glfw-mjrc-fork = {version = "0.60.0", optional = true, default-features = false, features = [
     "prebuilt-libs", "static-link", "raw-window-handle-v0-6"
 ]}
-
-[patch.crates-io]
-glfw = {git = "https://github.com/davidhozic/glfw-rs", branch = "patch-1"}
-glfw-sys = {git = "https://github.com/davidhozic/glfw-sys.git", branch = "patch-1"}
 
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ More detailed documentation is available at the:
 ## MuJoCo version
 This library uses FFI bindings to MuJoCo **3.3.5**.
 
+You can download it from [official MuJoCo releases](https://github.com/google-deepmind/mujoco/releases/tag/3.3.5).
+
+
 ## Installation
-For installation see the [**guide book**](https://mujoco-rs.readthedocs.io/en/stable/).
+For installation, see the [**guide book**](https://mujoco-rs.readthedocs.io/en/stable/installation.html).
 
 ## Main features
 MuJoCo-rs tries to stay close to the MuJoCo's C API, with a few additional features for ease of use.
@@ -56,9 +59,10 @@ Optional Cargo features can be enabled:
 By default, ``viewer`` and ``renderer`` are enabled.
 
 ## Missing libraries
-The crate should work out of the box after you provide it with the MuJoCo library. If the build fails and asks
-for additional dependencies, install them via your system package manager.
-For example, to install glfw3 on Ubuntu/Debian, this can be done like so: ``apt install libglfw3-dev``.
+MuJoCo-rs should on Windows work without problems after the MuJoCo library
+is provided. On Linux (and potentially MacOS, which we don't test) you may need
+additional build-time dependencies, such as CMake. This depends
+on your Linux distro and whether you want visualization/rendering support. See the [installation guide](https://mujoco-rs.readthedocs.io/en/stable/installation.html#build-dependencies-visualization-rendering-only) for more information.
 
 ## NOTE
 This project is WIP but functional. I accept pull requests about bug fixes

--- a/docs/guide/source/_extensions/gh-example.py
+++ b/docs/guide/source/_extensions/gh-example.py
@@ -52,7 +52,7 @@ def link_docs_rs(name, rawtext, text: str, lineno, inliner, options={}, content=
     repository = "mujoco-rs"
     author_gh = "davidhozic"
 
-    url = f"https://github.com/{author_gh}/{repository}/blob/release/{release}/examples/{link_text}"
+    url = f"https://github.com/{author_gh}/{repository}/blob/v{release}/examples/{link_text}"
     node = nodes.reference(rawtext, text, refuri=url, **options)
     return [node], []
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -16,7 +16,7 @@ This also includes breaking changes that MuJoCo itself introduced, thus even an
 update of MuJoCo alone can increase the major version.
 
 
-Unreleased
+1.4.0 (MuJoCo 3.3.5)
 ================================
 - |mj_model|:
 

--- a/docs/guide/source/installation.rst
+++ b/docs/guide/source/installation.rst
@@ -97,7 +97,7 @@ Alternatively, the DLL file can be placed in the working directory.
 
     Make sure the PATH variable contains the path to the **.dll** file, **NOT .lib**.
     The **.lib** file is used only for compilation, while the **.dll** is used at runtime.
-    The **.dll** file should be contained in the ``bin/`` directory of the MuJoCo download.
+    The **.dll** file is contained in the ``bin/`` directory of the MuJoCo download.
 
 
 MacOS
@@ -111,31 +111,17 @@ MacOS is currently untested.
 
 Static linking
 ~~~~~~~~~~~~~~~~~~
-We also provide an option to statically link:
-::
+**Official MuJoCo builds** include the precompiled MuJoCo library only in its **shared (dynamic) form**.
+To statically link, you'll need to **compile** MuJoCo **yourself**.
+MuJoCo's build system doesn't (yet) support static linking, which is why
+we provide a modified MuJoCo repository with static linking support.
 
-   export MUJOCO_STATIC_LINK_DIR=/path/mujoco/lib/
-   cargo build
-
-
-Note that the ``/path/mujoco/lib`` needs to contain all the MuJoCo dependencies.
-
-Additionally, official MuJoCo builds include the precompiled MuJoCo library only in its shared (dynamic) form.
-To statically link, you'll need to compile the library yourself.
-MuJoCo's build system doesn't (yet) support static linking, however
-we provide a modified MuJoCo repository, which allow static linking (see :ref:`static_link_with_cpp_viewer`).
-
-
-.. _static_link_with_cpp_viewer:
-
-Static linking with C++ viewer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 While MuJoCo-rs already provides a :ref:`rust_native_viewer`, we understand that some projects wish
 to use the original C++ based 3D viewer (also named Simulate).
-To enable this, we provide a modified MuJoCo repository, with modifications
-enabling static linking and a safe interface between Rust and the C++ Simulate code.
+To enable this, the modified MuJoCo repository also includes changes that support
+a safe interface between Rust and the C++ Simulate code.
 
-To build statically linkable libs with C++ based viewer included perform the following steps:
+To build statically linkable libraries, perform the following steps:
 
 1. Clone the MuJoCo-rs repository,
 2. Change your directory to the cloned repository,
@@ -147,9 +133,29 @@ To build statically linkable libs with C++ based viewer included perform the fol
        cmake -B build -S . -DBUILD_SHARED_LIBS:BOOL=OFF -DMUJOCO_HARDEN:BOOL=OFF -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON -DMUJOCO_BUILD_EXAMPLES:BOOL=OFF -DCMAKE_EXE_LINKER_FLAGS:STRING=-Wl,--no-as-needed
        cmake --build build --parallel --target libsimulate --config=Release
 
-4. Follow instructions in the :ref:`Static linking <static_linking>` section.
+   The builds are tested with the ``gcc`` compiler.
 
-The builds are tested with the ``gcc`` compiler.
+4. Set the environmental variable ``MUJOCO_STATIC_LINK_DIR``. Bash example:
+
+   ::
+
+      export MUJOCO_STATIC_LINK_DIR=/path/mujoco/lib/
+
+5. Build MuJoCo-rs
+
+   ::
+
+      cargo build
+
+   .. attention::
+
+      On **Linux**, you may need to tell Rust to use the system linker instead of rust-lld.
+      This is a problem with LTO and different linkers being used to link MuJoCo-rs and MuJoCo.
+      The problem will be addressed in a future MuJoCo-rs release.    
+
+      ::
+
+        RUSTFLAGS="-C linker-features=-lld" cargo build
 
 
 .. _build_deps:

--- a/docs/guide/source/programming/visualization/viewer.rst
+++ b/docs/guide/source/programming/visualization/viewer.rst
@@ -7,7 +7,7 @@ MuJoCo provides an official viewer application, written in C++, which can also b
 Python package. To avoid C++ dependencies, MuJoCo-rs provides **its own 3D viewer, written in Rust**.
 
 We also provide the ability to use the official C++ based viewer, however this requires
-static linking to modified MuJoCo code, as described in :ref:`static_link_with_cpp_viewer`.
+static linking to modified MuJoCo code, as described in :ref:`static_linking`.
 
 .. _rust_native_viewer:
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -7,7 +7,6 @@ use crate::prelude::*;
 use glfw_mjrc_fork as glfw;
 use glfw_mjrc_fork::{Context, InitError, PWindow, WindowHint};
 
-
 use bitflags::bitflags;
 use png::Encoder;
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -5,7 +5,7 @@ use crate::builder_setters;
 use crate::prelude::*;
 
 use glfw_mjrc_fork as glfw;
-use glfw::{Context, InitError, PWindow, WindowHint};
+use glfw_mjrc_fork::{Context, InitError, PWindow, WindowHint};
 
 
 use bitflags::bitflags;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -4,7 +4,10 @@ use crate::wrappers::mj_rendering::MjrContext;
 use crate::builder_setters;
 use crate::prelude::*;
 
+use glfw_mjrc_fork as glfw;
 use glfw::{Context, InitError, PWindow, WindowHint};
+
+
 use bitflags::bitflags;
 use png::Encoder;
 

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -1,6 +1,8 @@
 //! Module related to implementation of the [`MjViewer`] and [`MjViewerCpp`].
 
+use glfw_mjrc_fork as glfw;
 use glfw::{Action, Context, Glfw, GlfwReceiver, Key, Modifiers, MouseButton, PWindow, WindowEvent, WindowMode};
+
 use bitflags::bitflags;
 
 use std::time::Instant;

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -1,7 +1,7 @@
 //! Module related to implementation of the [`MjViewer`] and [`MjViewerCpp`].
 
 use glfw_mjrc_fork as glfw;
-use glfw::{Action, Context, Glfw, GlfwReceiver, Key, Modifiers, MouseButton, PWindow, WindowEvent, WindowMode};
+use glfw_mjrc_fork::{Action, Context, Glfw, GlfwReceiver, Key, Modifiers, MouseButton, PWindow, WindowEvent, WindowMode};
 
 use bitflags::bitflags;
 


### PR DESCRIPTION
Fixes GLFW dependencies in such way that publishing to crates.io is allowed.

Originally, ``[patch]`` was used, which does not allow the crate to be published to crates.io.