### PR TITLE
Implement missing Sync and Send bounds

### DIFF
--- a/.agents/rules/coding-conventions.md
+++ b/.agents/rules/coding-conventions.md
@@ -27,7 +27,7 @@ trigger: always_on
 
 ## Documentation
 - Always verify any changes made to MuJoCo's official documentation to verify everything is correct.
-- Any changes made should be reflected in the changelog: `docs/guide/changelog.rst`.
+- Any changes made should be reflected in the changelog: `docs/guide/source/changelog.rst`.
   Make sure to follow the conventions and style of previous changelog entries.
 - Always make sure MuJoCo-rs's documentation in `docs/guide` stays up to date with the changes.
 

--- a/.agents/rules/important-context.md
+++ b/.agents/rules/important-context.md
@@ -66,6 +66,7 @@ All linking env vars must be **absolute paths**. Use `realpath` to convert relat
 - **Boolean flag inversion**: `flg_local as i32` is correct when the C function expects 1=local/0=world. Watch for accidental `!flg_local as i32` which silently inverts the meaning with no crash.
 - **`mj_view_indices!` last-joint edge case**: for the final joint in a model there is no next address entry, so the macro falls back to `$max_n` (e.g. `nq` for qpos-addressed fields) as the exclusive end. Double-check this path when adding new fields that use `mj_view_indices!`.
 - **Free/ball joints and nq vs njnt**: `nq != njnt` for models with free joints (7 qpos each) or ball joints (4 qpos each). `mj_model_nx_to_nitem!(model, nq)` returns `njnt` not `nq`. The `mj_view_indices!` macro computes the correct per-joint slice within the total array.
+- **Send/Sync bounds for generic wrapper types**: When a wrapper is generic over a type parameter, any `unsafe impl Send/Sync` MUST require the generic parameter to also be `Send` / `Sync` respectively. Without these bounds, non-thread-safe inner types would be incorrectly marked as `Send + Sync`.
 
 ## Comprehensive code verification
 When doing a deep audit for type mismatches, stride errors, UB, or memory safety issues:

--- a/.agents/workflows/verify.md
+++ b/.agents/workflows/verify.md
@@ -58,7 +58,7 @@ Build a numbered list covering all verification items. Organize by concern group
 ### F. Lifecycle and concurrency
 - Visualization struct lifecycle (Drop impl correctness)
 - Box<MaybeUninit> initialization patterns (fully written before use)
-- Send/Sync impl safety for MjModel, MjData
+- Send/Sync impl safety: verify that all `unsafe impl Send/Sync` for generic wrapper types require the generic parameter to also be `Send` / `Sync`
 - MjData model signature check in view methods
 
 ### G. Edge cases and misc

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -401,6 +401,10 @@ update of MuJoCo alone can increase the major version.
     panics via Rust's bounds checker instead of causing undefined behavior.
     In release mode, the slice index will panic instead of the ``debug_assert!``.
 
+  - The ``unsafe impl Send`` and ``unsafe impl Sync`` for |mj_data| now require the inner
+    model handle ``M`` to itself be ``Send`` / ``Sync``, matching the bounds already present on
+    |mjv_scene|. Previously, ``MjData<Rc<MjModel>>`` was incorrectly ``Send + Sync``.
+
 - Other changes:
 
   - Updated enum type aliases.

--- a/src/wrappers/mj_data.rs
+++ b/src/wrappers/mj_data.rs
@@ -58,10 +58,11 @@ impl<M: Deref<Target = MjModel> + Debug> Debug for MjData<M> {
     }
 }
 
-// Allow usage in threaded contexts as the data won't be shared anywhere outside Rust,
-// except in the C++ code.
-unsafe impl<M: Deref<Target = MjModel>> Send for MjData<M> {}
-unsafe impl<M: Deref<Target = MjModel>> Sync for MjData<M> {}
+// Allow usage in threaded contexts as long as M itself is Send / Sync
+// (e.g. Arc<MjModel>). Non-Send M types such as Rc<MjModel> are correctly
+// excluded by the M: Send / M: Sync bounds.
+unsafe impl<M: Deref<Target = MjModel> + Send> Send for MjData<M> {}
+unsafe impl<M: Deref<Target = MjModel> + Sync> Sync for MjData<M> {}
 
 
 impl<M: Deref<Target = MjModel>> MjData<M> {


### PR DESCRIPTION
Implements missing `Sync` and `Send` bounds. Specifically, this was made on `MjData`.