### PR TITLE
Depth rendering on Rust viewer

### DIFF
--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -108,6 +108,8 @@ Unreleased [3.0.0] (MuJoCo 3.5.0)
 
   - Updated enum type aliases.
   - Improved fixed-size array pointer handling.
+  - Added support for ``Depth`` rendering flag (``mjRND_DEPTH``) to ``MjViewer``.
+  - |mj_data| and |mj_model| views now contain extra fields.
 
 2.3.3 (MuJoCo 3.3.7)
 =============================

--- a/src/viewer/ui.rs
+++ b/src/viewer/ui.rs
@@ -36,7 +36,7 @@ const TOGGLE_LABEL_HEIGHT_EXTRA_SPACE: f32 = 20.0;
 const SIDE_PANEL_PAD: f32 = 10.0;
 
 /// Maps [`MjtRndFlag`](crate::wrappers::mj_visualization::MjtRndFlag) to their string
-const GL_EFFECT_MAP: [&str; 10] = [
+const GL_EFFECT_MAP: [&str; 11] = [
     "Shadow",
     "Wireframe",
     "Reflection",
@@ -44,6 +44,7 @@ const GL_EFFECT_MAP: [&str; 10] = [
     "Skybox",
     "Fog",
     "Haze",
+    "Depth",
     "Segment",
     "ID color",
     "Cull face"


### PR DESCRIPTION
Implements the depth flag in the MjViewer's UI for rendering depth. Note that shadows need to be disabled.