### PR TITLE
Fix dragging of UI to cause dragging in the scene

### DIFF
--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -413,11 +413,11 @@ impl<M: Deref<Target = MjModel> + Clone> MjViewer<M> {
                     let PhysicalPosition { x, y } = position;
 
                     // The UI might not be detected as covered as dragging can happen slightly outside
-                    // of a (popup) window. This might seem as a ad-hoc solution, but is at the time the
+                    // of a (popup) window. This might seem like an ad-hoc solution, but is at the time the
                     // shortest and most efficient one.
                     #[cfg(feature = "viewer-ui")]
                     if self.ui.dragged() {
-                        continue;    
+                        continue;
                     }
 
                     self.process_cursor_pos(x, y, data);

--- a/src/viewer/ui.rs
+++ b/src/viewer/ui.rs
@@ -543,7 +543,8 @@ impl<M: Deref<Target = MjModel>> ViewerUI<M> {
         self.egui_ctx.is_pointer_over_area()
     }
 
-    pub (crate) fn dragged(&self) -> bool {
+    /// Checks whether the UI is currently being dragged.
+    pub(crate) fn dragged(&self) -> bool {
         self.egui_ctx.dragged_id().is_some()
     }
 


### PR DESCRIPTION
Whenever viewer UI's popups were open and drag was being done on them with the cursor just slightly outside their area, the drag of the popup window also caused the camera of the MuJoCo scene to be moved.