### PR TITLE
Add integration tests for force-cast functionality

### DIFF
--- a/src/wrappers/mj_auxiliary.rs
+++ b/src/wrappers/mj_auxiliary.rs
@@ -289,4 +289,34 @@ mod tests {
         let _ = vfs.mount("/tmp");
         let _ = vfs.unmount("/tmp");
     }
+
+    /// Tests that deleting a nonexistent file from VFS returns the `NotFound` error variant.
+    #[test]
+    fn test_vfs_delete_nonexistent() {
+        let mut vfs = MjVfs::new();
+        let err = vfs.delete_file("does_not_exist.xml").unwrap_err();
+        assert!(matches!(err, MjVfsError::NotFound));
+    }
+
+    /// Tests adding a model buffer to VFS and loading it back: verifies the model is
+    /// parsed correctly and has the expected body count.
+    #[test]
+    fn test_vfs_buffer_round_trip() {
+        const CUSTOM_MODEL: &str = "
+<mujoco>
+  <worldbody>
+    <body name='extra_body'>
+      <geom size='0.1'/>
+    </body>
+  </worldbody>
+</mujoco>";
+
+        let mut vfs = MjVfs::new();
+        vfs.add_from_buffer("round_trip.xml", CUSTOM_MODEL.as_bytes()).unwrap();
+
+        let model = MjModel::from_xml_vfs("round_trip.xml", &vfs).unwrap();
+        // 2 bodies: worldbody + extra_body
+        assert_eq!(model.ffi().nbody, 2);
+        assert!(model.body("extra_body").is_some());
+    }
 }

--- a/src/wrappers/mj_data.rs
+++ b/src/wrappers/mj_data.rs
@@ -2537,4 +2537,1539 @@ mod test {
         let view_m2 = info_m2.view(&data);
         assert!(view_m2.act.is_none(), "motor must have no act view");
     }
+
+    /// Tests `mj_view_indices!` with mixed joint types (free/ball/slide),
+    /// verifying that qpos and qvel view lengths match per-joint DOF counts.
+    #[test]
+    fn test_view_indices_mixed_joint_types() {
+        const MIXED_MODEL: &str = "
+<mujoco>
+  <worldbody>
+    <body name='b_free'>
+      <joint name='j_free' type='free'/>
+      <geom size='0.1' mass='1'/>
+    </body>
+    <body name='b_ball'>
+      <joint name='j_ball' type='ball'/>
+      <geom size='0.1' mass='1'/>
+    </body>
+    <body name='b_slide'>
+      <joint name='j_slide' type='slide'/>
+      <geom size='0.1' mass='1'/>
+    </body>
+  </worldbody>
+</mujoco>";
+
+        let model = MjModel::from_xml_string(MIXED_MODEL).unwrap();
+        let data = model.make_data();
+
+        // free: 7 qpos, 6 qvel; ball: 4 qpos, 3 qvel; slide: 1 qpos, 1 qvel
+        let jfree = data.joint("j_free").unwrap();
+        let jball = data.joint("j_ball").unwrap();
+        let jslide = data.joint("j_slide").unwrap();
+
+        let vfree = jfree.view(&data);
+        let vball = jball.view(&data);
+        let vslide = jslide.view(&data);
+
+        assert_eq!(vfree.qpos.len(), 7);
+        assert_eq!(vfree.qvel.len(), 6);
+        assert_eq!(vball.qpos.len(), 4);
+        assert_eq!(vball.qvel.len(), 3);
+        assert_eq!(vslide.qpos.len(), 1);
+        assert_eq!(vslide.qvel.len(), 1);
+
+        // Total should equal model nq and nv
+        assert_eq!(model.ffi().nq as usize, 7 + 4 + 1);
+        assert_eq!(model.ffi().nv as usize, 6 + 3 + 1);
+    }
+
+    /// Tests `info_method!` stride correctness for body data views:
+    /// xpos=3, xmat=9, xquat=4, cinert=10, cvel=6.
+    #[test]
+    fn test_body_data_view_stride_lengths() {
+        let model = MjModel::from_xml_string(MODEL).unwrap();
+        let data = model.make_data();
+
+        let ball = data.body("ball").unwrap();
+        let ball2 = data.body("ball2").unwrap();
+
+        let v1 = ball.view(&data);
+        let v2 = ball2.view(&data);
+
+        // Stride correctness
+        assert_eq!(v1.xpos.len(), 3);
+        assert_eq!(v1.xmat.len(), 9);
+        assert_eq!(v1.xquat.len(), 4);
+        assert_eq!(v1.cinert.len(), 10);
+        assert_eq!(v1.cvel.len(), 6);
+
+        // Non-aliasing: different bodies must have distinct slices
+        assert_ne!(v1.xpos.as_ptr(), v2.xpos.as_ptr());
+        assert_ne!(v1.cvel.as_ptr(), v2.cvel.as_ptr());
+    }
+
+    /// Tests `getter_setter!` for MjtNum time: set, get, and builder roundtrip.
+    #[test]
+    fn test_time_getter_setter_roundtrip() {
+        let model = MjModel::from_xml_string(MODEL).unwrap();
+        let mut data = model.make_data();
+
+        assert_relative_eq!(data.time(), 0.0, epsilon = 1e-15);
+
+        data.set_time(3.14);
+        assert_relative_eq!(data.time(), 3.14, epsilon = 1e-15);
+
+        let data2 = model.make_data().with_time(2.718);
+        assert_relative_eq!(data2.time(), 2.718, epsilon = 1e-15);
+    }
+
+    /// Tests that `jac` returns `IndexOutOfBounds` for invalid body IDs.
+    #[test]
+    fn test_jac_invalid_body_id() {
+        let model = MjModel::from_xml_string(MODEL).unwrap();
+        let data = model.make_data();
+        let point = [0.0; 3];
+
+        // Negative ID
+        let err = data.jac(true, true, &point, -1).unwrap_err();
+        assert!(matches!(err, MjDataError::IndexOutOfBounds { kind: "body_id", .. }));
+
+        // Too-large ID
+        let err = data.jac(true, true, &point, 9999).unwrap_err();
+        assert!(matches!(err, MjDataError::IndexOutOfBounds { kind: "body_id", .. }));
+    }
+
+    /// Tests that `object_velocity` returns `UnsupportedObjectType` for unsupported types
+    /// and `IndexOutOfBounds` for out-of-range IDs.
+    #[test]
+    fn test_object_velocity_error_paths() {
+        let model = MjModel::from_xml_string(MODEL).unwrap();
+        let data = model.make_data();
+
+        // Unsupported type (mjOBJ_JOINT is not in the match arms)
+        let err = data.object_velocity(MjtObj::mjOBJ_JOINT, 0, false).unwrap_err();
+        assert!(matches!(err, MjDataError::UnsupportedObjectType(_)));
+
+        // Out-of-range body ID
+        let err = data.object_velocity(MjtObj::mjOBJ_BODY, 9999, false).unwrap_err();
+        assert!(matches!(err, MjDataError::IndexOutOfBounds { kind: "obj_id", .. }));
+    }
+
+    /// Tests that state flags select only their subset: setting QPOS must not clobber qvel.
+    #[test]
+    fn test_state_spec_flags_select_subsets() {
+        let model = MjModel::from_xml_string(MODEL).unwrap();
+        let mut data = model.make_data();
+
+        // Give data some known non-zero qvel
+        let jinfo = data.joint("ball").unwrap();
+        jinfo.view_mut(&mut data).qvel[0] = 42.0;
+        let original_qvel0 = jinfo.view(&data).qvel[0];
+
+        // Now overwrite only QPOS from a fresh data instance
+        let fresh = model.make_data();
+        data.copy_state_from_data(&fresh, MjtState::mjSTATE_QPOS as u32);
+
+        // qvel should be untouched
+        assert_relative_eq!(jinfo.view(&data).qvel[0], original_qvel0, epsilon = 1e-15);
+    }
+
+    /// Tests `try_copy_state_from_data` returns `SignatureMismatch` for mismatched models.
+    #[test]
+    fn test_try_copy_state_signature_mismatch() {
+        let model1 = MjModel::from_xml_string("<mujoco><worldbody><body><joint type='free'/><geom size='0.1'/></body></worldbody></mujoco>").unwrap();
+        let model2 = MjModel::from_xml_string("<mujoco><worldbody><body><joint type='slide'/><geom size='0.1'/></body></worldbody></mujoco>").unwrap();
+
+        let data1 = model1.make_data();
+        let mut data2 = model2.make_data();
+
+        let err = data2.try_copy_state_from_data(&data1, MjtState::mjSTATE_FULLPHYSICS as u32).unwrap_err();
+        match err {
+            MjDataError::SignatureMismatch { source, destination } => {
+                assert_ne!(source, destination);
+            }
+            other => panic!("expected SignatureMismatch, got {:?}", other),
+        }
+    }
+
+    /// Tests `copy_state_from_data` with full physics: time, qpos, qvel all match.
+    #[test]
+    fn test_copy_state_full_physics() {
+        let model = MjModel::from_xml_string(MODEL).unwrap();
+        let mut data1 = model.make_data();
+        let mut data2 = model.make_data();
+
+        // Evolve data1
+        data1.set_time(1.0);
+        data1.joint("ball").unwrap().view_mut(&mut data1).qpos[0] = 5.0;
+        data1.joint("ball").unwrap().view_mut(&mut data1).qvel[0] = 3.0;
+
+        data2.copy_state_from_data(&data1, MjtState::mjSTATE_FULLPHYSICS as u32);
+
+        assert_relative_eq!(data2.time(), 1.0, epsilon = 1e-15);
+        assert_relative_eq!(data2.qpos()[0], 5.0, epsilon = 1e-15);
+        assert_relative_eq!(data2.qvel()[0], 3.0, epsilon = 1e-15);
+    }
+
+    /**************************************************************************/
+    // Force-cast macro correctness tests
+    /**************************************************************************/
+
+    /// A richer model for force-cast tests: free joint, slide joint, equalities,
+    /// mocap body, tendon, multiple geom types, sensors, contacts.
+    const FORCE_MODEL: &str = "
+<mujoco>
+  <worldbody>
+    <body name='b_free' pos='1 2 3'>
+        <joint name='j_free' type='free'/>
+        <geom name='g_sphere' type='sphere' size='0.1' mass='1'/>
+    </body>
+
+    <body name='b_slide' pos='0 0 5'>
+        <joint name='j_slide' type='slide' axis='0 0 1' range='-1 1' limited='true'/>
+        <geom name='g_box' type='box' size='0.1 0.2 0.3' mass='1'/>
+        <site name='s1' pos='0 0 0' size='0.05'/>
+    </body>
+
+    <body name='b_hinge' pos='0 5 0'>
+        <joint name='j_hinge' type='hinge' axis='0 1 0'/>
+        <geom name='g_capsule' type='capsule' size='0.1 0.5' mass='1'/>
+        <site name='s2' pos='0 0 0' size='0.05'/>
+    </body>
+
+    <body name='mocap_body' mocap='true' pos='10 10 10'>
+        <geom name='g_mocap' type='sphere' size='0.01' contype='0' conaffinity='0'/>
+    </body>
+
+    <geom name='floor' type='plane' size='50 50 1'/>
+  </worldbody>
+
+  <equality>
+      <connect name='eq1' body1='b_slide' body2='b_hinge' anchor='0 0 0'/>
+      <connect name='eq2' body1='b_hinge' body2='b_slide' anchor='1 2 3'/>
+  </equality>
+
+  <tendon>
+      <spatial name='ten1'>
+          <site site='s1'/>
+          <site site='s2'/>
+      </spatial>
+  </tendon>
+
+  <actuator>
+      <motor name='motor_slide' joint='j_slide'/>
+  </actuator>
+
+  <sensor>
+      <touch name='touch_sensor' site='s1'/>
+  </sensor>
+</mujoco>";
+
+    /// Verifies [force]-cast array grouping: xpos returns &[[MjtNum; 3]]
+    /// with the correct number of elements and matching raw FFI data.
+    #[test]
+    fn test_force_cast_xpos_array_grouping() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nbody = model.ffi().nbody as usize;
+        let xpos = data.xpos();
+
+        // The force-cast from *mut f64 -> *mut [MjtNum; 3] must produce
+        // exactly nbody elements of [f64; 3].
+        assert_eq!(xpos.len(), nbody, "xpos slice len must equal nbody");
+
+        // Cross-validate every element against the raw FFI pointer.
+        for i in 0..nbody {
+            for j in 0..3 {
+                let ffi_val = unsafe { *data.ffi().xpos.add(i * 3 + j) };
+                assert_eq!(xpos[i][j], ffi_val,
+                    "xpos[{}][{}] mismatch: slice={} ffi={}", i, j, xpos[i][j], ffi_val);
+            }
+        }
+    }
+
+    /// Verifies [force]-cast for xmat (&[[MjtNum; 9]]) and xquat (&[[MjtNum; 4]]).
+    #[test]
+    fn test_force_cast_xmat_xquat_grouping() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nbody = model.ffi().nbody as usize;
+        let xmat = data.xmat();
+        let xquat = data.xquat();
+
+        assert_eq!(xmat.len(), nbody);
+        assert_eq!(xquat.len(), nbody);
+
+        // xmat stride = 9
+        for i in 0..nbody {
+            for j in 0..9 {
+                let ffi_val = unsafe { *data.ffi().xmat.add(i * 9 + j) };
+                assert_eq!(xmat[i][j], ffi_val,
+                    "xmat[{}][{}] mismatch", i, j);
+            }
+        }
+
+        // xquat stride = 4
+        for i in 0..nbody {
+            for j in 0..4 {
+                let ffi_val = unsafe { *data.ffi().xquat.add(i * 4 + j) };
+                assert_eq!(xquat[i][j], ffi_val,
+                    "xquat[{}][{}] mismatch", i, j);
+            }
+        }
+    }
+
+    /// Verifies [force]-cast for cinert (&[[MjtNum; 10]]) - the widest array grouping.
+    #[test]
+    fn test_force_cast_cinert_10_element_grouping() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nbody = model.ffi().nbody as usize;
+        let cinert = data.cinert();
+        assert_eq!(cinert.len(), nbody);
+
+        for i in 0..nbody {
+            for j in 0..10 {
+                let ffi_val = unsafe { *data.ffi().cinert.add(i * 10 + j) };
+                assert_eq!(cinert[i][j], ffi_val,
+                    "cinert[{}][{}] mismatch", i, j);
+            }
+        }
+    }
+
+    /// Verifies [force]-cast for cvel (&[[MjtNum; 6]]) and xfrc_applied (&[[MjtNum; 6]]).
+    #[test]
+    fn test_force_cast_6_element_groupings() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nbody = model.ffi().nbody as usize;
+
+        // cvel: [MjtNum; 6]
+        let cvel = data.cvel();
+        assert_eq!(cvel.len(), nbody);
+        for i in 0..nbody {
+            for j in 0..6 {
+                let ffi_val = unsafe { *data.ffi().cvel.add(i * 6 + j) };
+                assert_eq!(cvel[i][j], ffi_val, "cvel[{}][{}] mismatch", i, j);
+            }
+        }
+
+        // xfrc_applied: [MjtNum; 6]
+        let xfrc = data.xfrc_applied();
+        assert_eq!(xfrc.len(), nbody);
+        for i in 0..nbody {
+            for j in 0..6 {
+                let ffi_val = unsafe { *data.ffi().xfrc_applied.add(i * 6 + j) };
+                assert_eq!(xfrc[i][j], ffi_val, "xfrc_applied[{}][{}] mismatch", i, j);
+            }
+        }
+    }
+
+    /// Verifies [force]-cast for mocap_pos (&[[MjtNum; 3]]) and mocap_quat (&[[MjtNum; 4]]).
+    #[test]
+    fn test_force_cast_mocap_arrays() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let data = model.make_data();
+
+        let nmocap = model.ffi().nmocap as usize;
+        assert!(nmocap > 0, "test model must have at least one mocap body");
+
+        let mocap_pos = data.mocap_pos();
+        let mocap_quat = data.mocap_quat();
+
+        assert_eq!(mocap_pos.len(), nmocap);
+        assert_eq!(mocap_quat.len(), nmocap);
+
+        // The mocap body was placed at pos='10 10 10'
+        assert_relative_eq!(mocap_pos[0][0], 10.0, epsilon = 1e-9);
+        assert_relative_eq!(mocap_pos[0][1], 10.0, epsilon = 1e-9);
+        assert_relative_eq!(mocap_pos[0][2], 10.0, epsilon = 1e-9);
+
+        // Default quaternion is identity [1, 0, 0, 0]
+        assert_relative_eq!(mocap_quat[0][0], 1.0, epsilon = 1e-9);
+        assert_relative_eq!(mocap_quat[0][1], 0.0, epsilon = 1e-9);
+        assert_relative_eq!(mocap_quat[0][2], 0.0, epsilon = 1e-9);
+        assert_relative_eq!(mocap_quat[0][3], 0.0, epsilon = 1e-9);
+
+        // Cross-validate with FFI
+        for i in 0..nmocap {
+            for j in 0..3 {
+                assert_eq!(mocap_pos[i][j], unsafe { *data.ffi().mocap_pos.add(i * 3 + j) });
+            }
+            for j in 0..4 {
+                assert_eq!(mocap_quat[i][j], unsafe { *data.ffi().mocap_quat.add(i * 4 + j) });
+            }
+        }
+    }
+
+    /// Verifies [force]-cast bool conversion: eq_active (*mut u8 -> *mut bool).
+    #[test]
+    fn test_force_cast_eq_active_bool() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+
+        let neq = model.ffi().neq as usize;
+        assert_eq!(neq, 2, "test model must have exactly 2 equality constraints");
+
+        // Equality constraints are active by default
+        let eq_active = data.eq_active();
+        assert_eq!(eq_active.len(), neq);
+        assert_eq!(eq_active[0], true);
+        assert_eq!(eq_active[1], true);
+
+        // Cross-validate with raw u8 FFI pointer
+        for i in 0..neq {
+            let raw_val = unsafe { *data.ffi().eq_active.add(i) };
+            assert_eq!(eq_active[i], raw_val != 0,
+                "eq_active[{}]: bool={} raw_u8={}", i, eq_active[i], raw_val);
+        }
+
+        // Disable one via mutable force-cast
+        data.eq_active_mut()[0] = false;
+        assert_eq!(data.eq_active()[0], false);
+        assert_eq!(data.eq_active()[1], true);
+
+        // Verify FFI side was actually modified
+        let raw_val = unsafe { *data.ffi().eq_active.add(0) };
+        assert_eq!(raw_val, 0u8, "disabling eq_active[0] must write 0 to FFI");
+    }
+
+    /// Verifies [force]-cast mutable roundtrip for xfrc_applied and mocap_pos.
+    #[test]
+    fn test_force_cast_mutable_roundtrip() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+
+        let nbody = model.ffi().nbody as usize;
+        assert!(nbody > 1);
+
+        // Write a known pattern into xfrc_applied via mutable force-cast
+        let body_idx = 1; // first non-world body
+        data.xfrc_applied_mut()[body_idx] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+
+        // Read back via immutable force-cast
+        let xfrc = data.xfrc_applied();
+        assert_eq!(xfrc[body_idx], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+        // Verify all 6 elements individually against raw FFI
+        for j in 0..6 {
+            let ffi_val = unsafe { *data.ffi().xfrc_applied.add(body_idx * 6 + j) };
+            assert_eq!(ffi_val, (j + 1) as f64,
+                "xfrc_applied FFI[{}] mismatch", j);
+        }
+
+        // Mocap pos write/read roundtrip
+        let nmocap = model.ffi().nmocap as usize;
+        if nmocap > 0 {
+            data.mocap_pos_mut()[0] = [99.0, 88.0, 77.0];
+            assert_eq!(data.mocap_pos()[0], [99.0, 88.0, 77.0]);
+            for j in 0..3 {
+                let ffi_val = unsafe { *data.ffi().mocap_pos.add(j) };
+                assert_eq!(ffi_val, [99.0, 88.0, 77.0][j]);
+            }
+        }
+    }
+
+    /// Verifies force-cast for body view fields (xpos, xquat, xmat, cinert, cvel)
+    /// have the correct stride and match FFI data.
+    #[test]
+    fn test_force_cast_body_view_strides_and_values() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let body_info = data.body("b_free").unwrap();
+        let view = body_info.view(&data);
+
+        // Stride correctness (all derived from [force] grouping)
+        assert_eq!(view.xpos.len(), 3);
+        assert_eq!(view.xquat.len(), 4);
+        assert_eq!(view.xmat.len(), 9);
+        assert_eq!(view.xipos.len(), 3);
+        assert_eq!(view.ximat.len(), 9);
+        assert_eq!(view.cinert.len(), 10);
+        assert_eq!(view.cvel.len(), 6);
+        assert_eq!(view.xfrc_applied.len(), 6);
+        assert_eq!(view.crb.len(), 10);
+        assert_eq!(view.subtree_com.len(), 3);
+        assert_eq!(view.subtree_linvel.len(), 3);
+        assert_eq!(view.subtree_angmom.len(), 3);
+        assert_eq!(view.cacc.len(), 6);
+        assert_eq!(view.cfrc_int.len(), 6);
+        assert_eq!(view.cfrc_ext.len(), 6);
+
+        // The body was placed at pos='1 2 3' with a free joint;
+        // after forward(), xpos should reflect position from qpos
+        let body_id = body_info.id;
+        for j in 0..3 {
+            let ffi_val = unsafe { *data.ffi().xpos.add(body_id * 3 + j) };
+            assert_eq!(view.xpos[j], ffi_val,
+                "body view xpos[{}] must match FFI xpos", j);
+        }
+    }
+
+    /// Verifies that the body data view for the world body (id=0) works correctly.
+    /// Edge case: world body has special status in MuJoCo.
+    #[test]
+    fn test_force_cast_world_body_view() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        // The world body (id=0) has name "world" in MuJoCo >= 3.x
+        let world_info = data.body("world").unwrap();
+        assert_eq!(world_info.id, 0);
+        let view = world_info.view(&data);
+
+        // World body xpos = [0, 0, 0]
+        assert_eq!(view.xpos[..], [0.0, 0.0, 0.0]);
+        // World body xquat = [1, 0, 0, 0] (identity)
+        assert_relative_eq!(view.xquat[0], 1.0, epsilon = 1e-9);
+        assert_relative_eq!(view.xquat[1], 0.0, epsilon = 1e-9);
+        assert_relative_eq!(view.xquat[2], 0.0, epsilon = 1e-9);
+        assert_relative_eq!(view.xquat[3], 0.0, epsilon = 1e-9);
+        // Stride must still be correct
+        assert_eq!(view.xmat.len(), 9);
+        assert_eq!(view.cinert.len(), 10);
+    }
+
+    /// Verifies mutable force-cast view roundtrip for body xfrc_applied.
+    #[test]
+    fn test_force_cast_body_view_mut_roundtrip() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+
+        let body_info = data.body("b_free").unwrap();
+        let body_id = body_info.id;
+
+        // Write via view_mut
+        body_info.view_mut(&mut data).xfrc_applied.copy_from_slice(&[10.0, 20.0, 30.0, 40.0, 50.0, 60.0]);
+
+        // Read back via view
+        let view = body_info.view(&data);
+        assert_eq!(&view.xfrc_applied[..], &[10.0, 20.0, 30.0, 40.0, 50.0, 60.0]);
+
+        // Read back via flat slice
+        assert_eq!(data.xfrc_applied()[body_id], [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]);
+
+        // Read back via FFI
+        for j in 0..6 {
+            let ffi_val = unsafe { *data.ffi().xfrc_applied.add(body_id * 6 + j) };
+            assert_eq!(ffi_val, ((j + 1) * 10) as f64);
+        }
+    }
+
+    /// Verifies [force]-cast camera/light/geom/site xpos+xmat grouping in data.
+    #[test]
+    fn test_force_cast_geom_site_cam_light_data() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        // Geom xpos: [MjtNum; 3], xmat: [MjtNum; 9]
+        let ngeom = model.ffi().ngeom as usize;
+        assert_eq!(data.geom_xpos().len(), ngeom);
+        assert_eq!(data.geom_xmat().len(), ngeom);
+        for i in 0..ngeom {
+            for j in 0..3 {
+                assert_eq!(data.geom_xpos()[i][j],
+                    unsafe { *data.ffi().geom_xpos.add(i * 3 + j) });
+            }
+            for j in 0..9 {
+                assert_eq!(data.geom_xmat()[i][j],
+                    unsafe { *data.ffi().geom_xmat.add(i * 9 + j) });
+            }
+        }
+
+        // Site xpos: [MjtNum; 3], xmat: [MjtNum; 9]
+        let nsite = model.ffi().nsite as usize;
+        assert_eq!(data.site_xpos().len(), nsite);
+        assert_eq!(data.site_xmat().len(), nsite);
+        for i in 0..nsite {
+            for j in 0..3 {
+                assert_eq!(data.site_xpos()[i][j],
+                    unsafe { *data.ffi().site_xpos.add(i * 3 + j) });
+            }
+        }
+
+        // Cam xpos: [MjtNum; 3], xmat: [MjtNum; 9]
+        let ncam = model.ffi().ncam as usize;
+        assert_eq!(data.cam_xpos().len(), ncam);
+        assert_eq!(data.cam_xmat().len(), ncam);
+
+        // Light xpos: [MjtNum; 3], xdir: [MjtNum; 3]
+        let nlight = model.ffi().nlight as usize;
+        assert_eq!(data.light_xpos().len(), nlight);
+        assert_eq!(data.light_xdir().len(), nlight);
+    }
+
+    /// Verifies [force]-cast for joint anchor/axis: xanchor (&[[MjtNum; 3]]), xaxis (&[[MjtNum; 3]]).
+    #[test]
+    fn test_force_cast_joint_anchor_axis() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let njnt = model.ffi().njnt as usize;
+        let xanchor = data.xanchor();
+        let xaxis = data.xaxis();
+
+        assert_eq!(xanchor.len(), njnt);
+        assert_eq!(xaxis.len(), njnt);
+
+        for i in 0..njnt {
+            for j in 0..3 {
+                assert_eq!(xanchor[i][j], unsafe { *data.ffi().xanchor.add(i * 3 + j) });
+                assert_eq!(xaxis[i][j], unsafe { *data.ffi().xaxis.add(i * 3 + j) });
+            }
+        }
+    }
+
+    /// Verifies [force]-cast for cdof (&[[MjtNum; 6]]) and cdof_dot (&[[MjtNum; 6]]).
+    #[test]
+    fn test_force_cast_cdof_6_element() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nv = model.ffi().nv as usize;
+        let cdof = data.cdof();
+        let cdof_dot = data.cdof_dot();
+
+        assert_eq!(cdof.len(), nv);
+        assert_eq!(cdof_dot.len(), nv);
+
+        for i in 0..nv {
+            for j in 0..6 {
+                assert_eq!(cdof[i][j], unsafe { *data.ffi().cdof.add(i * 6 + j) });
+                assert_eq!(cdof_dot[i][j], unsafe { *data.ffi().cdof_dot.add(i * 6 + j) });
+            }
+        }
+    }
+
+    /// Verifies [force]-cast for efc_KBIP (&[[MjtNum; 4]]).
+    /// Requires contacts to produce constraint data.
+    #[test]
+    fn test_force_cast_efc_kbip_4_element() {
+        // Use the main MODEL which has balls falling onto a floor -> contacts
+        let model = MjModel::from_xml_string(MODEL).unwrap();
+        let mut data = model.make_data();
+
+        // Step a few times to generate contacts
+        for _ in 0..10 {
+            data.step();
+        }
+
+        let nefc = data.ffi().nefc as usize;
+        if nefc > 0 {
+            let efc_kbip = data.efc_kbip();
+            assert_eq!(efc_kbip.len(), nefc);
+            for i in 0..nefc {
+                for j in 0..4 {
+                    assert_eq!(efc_kbip[i][j], unsafe { *data.ffi().efc_KBIP.add(i * 4 + j) });
+                }
+            }
+        }
+    }
+
+    /// Verifies [force]-cast enum: efc_type (*mut i32 -> *mut MjtConstraint).
+    #[test]
+    fn test_force_cast_efc_type_enum() {
+        let model = MjModel::from_xml_string(MODEL).unwrap();
+        let mut data = model.make_data();
+
+        for _ in 0..10 {
+            data.step();
+        }
+
+        let nefc = data.ffi().nefc as usize;
+        if nefc > 0 {
+            let efc_type = data.efc_type();
+            assert_eq!(efc_type.len(), nefc);
+
+            for i in 0..nefc {
+                let raw_i32 = unsafe { *data.ffi().efc_type.add(i) };
+                let expected: MjtConstraint = unsafe { crate::util::force_cast(raw_i32) };
+                assert_eq!(efc_type[i], expected,
+                    "efc_type[{}]: got {:?}, expected {:?} (raw={})", i, efc_type[i], expected, raw_i32);
+            }
+        }
+    }
+
+    /// Verifies [force]-cast enum: efc_state (*mut i32 -> *mut MjtConstraintState).
+    #[test]
+    fn test_force_cast_efc_state_enum() {
+        let model = MjModel::from_xml_string(MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nefc = data.ffi().nefc as usize;
+        if nefc > 0 {
+            let efc_state = data.efc_state();
+            assert_eq!(efc_state.len(), nefc);
+
+            for i in 0..nefc {
+                let raw_i32 = unsafe { *data.ffi().efc_state.add(i) };
+                let expected: MjtConstraintState = unsafe { crate::util::force_cast(raw_i32) };
+                assert_eq!(efc_state[i], expected);
+            }
+        }
+    }
+
+    /// Verifies [force]-cast enum: body_awake (*mut i32 -> *mut MjtSleepState).
+    #[test]
+    fn test_force_cast_body_awake_enum() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nbody = model.ffi().nbody as usize;
+        let body_awake = data.body_awake();
+        assert_eq!(body_awake.len(), nbody);
+
+        for i in 0..nbody {
+            let raw_i32 = unsafe { *data.ffi().body_awake.add(i) };
+            let expected: MjtSleepState = unsafe { crate::util::force_cast(raw_i32) };
+            assert_eq!(body_awake[i], expected,
+                "body_awake[{}] mismatch", i);
+        }
+    }
+
+    /// Verifies [force]-cast for bvh_active (*mut u8 -> *mut bool) and that
+    /// the result is valid (true or false, no garbage).
+    #[test]
+    fn test_force_cast_bvh_active_bool() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+
+        // Step to populate bvh
+        data.step();
+
+        let nbvh = model.ffi().nbvh as usize;
+        let bvh_active = data.bvh_active();
+        assert_eq!(bvh_active.len(), nbvh);
+
+        for i in 0..nbvh {
+            let raw_u8 = unsafe { *data.ffi().bvh_active.add(i) };
+            assert!(raw_u8 == 0 || raw_u8 == 1,
+                "raw bvh_active[{}]={} must be 0 or 1", i, raw_u8);
+            assert_eq!(bvh_active[i], raw_u8 != 0);
+        }
+    }
+
+    /// Verifies [force]-cast for wrap_obj (&[[i32; 2]]) and wrap_xpos (&[[MjtNum; 6]]).
+    #[test]
+    fn test_force_cast_wrap_arrays() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nwrap = model.ffi().nwrap as usize;
+        let wrap_obj = data.wrap_obj();
+        let wrap_xpos = data.wrap_xpos();
+
+        assert_eq!(wrap_obj.len(), nwrap);
+        assert_eq!(wrap_xpos.len(), nwrap);
+
+        for i in 0..nwrap {
+            for j in 0..2 {
+                assert_eq!(wrap_obj[i][j], unsafe { *data.ffi().wrap_obj.add(i * 2 + j) });
+            }
+            for j in 0..6 {
+                assert_eq!(wrap_xpos[i][j], unsafe { *data.ffi().wrap_xpos.add(i * 6 + j) });
+            }
+        }
+    }
+
+    /// Verifies [force]-cast for flexvert_J (&[[MjtNum; 2]]) and flexvert_length (&[[MjtNum; 2]]).
+    /// In a model with no flexes, these should return empty slices.
+    #[test]
+    fn test_force_cast_flex_empty_slices() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let data = model.make_data();
+
+        // Model has no flexes, so these should be empty
+        assert_eq!(data.flexvert_xpos().len(), 0, "no flex -> empty flexvert_xpos");
+        assert_eq!(data.flexelem_aabb().len(), 0, "no flex -> empty flexelem_aabb");
+        assert_eq!(data.flexvert_j().len(), 0, "no flex -> empty flexvert_J");
+        assert_eq!(data.flexvert_length().len(), 0, "no flex -> empty flexvert_length");
+        assert_eq!(data.flexedge_j().len(), 0, "no flex -> empty flexedge_J");
+        assert_eq!(data.flexedge_length().len(), 0, "no flex -> empty flexedge_length");
+    }
+
+    /// Verifies [force]-cast for bvh_aabb_dyn (&[[MjtNum; 6]]).
+    #[test]
+    fn test_force_cast_bvh_aabb_dyn() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nbvhdyn = model.ffi().nbvhdynamic as usize;
+        let aabb_dyn = data.bvh_aabb_dyn();
+        assert_eq!(aabb_dyn.len(), nbvhdyn);
+
+        for i in 0..nbvhdyn {
+            for j in 0..6 {
+                assert_eq!(aabb_dyn[i][j], unsafe { *data.ffi().bvh_aabb_dyn.add(i * 6 + j) });
+            }
+        }
+    }
+
+    /// Verifies [force]-cast for subtree arrays: subtree_com, subtree_linvel, subtree_angmom
+    /// all with stride 3.
+    #[test]
+    fn test_force_cast_subtree_3_element() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nbody = model.ffi().nbody as usize;
+
+        let subtree_com = data.subtree_com();
+        let subtree_linvel = data.subtree_linvel();
+        let subtree_angmom = data.subtree_angmom();
+
+        assert_eq!(subtree_com.len(), nbody);
+        assert_eq!(subtree_linvel.len(), nbody);
+        assert_eq!(subtree_angmom.len(), nbody);
+
+        for i in 0..nbody {
+            for j in 0..3 {
+                assert_eq!(subtree_com[i][j], unsafe { *data.ffi().subtree_com.add(i * 3 + j) });
+            }
+        }
+    }
+
+    /// Verifies [force]-cast consistency: body view xfrc_applied matches flat slice.
+    /// This catches any stride/offset mismatch between view_creator! and array_slice_dyn!.
+    #[test]
+    fn test_force_cast_view_vs_flat_slice_consistency() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        // Check every named body: view xpos must equal flat xpos slice
+        let body_names = ["world", "b_free", "b_slide", "b_hinge", "mocap_body"];
+        for name in &body_names {
+            let info = data.body(name).unwrap();
+            let id = info.id;
+            let view = info.view(&data);
+            let flat = data.xpos();
+
+            for j in 0..3 {
+                assert_eq!(view.xpos[j], flat[id][j],
+                    "body {} xpos[{}]: view={} flat={}", id, j, view.xpos[j], flat[id][j]);
+            }
+
+            for j in 0..4 {
+                assert_eq!(view.xquat[j], data.xquat()[id][j],
+                    "body {} xquat[{}] mismatch", id, j);
+            }
+
+            for j in 0..10 {
+                assert_eq!(view.cinert[j], data.cinert()[id][j],
+                    "body {} cinert[{}] mismatch", id, j);
+            }
+        }
+    }
+
+    /// Verifies [force]-cast for the cacc/cfrc_int/cfrc_ext body arrays (stride 6).
+    #[test]
+    fn test_force_cast_body_cfrc_arrays() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nbody = model.ffi().nbody as usize;
+        let cacc = data.cacc();
+        let cfrc_int = data.cfrc_int();
+        let cfrc_ext = data.cfrc_ext();
+
+        assert_eq!(cacc.len(), nbody);
+        assert_eq!(cfrc_int.len(), nbody);
+        assert_eq!(cfrc_ext.len(), nbody);
+
+        for i in 0..nbody {
+            for j in 0..6 {
+                assert_eq!(cacc[i][j], unsafe { *data.ffi().cacc.add(i * 6 + j) });
+                assert_eq!(cfrc_int[i][j], unsafe { *data.ffi().cfrc_int.add(i * 6 + j) });
+                assert_eq!(cfrc_ext[i][j], unsafe { *data.ffi().cfrc_ext.add(i * 6 + j) });
+            }
+        }
+    }
+
+    /// Verifies [force]-cast for crb (&[[MjtNum; 10]]).
+    #[test]
+    fn test_force_cast_crb_10_element() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nbody = model.ffi().nbody as usize;
+        let crb = data.crb();
+        assert_eq!(crb.len(), nbody);
+
+        for i in 0..nbody {
+            for j in 0..10 {
+                assert_eq!(crb[i][j], unsafe { *data.ffi().crb.add(i * 10 + j) });
+            }
+        }
+    }
+
+    /// Minimal model test: a model with zero equalities, zero tendons, zero actuators
+    /// should produce empty slices for all force-cast fields that depend on those counts.
+    #[test]
+    fn test_force_cast_empty_model_edge_case() {
+        let xml = "<mujoco><worldbody><body><joint type='free'/><geom size='0.1'/></body></worldbody></mujoco>";
+        let model = MjModel::from_xml_string(xml).unwrap();
+        let data = model.make_data();
+
+        assert_eq!(model.ffi().neq, 0);
+        assert_eq!(model.ffi().nmocap, 0);
+        assert_eq!(model.ffi().ntendon, 0);
+
+        // Empty force-cast slices
+        assert!(data.eq_active().is_empty());
+        assert!(data.mocap_pos().is_empty());
+        assert!(data.mocap_quat().is_empty());
+        assert!(data.wrap_obj().is_empty());
+        assert!(data.wrap_xpos().is_empty());
+        assert!(data.ten_j_colind().is_empty());
+        assert!(data.ten_j().is_empty());
+
+        // But body arrays should still work (nbody >= 1 always: world body)
+        let nbody = model.ffi().nbody as usize;
+        assert!(nbody >= 2); // world + one body
+        assert_eq!(data.xpos().len(), nbody);
+        assert_eq!(data.xquat().len(), nbody);
+        assert_eq!(data.cinert().len(), nbody);
+    }
+
+    /// Verifies [force]-cast sublen_dep variant: ten_J_colind and ten_J.
+    /// These have a variable inner dimension (nv).
+    #[test]
+    fn test_force_cast_sublen_dep_ten_j() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let ntendon = model.ffi().ntendon as usize;
+        let nv = model.ffi().nv as usize;
+
+        assert!(ntendon > 0, "test model must have at least one tendon");
+        assert!(nv > 0);
+
+        // ten_J_colind is a flat array of length ntendon * nv
+        let ten_j_colind = data.ten_j_colind();
+        assert_eq!(ten_j_colind.len(), ntendon * nv,
+            "ten_J_colind length must be ntendon*nv = {}*{} = {}", ntendon, nv, ntendon * nv);
+
+        // ten_J is also flat array of length ntendon * nv
+        let ten_j = data.ten_j();
+        assert_eq!(ten_j.len(), ntendon * nv,
+            "ten_J length must be ntendon*nv = {}*{} = {}", ntendon, nv, ntendon * nv);
+
+        // Cross-validate with FFI
+        for i in 0..(ntendon * nv) {
+            assert_eq!(ten_j_colind[i], unsafe { *data.ffi().ten_J_colind.add(i) });
+            assert_eq!(ten_j[i], unsafe { *data.ffi().ten_J.add(i) });
+        }
+    }
+
+    /// Verifies [force]-cast for iefc_type and iefc_state (island-reordered constraint arrays).
+    #[test]
+    fn test_force_cast_island_efc_enums() {
+        let model = MjModel::from_xml_string(MODEL).unwrap();
+        let mut data = model.make_data();
+
+        for _ in 0..10 {
+            data.step();
+        }
+
+        let nefc = data.ffi().nefc as usize;
+        if nefc > 0 {
+            let iefc_type = data.iefc_type();
+            let iefc_state = data.iefc_state();
+
+            assert_eq!(iefc_type.len(), nefc);
+            assert_eq!(iefc_state.len(), nefc);
+
+            for i in 0..nefc {
+                let raw_type = unsafe { *data.ffi().iefc_type.add(i) };
+                let raw_state = unsafe { *data.ffi().iefc_state.add(i) };
+                let expected_type: MjtConstraint = unsafe { crate::util::force_cast(raw_type) };
+                let expected_state: MjtConstraintState = unsafe { crate::util::force_cast(raw_state) };
+                assert_eq!(iefc_type[i], expected_type);
+                assert_eq!(iefc_state[i], expected_state);
+            }
+        }
+    }
+
+    /// Verifies [force]-cast non-aliasing: adjacent bodies' xpos slices must not overlap.
+    #[test]
+    fn test_force_cast_non_aliasing_adjacent_bodies() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let b_free = data.body("b_free").unwrap();
+        let b_slide = data.body("b_slide").unwrap();
+
+        let v_free = b_free.view(&data);
+        let v_slide = b_slide.view(&data);
+
+        // Pointers must differ
+        assert_ne!(v_free.xpos.as_ptr(), v_slide.xpos.as_ptr(),
+            "adjacent bodies must have non-overlapping xpos");
+        assert_ne!(v_free.cinert.as_ptr(), v_slide.cinert.as_ptr(),
+            "adjacent bodies must have non-overlapping cinert");
+        assert_ne!(v_free.cvel.as_ptr(), v_slide.cvel.as_ptr(),
+            "adjacent bodies must have non-overlapping cvel");
+
+        // Pointer difference must equal exactly one stride
+        let xpos_diff = unsafe { v_slide.xpos.as_ptr().offset_from(v_free.xpos.as_ptr()) };
+        let id_diff = b_slide.id as isize - b_free.id as isize;
+        assert_eq!(xpos_diff, id_diff * 3, "xpos pointer gap must be stride*id_diff = 3*{}", id_diff);
+
+        let cinert_diff = unsafe { v_slide.cinert.as_ptr().offset_from(v_free.cinert.as_ptr()) };
+        assert_eq!(cinert_diff, id_diff * 10, "cinert pointer gap must be 10*{}", id_diff);
+    }
+
+    /**************************************************************************/
+    // Multi-timestep force-cast divergence tests
+    /**************************************************************************/
+
+    /// Simulates multiple timesteps and verifies that force-cast xpos, qpos, qvel
+    /// arrays diverge from initial state while remaining consistent with FFI.
+    /// This exercises the force-cast pointer arithmetic across changing data.
+    #[test]
+    fn test_force_cast_multi_step_xpos_qpos_diverge() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nbody = model.ffi().nbody as usize;
+        let nq = model.ffi().nq as usize;
+        let nv = model.ffi().nv as usize;
+
+        // Snapshot initial values
+        let init_xpos: Vec<[MjtNum; 3]> = data.xpos().to_vec();
+        let init_qpos: Vec<MjtNum> = data.qpos().to_vec();
+        let init_qvel: Vec<MjtNum> = data.qvel().to_vec();
+
+        assert_eq!(init_xpos.len(), nbody);
+        assert_eq!(init_qpos.len(), nq);
+        assert_eq!(init_qvel.len(), nv);
+
+        // Step 100 times -- gravity should cause free body to fall
+        for _ in 0..100 {
+            data.step();
+        }
+
+        let post_xpos = data.xpos();
+        let post_qpos = data.qpos();
+        let post_qvel = data.qvel();
+
+        assert_eq!(post_xpos.len(), nbody);
+        assert_eq!(post_qpos.len(), nq);
+        assert_eq!(post_qvel.len(), nv);
+
+        // b_free should have fallen (z position decreased under gravity)
+        let b_free = data.body("b_free").unwrap();
+        assert!(post_xpos[b_free.id][2] < init_xpos[b_free.id][2],
+            "free body should have fallen: init_z={}, post_z={}",
+            init_xpos[b_free.id][2], post_xpos[b_free.id][2]);
+
+        // qpos should differ from initial
+        assert_ne!(post_qpos, &init_qpos[..], "qpos must change after 100 steps");
+
+        // qvel should differ from zero (gravity accelerates bodies)
+        let any_nonzero_vel = post_qvel.iter().any(|v| v.abs() > 1e-12);
+        assert!(any_nonzero_vel, "qvel must have nonzero entries after gravity steps");
+
+        // Cross-validate post-step xpos with FFI
+        for i in 0..nbody {
+            for j in 0..3 {
+                assert_eq!(post_xpos[i][j], unsafe { *data.ffi().xpos.add(i * 3 + j) },
+                    "xpos[{}][{}] FFI mismatch after stepping", i, j);
+            }
+        }
+
+        // Cross-validate post-step qvel with FFI
+        for i in 0..nv {
+            assert_eq!(post_qvel[i], unsafe { *data.ffi().qvel.add(i) },
+                "qvel[{}] FFI mismatch after stepping", i);
+        }
+    }
+
+    /// Simulates with an actuator active and verifies force-cast arrays (ctrl, qfrc_actuator,
+    /// actuator_force) reflect the control input after multiple steps.
+    #[test]
+    fn test_force_cast_multi_step_actuator_ctrl() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+
+        // Apply control to the slide actuator
+        data.ctrl_mut()[0] = 5.0;
+
+        // Step a few times to let forces propagate
+        for _ in 0..20 {
+            data.step();
+        }
+
+        let nu = model.ffi().nu as usize;
+        let ctrl = data.ctrl();
+        assert_eq!(ctrl.len(), nu);
+        assert_eq!(ctrl[0], 5.0);
+
+        // actuator_force should be nonzero
+        let act_force = data.actuator_force();
+        assert_eq!(act_force.len(), nu);
+        assert!(act_force[0].abs() > 1e-12,
+            "actuator_force should be nonzero with ctrl=5.0, got {}", act_force[0]);
+
+        // FFI cross-validation
+        assert_eq!(act_force[0], unsafe { *data.ffi().actuator_force });
+
+        // qfrc_actuator should be nonzero (force applied to joint)
+        let nv = model.ffi().nv as usize;
+        let qfrc = data.qfrc_actuator();
+        assert_eq!(qfrc.len(), nv);
+        let any_nonzero = qfrc.iter().any(|v| v.abs() > 1e-12);
+        assert!(any_nonzero, "qfrc_actuator must reflect the actuator force");
+    }
+
+    /// Steps multiple times with gravity & contacts, then verifies enum force-casts
+    /// (efc_type, efc_state) and array groupings (efc_KBIP, contact xpos/frame)
+    /// reflect the evolved simulation state and remain FFI-consistent.
+    #[test]
+    fn test_force_cast_multi_step_constraints_evolve() {
+        // MODEL has many objects that create contacts
+        let model = MjModel::from_xml_string(MODEL).unwrap();
+        let mut data = model.make_data();
+
+        // Step enough for contacts to form and constraints to be generated
+        for _ in 0..50 {
+            data.step();
+        }
+
+        let nefc = data.ffi().nefc as usize;
+        let ncon = data.ffi().ncon as usize;
+
+        // With a rich model and 50 steps, we expect contacts
+        // (not guaranteed in every model, but MODEL has spheres falling on a plane)
+        if ncon > 0 {
+            // Contact positions (xpos) should have changed
+            let contacts = data.contacts();
+            assert_eq!(contacts.len(), ncon);
+            for c in contacts {
+                // Each contact's pos is a [f64; 3]
+                let pos_nonzero = c.pos.iter().any(|v| v.abs() > 1e-12);
+                assert!(pos_nonzero, "contact pos should be nonzero for an active contact");
+            }
+        }
+
+        if nefc > 0 {
+            let efc_type = data.efc_type();
+            let efc_state = data.efc_state();
+            assert_eq!(efc_type.len(), nefc);
+            assert_eq!(efc_state.len(), nefc);
+
+            // FFI cross-validation post-step
+            for i in 0..nefc {
+                let raw_type = unsafe { *data.ffi().efc_type.add(i) };
+                let raw_state = unsafe { *data.ffi().efc_state.add(i) };
+                assert_eq!(efc_type[i], unsafe { crate::util::force_cast::<_, MjtConstraint>(raw_type) });
+                assert_eq!(efc_state[i], unsafe { crate::util::force_cast::<_, MjtConstraintState>(raw_state) });
+            }
+
+            // efc_KBIP should be populated
+            let kbip = data.efc_kbip();
+            assert_eq!(kbip.len(), nefc);
+            for i in 0..nefc {
+                for j in 0..4 {
+                    assert_eq!(kbip[i][j], unsafe { *data.ffi().efc_KBIP.add(i * 4 + j) });
+                }
+            }
+        }
+    }
+
+    /// Runs many timesteps and verifies that body views (via info_with_view!)
+    /// remain consistent with flat slice accessors at each step.
+    /// This tests that force-cast pointers track the mutating mjData correctly.
+    #[test]
+    fn test_force_cast_view_consistency_across_steps() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+
+        let body_names = ["world", "b_free", "b_slide", "b_hinge", "mocap_body"];
+
+        for step_idx in 0..30 {
+            data.step();
+
+            let xpos_flat = data.xpos();
+            let xquat_flat = data.xquat();
+            let cvel_flat = data.cvel();
+            let cinert_flat = data.cinert();
+
+            for name in &body_names {
+                let info = data.body(name).unwrap();
+                let view = info.view(&data);
+                let id = info.id;
+
+                // xpos from view must match flat slice
+                assert_eq!(&view.xpos[..], &xpos_flat[id][..],
+                    "xpos mismatch at step {} body '{}'", step_idx, name);
+
+                // xquat from view must match flat slice
+                assert_eq!(&view.xquat[..], &xquat_flat[id][..],
+                    "xquat mismatch at step {} body '{}'", step_idx, name);
+
+                // cvel from view must match flat slice
+                assert_eq!(&view.cvel[..], &cvel_flat[id][..],
+                    "cvel mismatch at step {} body '{}'", step_idx, name);
+
+                // cinert from view must match flat slice
+                assert_eq!(&view.cinert[..], &cinert_flat[id][..],
+                    "cinert mismatch at step {} body '{}'", step_idx, name);
+            }
+        }
+    }
+
+    /// Steps with applied external forces via force-cast mutable array, verifies
+    /// that the force affects simulation state across multiple timesteps.
+    #[test]
+    fn test_force_cast_multi_step_xfrc_applied_effect() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+
+        let b_free = data.body("b_free").unwrap();
+        let b_free_id = b_free.id;
+
+        // Baseline: step without applied force
+        data.forward();
+        let baseline_xpos = data.xpos()[b_free_id];
+
+        // Reset and apply upward force to counteract gravity
+        data.reset();
+        // Apply a strong upward force: [fx, fy, fz, torque_x, torque_y, torque_z]
+        data.xfrc_applied_mut()[b_free_id] = [0.0, 0.0, 100.0, 0.0, 0.0, 0.0];
+
+        for _ in 0..50 {
+            data.step();
+        }
+
+        let forced_xpos = data.xpos()[b_free_id];
+
+        // With an upward force of 100N on a 1kg mass, z should increase
+        assert!(forced_xpos[2] > baseline_xpos[2],
+            "Upward force should raise body: baseline_z={}, forced_z={}",
+            baseline_xpos[2], forced_xpos[2]);
+
+        // FFI cross-validation at this point
+        for j in 0..3 {
+            assert_eq!(forced_xpos[j], unsafe { *data.ffi().xpos.add(b_free_id * 3 + j) });
+        }
+
+        // xfrc_applied should still hold our value
+        assert_eq!(data.xfrc_applied()[b_free_id], [0.0, 0.0, 100.0, 0.0, 0.0, 0.0]);
+    }
+
+    /// Simulates, mutates mocap position mid-simulation via force-cast mutable array,
+    /// and verifies the change is reflected in subsequent forward passes.
+    #[test]
+    fn test_force_cast_multi_step_mocap_mutation() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nmocap = model.ffi().nmocap as usize;
+        assert!(nmocap > 0, "model should have at least one mocap body");
+
+        // Check initial
+        let init_pos = data.mocap_pos()[0];
+        assert_eq!(init_pos, [10.0, 10.0, 10.0]);
+
+        // Step a few times
+        for _ in 0..10 {
+            data.step();
+        }
+
+        // Mutate mocap position mid-simulation
+        data.mocap_pos_mut()[0] = [20.0, 30.0, 40.0];
+        data.forward();
+
+        assert_eq!(data.mocap_pos()[0], [20.0, 30.0, 40.0]);
+        // FFI cross-validation
+        for j in 0..3 {
+            assert_eq!(unsafe { *data.ffi().mocap_pos.add(j) }, [20.0, 30.0, 40.0][j]);
+        }
+
+        // Mutate again and step further
+        data.mocap_pos_mut()[0] = [-5.0, -5.0, -5.0];
+        for _ in 0..10 {
+            data.step();
+        }
+        assert_eq!(data.mocap_pos()[0], [-5.0, -5.0, -5.0]);
+    }
+
+    /// Verifies that sensor data changes across multiple simulation steps.
+    /// Exercises the force-cast sensordata flat array after physics evolves.
+    #[test]
+    fn test_force_cast_multi_step_sensor_data_evolves() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+
+        let nsensordata = model.ffi().nsensordata as usize;
+        assert!(nsensordata > 0, "model needs at least one sensor");
+
+        data.forward();
+        let _init_sensor: Vec<MjtNum> = data.sensordata().to_vec();
+
+        // Apply force to create contact which the touch sensor may detect
+        let b_slide = data.body("b_slide").unwrap();
+        data.xfrc_applied_mut()[b_slide.id] = [0.0, 0.0, -50.0, 0.0, 0.0, 0.0];
+
+        for _ in 0..100 {
+            data.step();
+        }
+
+        let post_sensor = data.sensordata();
+        assert_eq!(post_sensor.len(), nsensordata);
+
+        // FFI cross-validation
+        for i in 0..nsensordata {
+            assert_eq!(post_sensor[i], unsafe { *data.ffi().sensordata.add(i) },
+                "sensordata[{}] FFI mismatch", i);
+        }
+    }
+
+    /// Multi-step test with eq_active force-cast bool: disable an equality
+    /// constraint mid-simulation, verify dynamics change.
+    #[test]
+    fn test_force_cast_multi_step_eq_active_toggle() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+
+        // Step with constraint active
+        for _ in 0..20 {
+            data.step();
+        }
+        let pos_with_eq = data.xpos().to_vec();
+
+        // Reset, disable equality constraint, step again
+        data.reset();
+        data.eq_active_mut()[0] = false;
+        data.eq_active_mut()[1] = false;
+
+        for _ in 0..20 {
+            data.step();
+        }
+        let pos_without_eq = data.xpos().to_vec();
+
+        // The positions should differ since the constraints are disabled
+        let b_slide = data.body("b_slide").unwrap();
+        let diff: MjtNum = (0..3)
+            .map(|j| (pos_with_eq[b_slide.id][j] - pos_without_eq[b_slide.id][j]).abs())
+            .sum();
+
+        // At least some difference expected from disabling the equality constraint
+        // (may be subtle depending on model dynamics, but should not be zero)
+        assert!(diff > 1e-15 || {
+            // If b_slide didn't move much, check b_hinge (the other constrained body)
+            let b_hinge = data.body("b_hinge").unwrap();
+            (0..3)
+                .map(|j| (pos_with_eq[b_hinge.id][j] - pos_without_eq[b_hinge.id][j]).abs())
+                .sum::<MjtNum>() > 1e-15
+        }, "disabling equality constraints should change positions");
+
+        // FFI cross-validation for eq_active
+        assert_eq!(data.eq_active()[0], false);
+        assert_eq!(data.eq_active()[1], false);
+        assert_eq!(unsafe { *data.ffi().eq_active }, 0u8);
+        assert_eq!(unsafe { *data.ffi().eq_active.add(1) }, 0u8);
+    }
+
+    /// Runs step1() + step2() split stepping and verifies force-cast arrays
+    /// remain consistent with FFI between sub-steps.
+    #[test]
+    fn test_force_cast_split_step_consistency() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+
+        let nbody = model.ffi().nbody as usize;
+
+        for _ in 0..15 {
+            data.step1();
+
+            // After step1: positions and velocities are computed
+            let mid_xpos = data.xpos();
+            assert_eq!(mid_xpos.len(), nbody);
+            for i in 0..nbody {
+                for j in 0..3 {
+                    assert_eq!(mid_xpos[i][j], unsafe { *data.ffi().xpos.add(i * 3 + j) },
+                        "xpos[{}][{}] FFI mismatch after step1", i, j);
+                }
+            }
+
+            data.step2();
+
+            // After step2: integration is complete
+            let post_xpos = data.xpos();
+            for i in 0..nbody {
+                for j in 0..3 {
+                    assert_eq!(post_xpos[i][j], unsafe { *data.ffi().xpos.add(i * 3 + j) },
+                        "xpos[{}][{}] FFI mismatch after step2", i, j);
+                }
+            }
+        }
+    }
+
+    /// Steps the simulation, copies state via get_state/set_state, steps further,
+    /// and verifies force-cast arrays reflect the correct state at each point.
+    #[test]
+    fn test_force_cast_multi_step_state_save_restore() {
+        use crate::wrappers::mj_data::MjtState;
+
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+
+        // Step 30 times
+        for _ in 0..30 {
+            data.step();
+        }
+        // Synchronize derived quantities (xpos, etc.) with current qpos
+        data.forward();
+
+        // Save state
+        let saved_state = data.get_state(MjtState::mjSTATE_FULLPHYSICS as u32);
+        let saved_xpos: Vec<[MjtNum; 3]> = data.xpos().to_vec();
+        let saved_qpos: Vec<MjtNum> = data.qpos().to_vec();
+
+        // Step 30 more times (state diverges)
+        for _ in 0..30 {
+            data.step();
+        }
+        let diverged_xpos: Vec<[MjtNum; 3]> = data.xpos().to_vec();
+        assert_ne!(diverged_xpos, saved_xpos, "state should diverge after more steps");
+
+        // Restore state
+        data.set_state(&saved_state, MjtState::mjSTATE_FULLPHYSICS as u32);
+        data.forward();
+
+        // Primary state (qpos) should be exactly restored
+        let restored_qpos = data.qpos();
+        for i in 0..saved_qpos.len() {
+            assert_eq!(restored_qpos[i], saved_qpos[i],
+                "qpos[{}] should match saved state after restore", i);
+        }
+
+        // Derived quantity (xpos) should be approximately restored
+        // (forward() recomputes from scratch, minor floating-point differences possible)
+        let restored_xpos = data.xpos();
+        for i in 0..saved_xpos.len() {
+            for j in 0..3 {
+                assert!(
+                    (restored_xpos[i][j] - saved_xpos[i][j]).abs() < 1e-10,
+                    "xpos[{}][{}] should approximately match saved state: got {} vs {}",
+                    i, j, restored_xpos[i][j], saved_xpos[i][j]
+                );
+            }
+        }
+    }
+
+    /// Multi-step test that verifies kinematic quantities (xmat, xipos, ximat)
+    /// change across steps and stay FFI-consistent via force-cast.
+    #[test]
+    fn test_force_cast_multi_step_kinematics_evolve() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+
+        // Apply an off-center force to induce rotation on the free body.
+        let b_free = data.body("b_free").unwrap();
+        data.xfrc_applied_mut()[b_free.id] = [1.0, 0.0, 0.0, 0.0, 0.5, 0.0];
+        data.forward();
+
+        let nbody = model.ffi().nbody as usize;
+        let init_xmat: Vec<[MjtNum; 9]> = data.xmat().to_vec();
+        let init_xipos: Vec<[MjtNum; 3]> = data.xipos().to_vec();
+
+        // Step 50 times with the off-center force
+        for _ in 0..50 {
+            data.step();
+        }
+
+        let post_xmat = data.xmat();
+        let post_xipos = data.xipos();
+
+        assert_eq!(post_xmat.len(), nbody);
+        assert_eq!(post_xipos.len(), nbody);
+
+        // Free body xipos should change (it falls and translates)
+        let pos_changed = (0..3).any(|j| (post_xipos[b_free.id][j] - init_xipos[b_free.id][j]).abs() > 1e-6);
+        assert!(pos_changed, "free body xipos should change as it moves");
+
+        // Free body xmat should change (off-center force induces rotation)
+        let mat_changed = (0..9).any(|j| (post_xmat[b_free.id][j] - init_xmat[b_free.id][j]).abs() > 1e-12);
+        assert!(mat_changed, "free body xmat should change with off-center force");
+
+        // FFI cross-validation
+        for i in 0..nbody {
+            for j in 0..9 {
+                assert_eq!(post_xmat[i][j], unsafe { *data.ffi().xmat.add(i * 9 + j) });
+            }
+            for j in 0..3 {
+                assert_eq!(post_xipos[i][j], unsafe { *data.ffi().xipos.add(i * 3 + j) });
+            }
+        }
+    }
+
+    /// Runs simulation and verifies dynamic subtree quantities (subtree_com,
+    /// subtree_linvel, subtree_angmom) change and match FFI after stepping.
+    #[test]
+    fn test_force_cast_multi_step_subtree_dynamics() {
+        let model = MjModel::from_xml_string(FORCE_MODEL).unwrap();
+        let mut data = model.make_data();
+        data.forward();
+
+        let nbody = model.ffi().nbody as usize;
+        let init_subtree_com: Vec<[MjtNum; 3]> = data.subtree_com().to_vec();
+
+        for _ in 0..60 {
+            data.step();
+        }
+
+        let post_subtree_com = data.subtree_com();
+        let post_subtree_linvel = data.subtree_linvel();
+        let post_subtree_angmom = data.subtree_angmom();
+
+        assert_eq!(post_subtree_com.len(), nbody);
+        assert_eq!(post_subtree_linvel.len(), nbody);
+        assert_eq!(post_subtree_angmom.len(), nbody);
+
+        // World subtree_com should change (bodies are falling)
+        let world_com_diff: MjtNum = (0..3)
+            .map(|j| (post_subtree_com[0][j] - init_subtree_com[0][j]).abs())
+            .sum();
+        assert!(world_com_diff > 1e-6,
+            "world subtree_com should shift as bodies fall");
+
+        // FFI cross-validation
+        for i in 0..nbody {
+            for j in 0..3 {
+                assert_eq!(post_subtree_com[i][j], unsafe { *data.ffi().subtree_com.add(i * 3 + j) });
+                assert_eq!(post_subtree_linvel[i][j], unsafe { *data.ffi().subtree_linvel.add(i * 3 + j) });
+                assert_eq!(post_subtree_angmom[i][j], unsafe { *data.ffi().subtree_angmom.add(i * 3 + j) });
+            }
+        }
+    }
 }

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -2112,4 +2112,45 @@ mod tests {
         assert!(xml.contains("prm=\"1\""));
         assert!(xml.contains("prm=\"2\""));
     }
+
+    /// Tests that wrapping sites on a tendon produces a compiled model
+    /// with correct ntendon, nwrap, wrap types, and wrap object IDs.
+    #[test]
+    fn test_tendon_wrap_site_compiled_model() {
+        let mut spec = MjSpec::new();
+        let world = spec.world_body_mut();
+
+        let b1 = world.add_body().with_pos([0.0, 0.0, 0.5]);
+        b1.add_geom().with_size([0.01; 3]);
+        b1.add_site().with_name("s1");
+        b1.add_joint().with_type(MjtJoint::mjJNT_FREE);
+
+        let b2 = world.add_body().with_pos([1.0, 0.0, 0.5]);
+        b2.add_geom().with_size([0.01; 3]);
+        b2.add_site().with_name("s2");
+        b2.add_joint().with_type(MjtJoint::mjJNT_FREE);
+
+        world.add_geom().with_type(MjtGeom::mjGEOM_PLANE).with_size([1.0; 3]);
+
+        let tendon = spec.add_tendon().with_range([0.0, 1.0]);
+        tendon.wrap_site("s1");
+        tendon.wrap_site("s2");
+
+        let model = spec.compile().unwrap();
+
+        assert_eq!(model.ffi().ntendon, 1, "expected one tendon");
+        assert_eq!(model.ffi().nwrap, 2, "expected two wrap elements");
+
+        // Verify wrap types are mjWRAP_SITE (= 1)
+        let wrap_types = model.wrap_type();
+        assert_eq!(wrap_types[0], MjtWrap::mjWRAP_SITE);
+        assert_eq!(wrap_types[1], MjtWrap::mjWRAP_SITE);
+
+        // Verify wrap object IDs point to the correct sites
+        let wrap_objid = model.wrap_objid();
+        let s1_id = model.site("s1").unwrap().id as i32;
+        let s2_id = model.site("s2").unwrap().id as i32;
+        assert_eq!(wrap_objid[0], s1_id);
+        assert_eq!(wrap_objid[1], s2_id);
+    }
 }

--- a/src/wrappers/mj_model.rs
+++ b/src/wrappers/mj_model.rs
@@ -2385,4 +2385,907 @@ mod tests {
         let written = model.extract_state_into(&state_full, MjtState::mjSTATE_FULLPHYSICS as u32, &mut buf, 0u32).unwrap();
         assert_eq!(written, 0);
     }
+
+    /**************************************************************************/
+    // Force-cast macro correctness tests for MjModel
+    /**************************************************************************/
+
+    /// Verifies [force]-cast array grouping for body_pos (&[[MjtNum; 3]]),
+    /// body_quat (&[[MjtNum; 4]]), body_inertia (&[[MjtNum; 3]]), body_invweight0 (&[[MjtNum; 2]]).
+    #[test]
+    fn test_force_cast_body_model_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let nbody = model.ffi().nbody as usize;
+
+        let body_pos = model.body_pos();
+        let body_quat = model.body_quat();
+        let body_inertia = model.body_inertia();
+        let body_invweight0 = model.body_invweight0();
+        let body_ipos = model.body_ipos();
+        let body_iquat = model.body_iquat();
+
+        assert_eq!(body_pos.len(), nbody);
+        assert_eq!(body_quat.len(), nbody);
+        assert_eq!(body_inertia.len(), nbody);
+        assert_eq!(body_invweight0.len(), nbody);
+        assert_eq!(body_ipos.len(), nbody);
+        assert_eq!(body_iquat.len(), nbody);
+
+        // Cross-validate against raw FFI
+        for i in 0..nbody {
+            for j in 0..3 {
+                assert_eq!(body_pos[i][j], unsafe { *model.ffi().body_pos.add(i * 3 + j) },
+                    "body_pos[{}][{}] mismatch", i, j);
+            }
+            for j in 0..4 {
+                assert_eq!(body_quat[i][j], unsafe { *model.ffi().body_quat.add(i * 4 + j) },
+                    "body_quat[{}][{}] mismatch", i, j);
+            }
+            for j in 0..3 {
+                assert_eq!(body_inertia[i][j], unsafe { *model.ffi().body_inertia.add(i * 3 + j) },
+                    "body_inertia[{}][{}] mismatch", i, j);
+            }
+            for j in 0..2 {
+                assert_eq!(body_invweight0[i][j], unsafe { *model.ffi().body_invweight0.add(i * 2 + j) },
+                    "body_invweight0[{}][{}] mismatch", i, j);
+            }
+        }
+    }
+
+    /// Verifies [force]-cast enum for jnt_type (*mut i32 -> *mut MjtJoint).
+    #[test]
+    fn test_force_cast_jnt_type_enum() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let njnt = model.ffi().njnt as usize;
+        let jnt_type = model.jnt_type();
+
+        assert_eq!(jnt_type.len(), njnt);
+
+        // Cross-validate with raw FFI
+        for i in 0..njnt {
+            let raw_i32 = unsafe { *model.ffi().jnt_type.add(i) };
+            let expected: MjtJoint = unsafe { crate::util::force_cast(raw_i32) };
+            assert_eq!(jnt_type[i], expected,
+                "jnt_type[{}]: got {:?}, expected {:?} (raw={})", i, jnt_type[i], expected, raw_i32);
+        }
+
+        // Verify known joints: "ball" is free, "rod" is slide
+        let ball_jnt = model.joint("ball").unwrap();
+        assert_eq!(jnt_type[ball_jnt.id], MjtJoint::mjJNT_FREE);
+
+        let rod_jnt = model.joint("rod").unwrap();
+        assert_eq!(jnt_type[rod_jnt.id], MjtJoint::mjJNT_SLIDE);
+    }
+
+    /// Verifies [force]-cast bool for jnt_limited (*mut u8 -> *mut bool).
+    #[test]
+    fn test_force_cast_jnt_limited_bool() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let njnt = model.ffi().njnt as usize;
+        let jnt_limited = model.jnt_limited();
+
+        assert_eq!(jnt_limited.len(), njnt);
+
+        // Cross-validate with raw FFI
+        for i in 0..njnt {
+            let raw_u8 = unsafe { *model.ffi().jnt_limited.add(i) };
+            assert!(raw_u8 == 0 || raw_u8 == 1,
+                "raw jnt_limited[{}]={} must be 0 or 1", i, raw_u8);
+            assert_eq!(jnt_limited[i], raw_u8 != 0,
+                "jnt_limited[{}] mismatch: bool={}, raw={}", i, jnt_limited[i], raw_u8);
+        }
+
+        // "rod" joint has range="0 1" -> limited=true; "ball" is free -> limited=false
+        let rod_jnt = model.joint("rod").unwrap();
+        assert_eq!(jnt_limited[rod_jnt.id], true);
+
+        let ball_jnt = model.joint("ball").unwrap();
+        assert_eq!(jnt_limited[ball_jnt.id], false);
+    }
+
+    /// Verifies [force]-cast enum for geom_type (*mut i32 -> *mut MjtGeom).
+    #[test]
+    fn test_force_cast_geom_type_enum() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let ngeom = model.ffi().ngeom as usize;
+        let geom_type = model.geom_type();
+
+        assert_eq!(geom_type.len(), ngeom);
+
+        // Cross-validate
+        for i in 0..ngeom {
+            let raw_i32 = unsafe { *model.ffi().geom_type.add(i) };
+            let expected: MjtGeom = unsafe { crate::util::force_cast(raw_i32) };
+            assert_eq!(geom_type[i], expected);
+        }
+
+        // Verify known geoms
+        let sphere_geom = model.geom("green_sphere").unwrap();
+        assert_eq!(geom_type[sphere_geom.id], MjtGeom::mjGEOM_SPHERE);
+
+        let floor_geom = model.geom("floor").unwrap();
+        assert_eq!(geom_type[floor_geom.id], MjtGeom::mjGEOM_PLANE);
+
+        let rod_geom = model.geom("rod").unwrap();
+        assert_eq!(geom_type[rod_geom.id], MjtGeom::mjGEOM_CYLINDER);
+    }
+
+    /// Verifies [force]-cast for geom_size (&[[MjtNum; 3]]), geom_pos (&[[MjtNum; 3]]),
+    /// geom_quat (&[[MjtNum; 4]]), geom_rgba (&[[f32; 4]]), geom_friction (&[[MjtNum; 3]]),
+    /// geom_aabb (&[[MjtNum; 6]]).
+    #[test]
+    fn test_force_cast_geom_model_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let ngeom = model.ffi().ngeom as usize;
+
+        let geom_size = model.geom_size();
+        let geom_pos = model.geom_pos();
+        let geom_quat = model.geom_quat();
+        let geom_rgba = model.geom_rgba();
+        let geom_friction = model.geom_friction();
+        let geom_aabb = model.geom_aabb();
+
+        assert_eq!(geom_size.len(), ngeom);
+        assert_eq!(geom_pos.len(), ngeom);
+        assert_eq!(geom_quat.len(), ngeom);
+        assert_eq!(geom_rgba.len(), ngeom);
+        assert_eq!(geom_friction.len(), ngeom);
+        assert_eq!(geom_aabb.len(), ngeom);
+
+        // Cross-validate all against FFI
+        for i in 0..ngeom {
+            for j in 0..3 {
+                assert_eq!(geom_size[i][j], unsafe { *model.ffi().geom_size.add(i * 3 + j) });
+                assert_eq!(geom_pos[i][j], unsafe { *model.ffi().geom_pos.add(i * 3 + j) });
+                assert_eq!(geom_friction[i][j], unsafe { *model.ffi().geom_friction.add(i * 3 + j) });
+            }
+            for j in 0..4 {
+                assert_eq!(geom_quat[i][j], unsafe { *model.ffi().geom_quat.add(i * 4 + j) });
+                assert_eq!(geom_rgba[i][j], unsafe { *model.ffi().geom_rgba.add(i * 4 + j) });
+            }
+            for j in 0..6 {
+                assert_eq!(geom_aabb[i][j], unsafe { *model.ffi().geom_aabb.add(i * 6 + j) });
+            }
+        }
+
+        // Verify a known geom: "green_sphere" has rgba="0 1 0 1" and size="0.1"
+        let gs = model.geom("green_sphere").unwrap();
+        assert_eq!(geom_rgba[gs.id], [0.0f32, 1.0, 0.0, 1.0]);
+        assert_relative_eq!(geom_size[gs.id][0], 0.1, epsilon = 1e-9);
+    }
+
+    /// Verifies [force]-cast for camera arrays: cam_mode (MjtCamLight), cam_projection (MjtProjection),
+    /// cam_resolution (&[[i32; 2]]), cam_sensorsize (&[[f32; 2]]), cam_intrinsic (&[[f32; 4]]),
+    /// cam_mat0 (&[[MjtNum; 9]]).
+    #[test]
+    fn test_force_cast_camera_model_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let ncam = model.ffi().ncam as usize;
+
+        if ncam == 0 {
+            // The EXAMPLE_MODEL has a camera, but guard just in case
+            return;
+        }
+
+        let cam_mode = model.cam_mode();
+        let cam_projection = model.cam_projection();
+        let cam_resolution = model.cam_resolution();
+        let cam_sensorsize = model.cam_sensorsize();
+        let cam_intrinsic = model.cam_intrinsic();
+        let cam_mat0 = model.cam_mat0();
+
+        assert_eq!(cam_mode.len(), ncam);
+        assert_eq!(cam_projection.len(), ncam);
+        assert_eq!(cam_resolution.len(), ncam);
+        assert_eq!(cam_sensorsize.len(), ncam);
+        assert_eq!(cam_intrinsic.len(), ncam);
+        assert_eq!(cam_mat0.len(), ncam);
+
+        // Cross-validate enum casts against raw FFI
+        for i in 0..ncam {
+            let raw_mode = unsafe { *model.ffi().cam_mode.add(i) };
+            let expected_mode: MjtCamLight = unsafe { crate::util::force_cast(raw_mode) };
+            assert_eq!(cam_mode[i], expected_mode);
+
+            let raw_proj = unsafe { *model.ffi().cam_projection.add(i) };
+            let expected_proj: MjtProjection = unsafe { crate::util::force_cast(raw_proj) };
+            assert_eq!(cam_projection[i], expected_proj);
+
+            for j in 0..2 {
+                assert_eq!(cam_resolution[i][j], unsafe { *model.ffi().cam_resolution.add(i * 2 + j) });
+                assert_eq!(cam_sensorsize[i][j], unsafe { *model.ffi().cam_sensorsize.add(i * 2 + j) });
+            }
+            for j in 0..4 {
+                assert_eq!(cam_intrinsic[i][j], unsafe { *model.ffi().cam_intrinsic.add(i * 4 + j) });
+            }
+            for j in 0..9 {
+                assert_eq!(cam_mat0[i][j], unsafe { *model.ffi().cam_mat0.add(i * 9 + j) });
+            }
+        }
+
+        // Verify known camera: "cam1" has resolution="100 200"
+        let cam1 = model.camera("cam1").unwrap();
+        assert_eq!(cam_resolution[cam1.id], [100, 200]);
+    }
+
+    /// Verifies [force]-cast for bvh_child (&[[i32; 2]]) and bvh_aabb (&[[MjtNum; 6]]).
+    #[test]
+    fn test_force_cast_bvh_model_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let nbvh = model.ffi().nbvh as usize;
+
+        let bvh_child = model.bvh_child();
+        assert_eq!(bvh_child.len(), nbvh);
+
+        for i in 0..nbvh {
+            for j in 0..2 {
+                assert_eq!(bvh_child[i][j], unsafe { *model.ffi().bvh_child.add(i * 2 + j) });
+            }
+        }
+
+        let nbvhstatic = model.ffi().nbvhstatic as usize;
+        let bvh_aabb = model.bvh_aabb();
+        assert_eq!(bvh_aabb.len(), nbvhstatic);
+
+        for i in 0..nbvhstatic {
+            for j in 0..6 {
+                assert_eq!(bvh_aabb[i][j], unsafe { *model.ffi().bvh_aabb.add(i * 6 + j) });
+            }
+        }
+    }
+
+    /// Verifies [force]-cast enum: body_sameframe and geom_sameframe (MjtSameFrame).
+    #[test]
+    fn test_force_cast_sameframe_enum() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let nbody = model.ffi().nbody as usize;
+        let ngeom = model.ffi().ngeom as usize;
+
+        let body_sameframe = model.body_sameframe();
+        let geom_sameframe = model.geom_sameframe();
+
+        assert_eq!(body_sameframe.len(), nbody);
+        assert_eq!(geom_sameframe.len(), ngeom);
+
+        for i in 0..nbody {
+            let raw = unsafe { *model.ffi().body_sameframe.add(i) };
+            let expected: MjtSameFrame = unsafe { crate::util::force_cast(raw) };
+            assert_eq!(body_sameframe[i], expected, "body_sameframe[{}] mismatch", i);
+        }
+
+        for i in 0..ngeom {
+            let raw = unsafe { *model.ffi().geom_sameframe.add(i) };
+            let expected: MjtSameFrame = unsafe { crate::util::force_cast(raw) };
+            assert_eq!(geom_sameframe[i], expected, "geom_sameframe[{}] mismatch", i);
+        }
+    }
+
+    /// Verifies [force]-cast for equality constraint arrays: eq_type (MjtEq),
+    /// eq_objtype (MjtObj), eq_active0 (bool), eq_data (&[[MjtNum; mjNEQDATA]]).
+    #[test]
+    fn test_force_cast_equality_model_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let neq = model.ffi().neq as usize;
+
+        if neq == 0 {
+            return;
+        }
+
+        let eq_type = model.eq_type();
+        let eq_objtype = model.eq_objtype();
+        let eq_active0 = model.eq_active0();
+
+        assert_eq!(eq_type.len(), neq);
+        assert_eq!(eq_objtype.len(), neq);
+        assert_eq!(eq_active0.len(), neq);
+
+        // Cross-validate enum casts
+        for i in 0..neq {
+            let raw_type = unsafe { *model.ffi().eq_type.add(i) };
+            let expected_type: MjtEq = unsafe { crate::util::force_cast(raw_type) };
+            assert_eq!(eq_type[i], expected_type);
+
+            let raw_objtype = unsafe { *model.ffi().eq_objtype.add(i) };
+            let expected_objtype: MjtObj = unsafe { crate::util::force_cast(raw_objtype) };
+            assert_eq!(eq_objtype[i], expected_objtype);
+
+            let raw_active = unsafe { *model.ffi().eq_active0.add(i) };
+            assert_eq!(eq_active0[i], raw_active != 0);
+        }
+
+        // Verify known equality: "eq1" is a connect constraint
+        let eq1 = model.equality("eq1").unwrap();
+        assert_eq!(eq_type[eq1.id], MjtEq::mjEQ_CONNECT);
+        assert_eq!(eq_objtype[eq1.id], MjtObj::mjOBJ_BODY);
+        assert_eq!(eq_active0[eq1.id], true);
+    }
+
+    /// Verifies [force]-cast for sensor arrays: sensor_type (MjtSensor), sensor_datatype (MjtDataType),
+    /// sensor_needstage (MjtStage), sensor_objtype (MjtObj), sensor_reftype (MjtObj).
+    #[test]
+    fn test_force_cast_sensor_model_enums() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let nsensor = model.ffi().nsensor as usize;
+
+        if nsensor == 0 {
+            return;
+        }
+
+        let sensor_type = model.sensor_type();
+        let sensor_datatype = model.sensor_datatype();
+        let sensor_needstage = model.sensor_needstage();
+        let sensor_objtype = model.sensor_objtype();
+        let sensor_reftype = model.sensor_reftype();
+
+        assert_eq!(sensor_type.len(), nsensor);
+        assert_eq!(sensor_datatype.len(), nsensor);
+        assert_eq!(sensor_needstage.len(), nsensor);
+        assert_eq!(sensor_objtype.len(), nsensor);
+        assert_eq!(sensor_reftype.len(), nsensor);
+
+        for i in 0..nsensor {
+            let raw_type = unsafe { *model.ffi().sensor_type.add(i) };
+            let raw_datatype = unsafe { *model.ffi().sensor_datatype.add(i) };
+            let raw_needstage = unsafe { *model.ffi().sensor_needstage.add(i) };
+            let raw_objtype = unsafe { *model.ffi().sensor_objtype.add(i) };
+            let raw_reftype = unsafe { *model.ffi().sensor_reftype.add(i) };
+
+            assert_eq!(sensor_type[i], unsafe { crate::util::force_cast::<_, MjtSensor>(raw_type) });
+            assert_eq!(sensor_datatype[i], unsafe { crate::util::force_cast::<_, MjtDataType>(raw_datatype) });
+            assert_eq!(sensor_needstage[i], unsafe { crate::util::force_cast::<_, MjtStage>(raw_needstage) });
+            assert_eq!(sensor_objtype[i], unsafe { crate::util::force_cast::<_, MjtObj>(raw_objtype) });
+            assert_eq!(sensor_reftype[i], unsafe { crate::util::force_cast::<_, MjtObj>(raw_reftype) });
+        }
+
+        // Verify known sensor: "touch" is a touch sensor on a site
+        let touch = model.sensor("touch").unwrap();
+        assert_eq!(sensor_type[touch.id], MjtSensor::mjSENS_TOUCH);
+        assert_eq!(sensor_objtype[touch.id], MjtObj::mjOBJ_SITE);
+    }
+
+    /// Verifies [force]-cast for actuator enum arrays: trntype (MjtTrn), dyntype (MjtDyn),
+    /// gaintype (MjtGain), biastype (MjtBias), and bool ctrllimited, forcelimited, actlimited.
+    #[test]
+    fn test_force_cast_actuator_model_enums_and_bools() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let nu = model.ffi().nu as usize;
+
+        if nu == 0 {
+            return;
+        }
+
+        let trntype = model.actuator_trntype();
+        let dyntype = model.actuator_dyntype();
+        let gaintype = model.actuator_gaintype();
+        let biastype = model.actuator_biastype();
+        let ctrllimited = model.actuator_ctrllimited();
+        let forcelimited = model.actuator_forcelimited();
+        let actlimited = model.actuator_actlimited();
+        let actearly = model.actuator_actearly();
+
+        assert_eq!(trntype.len(), nu);
+        assert_eq!(dyntype.len(), nu);
+        assert_eq!(gaintype.len(), nu);
+        assert_eq!(biastype.len(), nu);
+        assert_eq!(ctrllimited.len(), nu);
+        assert_eq!(forcelimited.len(), nu);
+        assert_eq!(actlimited.len(), nu);
+        assert_eq!(actearly.len(), nu);
+
+        for i in 0..nu {
+            // Enum cross-validation
+            assert_eq!(trntype[i], unsafe { crate::util::force_cast::<_, MjtTrn>(*model.ffi().actuator_trntype.add(i)) });
+            assert_eq!(dyntype[i], unsafe { crate::util::force_cast::<_, MjtDyn>(*model.ffi().actuator_dyntype.add(i)) });
+            assert_eq!(gaintype[i], unsafe { crate::util::force_cast::<_, MjtGain>(*model.ffi().actuator_gaintype.add(i)) });
+            assert_eq!(biastype[i], unsafe { crate::util::force_cast::<_, MjtBias>(*model.ffi().actuator_biastype.add(i)) });
+
+            // Bool cross-validation
+            let raw_ctrllimited = unsafe { *model.ffi().actuator_ctrllimited.add(i) };
+            assert_eq!(ctrllimited[i], raw_ctrllimited != 0);
+            let raw_forcelimited = unsafe { *model.ffi().actuator_forcelimited.add(i) };
+            assert_eq!(forcelimited[i], raw_forcelimited != 0);
+            let raw_actlimited = unsafe { *model.ffi().actuator_actlimited.add(i) };
+            assert_eq!(actlimited[i], raw_actlimited != 0);
+            let raw_actearly = unsafe { *model.ffi().actuator_actearly.add(i) };
+            assert_eq!(actearly[i], raw_actearly != 0);
+        }
+
+        // Verify known actuator: "slider" has biastype=affine, gaintype=fixed, ctrllimited=true
+        let slider = model.actuator("slider").unwrap();
+        assert_eq!(biastype[slider.id], MjtBias::mjBIAS_AFFINE);
+        assert_eq!(gaintype[slider.id], MjtGain::mjGAIN_FIXED);
+        assert_eq!(ctrllimited[slider.id], true);
+    }
+
+    /// Verifies [force]-cast for actuator parameter arrays: dynprm, gainprm, biasprm, ctrlrange,
+    /// gear (&[[MjtNum; 6]]).
+    #[test]
+    fn test_force_cast_actuator_param_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let nu = model.ffi().nu as usize;
+
+        let dynprm = model.actuator_dynprm();
+        let ctrlrange = model.actuator_ctrlrange();
+        let gear = model.actuator_gear();
+        let trnid = model.actuator_trnid();
+
+        assert_eq!(dynprm.len(), nu);
+        assert_eq!(ctrlrange.len(), nu);
+        assert_eq!(gear.len(), nu);
+        assert_eq!(trnid.len(), nu);
+
+        // Verify "slider" dynprm and ctrlrange
+        let slider = model.actuator("slider").unwrap();
+        assert_eq!(dynprm[slider.id][0..10], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]);
+        assert_eq!(ctrlrange[slider.id], [0.0, 1.0]);
+
+        // Verify "slider2" has reversed dynprm
+        let slider2 = model.actuator("slider2").unwrap();
+        assert_eq!(dynprm[slider2.id][0..10], [10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0]);
+
+        // Cross-validate FFI for gear (stride 6)
+        for i in 0..nu {
+            for j in 0..6 {
+                assert_eq!(gear[i][j], unsafe { *model.ffi().actuator_gear.add(i * 6 + j) });
+            }
+            for j in 0..2 {
+                assert_eq!(trnid[i][j], unsafe { *model.ffi().actuator_trnid.add(i * 2 + j) });
+                assert_eq!(ctrlrange[i][j], unsafe { *model.ffi().actuator_ctrlrange.add(i * 2 + j) });
+            }
+        }
+    }
+
+    /// Verifies [force]-cast for tendon bools and arrays: tendon_limited (bool),
+    /// tendon_range (&[[MjtNum; 2]]), tendon_rgba (&[[f32; 4]]), tendon_treeid (&[[i32; 2]]).
+    #[test]
+    fn test_force_cast_tendon_model_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let ntendon = model.ffi().ntendon as usize;
+
+        if ntendon == 0 {
+            return;
+        }
+
+        let tendon_limited = model.tendon_limited();
+        let tendon_range = model.tendon_range();
+        let tendon_rgba = model.tendon_rgba();
+        let tendon_treeid = model.tendon_treeid();
+        let tendon_lengthspring = model.tendon_lengthspring();
+
+        assert_eq!(tendon_limited.len(), ntendon);
+        assert_eq!(tendon_range.len(), ntendon);
+        assert_eq!(tendon_rgba.len(), ntendon);
+        assert_eq!(tendon_treeid.len(), ntendon);
+        assert_eq!(tendon_lengthspring.len(), ntendon);
+
+        for i in 0..ntendon {
+            let raw_limited = unsafe { *model.ffi().tendon_limited.add(i) };
+            assert_eq!(tendon_limited[i], raw_limited != 0);
+
+            for j in 0..2 {
+                assert_eq!(tendon_range[i][j], unsafe { *model.ffi().tendon_range.add(i * 2 + j) });
+                assert_eq!(tendon_treeid[i][j], unsafe { *model.ffi().tendon_treeid.add(i * 2 + j) });
+                assert_eq!(tendon_lengthspring[i][j], unsafe { *model.ffi().tendon_lengthspring.add(i * 2 + j) });
+            }
+
+            for j in 0..4 {
+                assert_eq!(tendon_rgba[i][j], unsafe { *model.ffi().tendon_rgba.add(i * 4 + j) });
+            }
+        }
+
+        // Verify known tendon: "tendon2" limited=true, range=(0,1), rgba=(0, 0.1, 1, 1)
+        let ten2 = model.tendon("tendon2").unwrap();
+        assert_eq!(tendon_limited[ten2.id], true);
+        assert_eq!(tendon_range[ten2.id], [0.0, 1.0]);
+        assert_relative_eq!(tendon_rgba[ten2.id][0], 0.0f32, epsilon = 1e-6);
+        assert_relative_eq!(tendon_rgba[ten2.id][1], 0.1f32, epsilon = 1e-6);
+    }
+
+    /// Verifies [force]-cast for texture enum: tex_type (MjtTexture), tex_colorspace (MjtColorSpace).
+    #[test]
+    fn test_force_cast_texture_model_enums() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let ntex = model.ffi().ntex as usize;
+
+        if ntex == 0 {
+            return;
+        }
+
+        let tex_type = model.tex_type();
+        let tex_colorspace = model.tex_colorspace();
+
+        assert_eq!(tex_type.len(), ntex);
+        assert_eq!(tex_colorspace.len(), ntex);
+
+        for i in 0..ntex {
+            let raw_type = unsafe { *model.ffi().tex_type.add(i) };
+            let expected_type: MjtTexture = unsafe { crate::util::force_cast(raw_type) };
+            assert_eq!(tex_type[i], expected_type);
+
+            let raw_cs = unsafe { *model.ffi().tex_colorspace.add(i) };
+            let expected_cs: MjtColorSpace = unsafe { crate::util::force_cast(raw_cs) };
+            assert_eq!(tex_colorspace[i], expected_cs);
+        }
+
+        // "wall_tex" is 2D, sRGB
+        let wall_tex = model.texture("wall_tex").unwrap();
+        assert_eq!(tex_type[wall_tex.id], MjtTexture::mjTEXTURE_2D);
+        assert_eq!(tex_colorspace[wall_tex.id], MjtColorSpace::mjCOLORSPACE_SRGB);
+    }
+
+    /// Verifies [force]-cast for material bools and f32 arrays: mat_texuniform (bool),
+    /// mat_texrepeat (&[[f32; 2]]), mat_rgba (&[[f32; 4]]).
+    #[test]
+    fn test_force_cast_material_model_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let nmat = model.ffi().nmat as usize;
+
+        if nmat == 0 {
+            return;
+        }
+
+        let mat_texuniform = model.mat_texuniform();
+        let mat_texrepeat = model.mat_texrepeat();
+        let mat_rgba = model.mat_rgba();
+
+        assert_eq!(mat_texuniform.len(), nmat);
+        assert_eq!(mat_texrepeat.len(), nmat);
+        assert_eq!(mat_rgba.len(), nmat);
+
+        for i in 0..nmat {
+            let raw_uniform = unsafe { *model.ffi().mat_texuniform.add(i) };
+            assert_eq!(mat_texuniform[i], raw_uniform != 0);
+
+            for j in 0..2 {
+                assert_eq!(mat_texrepeat[i][j], unsafe { *model.ffi().mat_texrepeat.add(i * 2 + j) });
+            }
+            for j in 0..4 {
+                assert_eq!(mat_rgba[i][j], unsafe { *model.ffi().mat_rgba.add(i * 4 + j) });
+            }
+        }
+
+        // "also_wood_material" has texuniform=false, texrepeat=[2,2], rgba=[0.8,0.5,0.3,1.0]
+        let mat = model.material("also_wood_material").unwrap();
+        assert_eq!(mat_texuniform[mat.id], false);
+        assert_eq!(mat_texrepeat[mat.id], [2.0f32, 2.0]);
+        assert_eq!(mat_rgba[mat.id], [0.8f32, 0.5, 0.3, 1.0]);
+    }
+
+    /// Verifies [force]-cast for light arrays: light mode/type enums, light_castshadow/active bools,
+    /// light_attenuation (&[[f32; 3]]), light_ambient/diffuse/specular (&[[f32; 3]]),
+    /// light_pos/dir (&[[MjtNum; 3]]).
+    #[test]
+    fn test_force_cast_light_model_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let nlight = model.ffi().nlight as usize;
+
+        if nlight == 0 {
+            return;
+        }
+
+        let light_mode = model.light_mode();
+        let light_type = model.light_type();
+        let light_castshadow = model.light_castshadow();
+        let light_active = model.light_active();
+        let light_attenuation = model.light_attenuation();
+        let light_ambient = model.light_ambient();
+        let light_diffuse = model.light_diffuse();
+        let light_specular = model.light_specular();
+        let light_pos = model.light_pos();
+        let light_dir = model.light_dir();
+
+        assert_eq!(light_mode.len(), nlight);
+        assert_eq!(light_type.len(), nlight);
+        assert_eq!(light_castshadow.len(), nlight);
+        assert_eq!(light_active.len(), nlight);
+
+        for i in 0..nlight {
+            assert_eq!(light_mode[i], unsafe { crate::util::force_cast::<_, MjtCamLight>(*model.ffi().light_mode.add(i)) });
+            assert_eq!(light_type[i], unsafe { crate::util::force_cast::<_, MjtLightType>(*model.ffi().light_type.add(i)) });
+
+            let raw_shadow = unsafe { *model.ffi().light_castshadow.add(i) };
+            assert_eq!(light_castshadow[i], raw_shadow != 0);
+            let raw_active = unsafe { *model.ffi().light_active.add(i) };
+            assert_eq!(light_active[i], raw_active != 0);
+
+            for j in 0..3 {
+                assert_eq!(light_attenuation[i][j], unsafe { *model.ffi().light_attenuation.add(i * 3 + j) });
+                assert_eq!(light_ambient[i][j], unsafe { *model.ffi().light_ambient.add(i * 3 + j) });
+                assert_eq!(light_diffuse[i][j], unsafe { *model.ffi().light_diffuse.add(i * 3 + j) });
+                assert_eq!(light_specular[i][j], unsafe { *model.ffi().light_specular.add(i * 3 + j) });
+                assert_eq!(light_pos[i][j], unsafe { *model.ffi().light_pos.add(i * 3 + j) });
+                assert_eq!(light_dir[i][j], unsafe { *model.ffi().light_dir.add(i * 3 + j) });
+            }
+        }
+
+        // Verify known: "lamp_light2" is spot, mode=fixed, castshadow=true
+        let l2 = model.light("lamp_light2").unwrap();
+        assert_eq!(light_mode[l2.id], MjtCamLight::mjCAMLIGHT_FIXED);
+        assert_eq!(light_type[l2.id], MjtLightType::mjLIGHT_SPOT);
+        assert_eq!(light_castshadow[l2.id], true);
+    }
+
+    /// Verifies [force]-cast for the site arrays: site_type (MjtGeom), site_sameframe (MjtSameFrame),
+    /// site_size (&[[MjtNum; 3]]), site_pos (&[[MjtNum; 3]]), site_quat (&[[MjtNum; 4]]),
+    /// site_rgba (&[[f32; 4]]).
+    #[test]
+    fn test_force_cast_site_model_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let nsite = model.ffi().nsite as usize;
+
+        let site_type = model.site_type();
+        let site_sameframe = model.site_sameframe();
+        let site_size = model.site_size();
+        let site_pos = model.site_pos();
+        let site_quat = model.site_quat();
+        let site_rgba = model.site_rgba();
+
+        assert_eq!(site_type.len(), nsite);
+        assert_eq!(site_sameframe.len(), nsite);
+        assert_eq!(site_size.len(), nsite);
+        assert_eq!(site_pos.len(), nsite);
+        assert_eq!(site_quat.len(), nsite);
+        assert_eq!(site_rgba.len(), nsite);
+
+        for i in 0..nsite {
+            assert_eq!(site_type[i], unsafe { crate::util::force_cast::<_, MjtGeom>(*model.ffi().site_type.add(i)) });
+            assert_eq!(site_sameframe[i], unsafe { crate::util::force_cast::<_, MjtSameFrame>(*model.ffi().site_sameframe.add(i)) });
+
+            for j in 0..3 {
+                assert_eq!(site_size[i][j], unsafe { *model.ffi().site_size.add(i * 3 + j) });
+                assert_eq!(site_pos[i][j], unsafe { *model.ffi().site_pos.add(i * 3 + j) });
+            }
+            for j in 0..4 {
+                assert_eq!(site_quat[i][j], unsafe { *model.ffi().site_quat.add(i * 4 + j) });
+                assert_eq!(site_rgba[i][j], unsafe { *model.ffi().site_rgba.add(i * 4 + j) });
+            }
+        }
+    }
+
+    /// Verifies [force]-cast for joint solver arrays: jnt_solref (&[[MjtNum; mjNREF]]),
+    /// jnt_solimp (&[[MjtNum; mjNIMP]]), jnt_pos (&[[MjtNum; 3]]), jnt_axis (&[[MjtNum; 3]]),
+    /// jnt_range (&[[MjtNum; 2]]).
+    #[test]
+    fn test_force_cast_joint_model_solver_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let njnt = model.ffi().njnt as usize;
+
+        let jnt_solref = model.jnt_solref();
+        let jnt_solimp = model.jnt_solimp();
+        let jnt_pos = model.jnt_pos();
+        let jnt_axis = model.jnt_axis();
+        let jnt_range = model.jnt_range();
+
+        assert_eq!(jnt_solref.len(), njnt);
+        assert_eq!(jnt_solimp.len(), njnt);
+        assert_eq!(jnt_pos.len(), njnt);
+        assert_eq!(jnt_axis.len(), njnt);
+        assert_eq!(jnt_range.len(), njnt);
+
+        let nref = mjNREF as usize;
+        let nimp = mjNIMP as usize;
+
+        for i in 0..njnt {
+            for j in 0..nref {
+                assert_eq!(jnt_solref[i][j], unsafe { *model.ffi().jnt_solref.add(i * nref + j) });
+            }
+            for j in 0..nimp {
+                assert_eq!(jnt_solimp[i][j], unsafe { *model.ffi().jnt_solimp.add(i * nimp + j) });
+            }
+            for j in 0..3 {
+                assert_eq!(jnt_pos[i][j], unsafe { *model.ffi().jnt_pos.add(i * 3 + j) });
+                assert_eq!(jnt_axis[i][j], unsafe { *model.ffi().jnt_axis.add(i * 3 + j) });
+            }
+            for j in 0..2 {
+                assert_eq!(jnt_range[i][j], unsafe { *model.ffi().jnt_range.add(i * 2 + j) });
+            }
+        }
+
+        // "rod" has axis="0 1 0", range="0 1"
+        let rod = model.joint("rod").unwrap();
+        assert_eq!(&jnt_axis[rod.id][..], &[0.0, 1.0, 0.0]);
+        assert_eq!(&jnt_range[rod.id][..], &[0.0, 1.0]);
+    }
+
+    /// Verifies [force]-cast for view fields with enum types: joint view r#type,
+    /// geom view r#type, sensor view r#type + objtype, actuator view trntype + biastype.
+    /// Tests that the view_creator! macro correctly passes [force] tokens through.
+    #[test]
+    fn test_force_cast_view_enum_fields() {
+        let mut model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+
+        // Joint type via view
+        let rod_info = model.joint("rod").unwrap();
+        let rod_view = rod_info.view(&model);
+        assert_eq!(rod_view.r#type[0], MjtJoint::mjJNT_SLIDE);
+        assert_eq!(rod_view.limited[0], true);
+
+        // Geom type via view
+        let ball2_info = model.geom("ball2").unwrap();
+        let ball2_view = ball2_info.view(&model);
+        assert_eq!(ball2_view.r#type[0], MjtGeom::mjGEOM_SPHERE);
+
+        // Sensor type via view
+        let touch_info = model.sensor("touch").unwrap();
+        let touch_view = touch_info.view(&model);
+        assert_eq!(touch_view.r#type[0], MjtSensor::mjSENS_TOUCH);
+        assert_eq!(touch_view.objtype[0], MjtObj::mjOBJ_SITE);
+
+        // Actuator types via view
+        let slider_info = model.actuator("slider").unwrap();
+        let slider_view = slider_info.view(&model);
+        assert_eq!(slider_view.trntype[0], MjtTrn::mjTRN_JOINT);
+        assert_eq!(slider_view.biastype[0], MjtBias::mjBIAS_AFFINE);
+        assert_eq!(slider_view.gaintype[0], MjtGain::mjGAIN_FIXED);
+        assert_eq!(slider_view.ctrllimited[0], true);
+
+        // Mutable enum roundtrip via view
+        let mut slider_view_mut = slider_info.view_mut(&mut model);
+        slider_view_mut.gaintype[0] = MjtGain::mjGAIN_AFFINE;
+        let slider_view2 = slider_info.view(&model);
+        assert_eq!(slider_view2.gaintype[0], MjtGain::mjGAIN_AFFINE);
+    }
+
+    /// Verifies [force]-cast for mutable flat slice roundtrip on model arrays.
+    /// Tests that mutations through force-cast mutable slices are reflected in FFI.
+    #[test]
+    fn test_force_cast_model_mut_roundtrip() {
+        let mut model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+
+        // Mutate body_pos via force-cast mutable slice
+        let ball2_id = model.body("ball2").unwrap().id;
+        let orig_pos = model.body_pos()[ball2_id];
+        assert_eq!(orig_pos, [0.5, 0.0, 0.0]);
+
+        model.body_pos_mut()[ball2_id] = [99.0, 88.0, 77.0];
+        assert_eq!(model.body_pos()[ball2_id], [99.0, 88.0, 77.0]);
+
+        // Verify FFI side
+        for j in 0..3 {
+            let ffi_val = unsafe { *model.ffi().body_pos.add(ball2_id * 3 + j) };
+            assert_eq!(ffi_val, [99.0, 88.0, 77.0][j]);
+        }
+
+        // Mutate geom_rgba via force-cast mutable slice ([f32; 4])
+        let gs_id = model.geom("green_sphere").unwrap().id;
+        model.geom_rgba_mut()[gs_id] = [1.0f32, 0.0, 0.0, 0.5];
+        assert_eq!(model.geom_rgba()[gs_id], [1.0f32, 0.0, 0.0, 0.5]);
+        for j in 0..4 {
+            assert_eq!(unsafe { *model.ffi().geom_rgba.add(gs_id * 4 + j) }, [1.0f32, 0.0, 0.0, 0.5][j]);
+        }
+    }
+
+    /// Verifies [force]-cast sublen_dep variant in model: key_qpos, key_qvel, key_act, key_ctrl.
+    /// These have variable inner dimensions dependent on nq, nv, na, nu.
+    #[test]
+    fn test_force_cast_sublen_dep_key_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let nkey = model.ffi().nkey as usize;
+        let nq = model.ffi().nq as usize;
+        let nv = model.ffi().nv as usize;
+        let na = model.ffi().na as usize;
+        let nu = model.ffi().nu as usize;
+
+        assert!(nkey >= 2, "EXAMPLE_MODEL must have at least 2 keyframes");
+
+        let key_qpos = model.key_qpos();
+        let key_qvel = model.key_qvel();
+        let key_act = model.key_act();
+        let key_ctrl = model.key_ctrl();
+
+        // Total flat length must be nkey * inner_dim
+        assert_eq!(key_qpos.len(), nkey * nq);
+        assert_eq!(key_qvel.len(), nkey * nv);
+        assert_eq!(key_act.len(), nkey * na);
+        assert_eq!(key_ctrl.len(), nkey * nu);
+
+        // Cross-validate with FFI
+        for i in 0..(nkey * nq) {
+            assert_eq!(key_qpos[i], unsafe { *model.ffi().key_qpos.add(i) });
+        }
+        for i in 0..(nkey * nv) {
+            assert_eq!(key_qvel[i], unsafe { *model.ffi().key_qvel.add(i) });
+        }
+        for i in 0..(nkey * nu) {
+            assert_eq!(key_ctrl[i], unsafe { *model.ffi().key_ctrl.add(i) });
+        }
+    }
+
+    /// Tests empty model edge case: model with no optional objects should return
+    /// empty slices for all force-cast enum/bool/array fields.
+    #[test]
+    fn test_force_cast_minimal_model_edge_case() {
+        let xml = "<mujoco><worldbody><body><joint type='free'/><geom size='0.1'/></body></worldbody></mujoco>";
+        let model = MjModel::from_xml_string(xml).unwrap();
+
+        // No equalities, no tendons, no actuators, no sensors, no cameras, no lights, no textures, no materials
+        assert_eq!(model.ffi().neq, 0);
+        assert_eq!(model.ffi().ntendon, 0);
+        assert_eq!(model.ffi().nu, 0);
+        assert_eq!(model.ffi().nsensor, 0);
+        assert_eq!(model.ffi().ncam, 0);
+        assert_eq!(model.ffi().ntex, 0);
+        assert_eq!(model.ffi().nmat, 0);
+
+        // All force-cast slices should be empty
+        assert!(model.eq_type().is_empty());
+        assert!(model.eq_active0().is_empty());
+        assert!(model.tendon_limited().is_empty());
+        assert!(model.tendon_rgba().is_empty());
+        assert!(model.actuator_trntype().is_empty());
+        assert!(model.actuator_ctrllimited().is_empty());
+        assert!(model.sensor_type().is_empty());
+        assert!(model.cam_mode().is_empty());
+        assert!(model.cam_resolution().is_empty());
+        assert!(model.tex_type().is_empty());
+        assert!(model.mat_texuniform().is_empty());
+        assert!(model.mat_rgba().is_empty());
+
+        // But body/geom/joint arrays should work (always have at least world body)
+        let nbody = model.ffi().nbody as usize;
+        assert!(nbody >= 2);
+        assert_eq!(model.body_pos().len(), nbody);
+        assert_eq!(model.body_sameframe().len(), nbody);
+        assert_eq!(model.jnt_type().len(), model.ffi().njnt as usize);
+        assert_eq!(model.geom_type().len(), model.ffi().ngeom as usize);
+    }
+
+    /// Verifies [force]-cast pair arrays: pair_solref (&[[MjtNum; mjNREF]]),
+    /// pair_friction (&[[MjtNum; 5]]).
+    #[test]
+    fn test_force_cast_pair_model_arrays() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let npair = model.ffi().npair as usize;
+
+        if npair == 0 {
+            return;
+        }
+
+        let pair_solref = model.pair_solref();
+        let pair_friction = model.pair_friction();
+        let pair_solimp = model.pair_solimp();
+
+        assert_eq!(pair_solref.len(), npair);
+        assert_eq!(pair_friction.len(), npair);
+        assert_eq!(pair_solimp.len(), npair);
+
+        let nref = mjNREF as usize;
+        let nimp = mjNIMP as usize;
+
+        for i in 0..npair {
+            for j in 0..nref {
+                assert_eq!(pair_solref[i][j], unsafe { *model.ffi().pair_solref.add(i * nref + j) });
+            }
+            for j in 0..5 {
+                assert_eq!(pair_friction[i][j], unsafe { *model.ffi().pair_friction.add(i * 5 + j) });
+            }
+            for j in 0..nimp {
+                assert_eq!(pair_solimp[i][j], unsafe { *model.ffi().pair_solimp.add(i * nimp + j) });
+            }
+        }
+    }
+
+    /// Verifies [force]-cast non-aliasing: adjacent joints' solver ref slices
+    /// point to different memory.
+    #[test]
+    fn test_force_cast_model_non_aliasing() {
+        let model = MjModel::from_xml_string(EXAMPLE_MODEL).unwrap();
+        let njnt = model.ffi().njnt as usize;
+
+        if njnt < 2 {
+            return;
+        }
+
+        let jnt_solref = model.jnt_solref();
+        let jnt_type = model.jnt_type();
+
+        // Adjacent elements must not alias
+        assert_ne!(jnt_solref[0].as_ptr(), jnt_solref[1].as_ptr());
+        assert_ne!(std::ptr::addr_of!(jnt_type[0]), std::ptr::addr_of!(jnt_type[1]));
+
+        // Pointer stride should be exactly mjNREF elements apart
+        let ptr_diff = unsafe { jnt_solref[1].as_ptr().offset_from(jnt_solref[0].as_ptr()) };
+        assert_eq!(ptr_diff, mjNREF as isize,
+            "jnt_solref stride must be mjNREF={}", mjNREF);
+    }
 }

--- a/src/wrappers/mj_visualization.rs
+++ b/src/wrappers/mj_visualization.rs
@@ -824,4 +824,103 @@ mod tests {
         assert_eq!(fig.pop_front(plot), None);
         assert_eq!(fig.pop_back(plot), None);
     }
+
+    /// Tests `getter_setter!` bool roundtrip for `enabletransform` on MjvScene.
+    #[test]
+    fn test_bool_getter_setter_roundtrip() {
+        let model = load_model();
+        let mut scene = MjvScene::new(&model, 100);
+
+        // Default should be false
+        assert!(!scene.enabletransform());
+
+        scene.set_enabletransform(true);
+        assert!(scene.enabletransform());
+
+        scene.set_enabletransform(false);
+        assert!(!scene.enabletransform());
+    }
+
+    /// Tests `getter_setter! force!` enum roundtrip for stereo (MjtStereo) on MjvScene.
+    #[test]
+    fn test_force_enum_getter_setter_roundtrip() {
+        let model = load_model();
+        let mut scene = MjvScene::new(&model, 100);
+
+        // Default stereo mode
+        let original = scene.stereo();
+        assert_eq!(original, MjtStereo::mjSTEREO_NONE);
+
+        scene.set_stereo(MjtStereo::mjSTEREO_QUADBUFFERED);
+        assert_eq!(scene.stereo(), MjtStereo::mjSTEREO_QUADBUFFERED);
+
+        scene.set_stereo(MjtStereo::mjSTEREO_SIDEBYSIDE);
+        assert_eq!(scene.stereo(), MjtStereo::mjSTEREO_SIDEBYSIDE);
+    }
+
+    /// Tests that `create_geom` returns `SceneFull` when the scene capacity is exhausted.
+    #[test]
+    fn test_scene_full_error() {
+        let model = load_model();
+        let mut scene = MjvScene::new(&model, 2);
+
+        // Fill to capacity
+        scene.create_geom(MjtGeom::mjGEOM_SPHERE, None, None, None, None).unwrap();
+        scene.create_geom(MjtGeom::mjGEOM_SPHERE, None, None, None, None).unwrap();
+
+        // Next should fail
+        let err = scene.create_geom(MjtGeom::mjGEOM_SPHERE, None, None, None, None).unwrap_err();
+        assert!(matches!(err, MjSceneError::SceneFull { capacity: 2 }));
+    }
+
+    /// Tests `set_label` boundary: too-long label returns `LabelTooLong`,
+    /// max-length label succeeds with roundtrip.
+    #[test]
+    fn test_geom_label_boundary() {
+        let model = load_model();
+        let mut scene = MjvScene::new(&model, 10);
+        let geom = scene.create_geom(MjtGeom::mjGEOM_BOX, None, None, None, None).unwrap();
+
+        // Determine capacity (buffer len - 1 for NUL)
+        let capacity = geom.label.len() - 1;
+
+        // Max-length label should succeed
+        let max_label: String = "A".repeat(capacity);
+        geom.set_label(&max_label).unwrap();
+        assert_eq!(geom.label(), max_label);
+
+        // One byte too long should fail
+        let too_long: String = "B".repeat(capacity + 1);
+        let err = geom.set_label(&too_long).unwrap_err();
+        assert!(matches!(err, MjSceneError::LabelTooLong { .. }));
+
+        // Empty label should work
+        geom.set_label("").unwrap();
+        assert_eq!(geom.label(), "");
+    }
+
+    /// Tests `try_push` returns `FigureBufferFull` at capacity,
+    /// and push succeeds after `pop_back` frees a slot.
+    #[test]
+    fn test_figure_try_push_overflow() {
+        let mut fig = MjvFigure::new();
+        let plot = 0;
+        let capacity = fig.linedata[plot].len() / 2;
+
+        // Fill to capacity
+        for i in 0..capacity {
+            fig.try_push(plot, i as f32, i as f32).unwrap();
+        }
+        assert!(fig.full(plot));
+
+        // Next push should fail
+        let err = fig.try_push(plot, 0.0, 0.0).unwrap_err();
+        assert!(matches!(err, MjSceneError::FigureBufferFull { plot_index: 0, .. }));
+
+        // Pop one element, then push should succeed again
+        fig.pop_back(plot);
+        assert!(!fig.full(plot));
+        fig.try_push(plot, 99.0, 99.0).unwrap();
+        assert!(fig.full(plot));
+    }
 }

--- a/tests/force_cast_integration.rs
+++ b/tests/force_cast_integration.rs
@@ -1,0 +1,508 @@
+//! Integration tests for force-cast macro correctness across the public API.
+//! These tests exercise mujoco_rs as an external consumer would, verifying that
+//! force-cast arrays, enum slices, bool slices, view fields, and mutable
+//! roundtrips work correctly through the public interface over multiple timesteps.
+
+use mujoco_rs::prelude::*;
+
+/// A model with diverse joint types, bodies, constraints, actuators, and sensors
+/// for thorough force-cast integration testing.
+const INTEGRATION_MODEL: &str = "
+<mujoco>
+  <option timestep='0.002'/>
+  <worldbody>
+    <geom name='floor' type='plane' size='10 10 1'/>
+
+    <body name='free_body' pos='0 0 3'>
+        <joint name='free_jnt' type='free'/>
+        <geom name='sphere' type='sphere' size='0.2' mass='1' rgba='1 0 0 1'/>
+        <site name='free_site' size='0.05'/>
+    </body>
+
+    <body name='hinge_body' pos='2 0 2'>
+        <joint name='hinge_jnt' type='hinge' axis='0 1 0'/>
+        <geom name='capsule' type='capsule' size='0.1 0.5' mass='0.5'/>
+        <site name='hinge_site' size='0.05'/>
+    </body>
+
+    <body name='slide_body' pos='-2 0 2'>
+        <joint name='slide_jnt' type='slide' axis='0 0 1' range='-5 5' limited='true'/>
+        <geom name='box' type='box' size='0.15 0.15 0.15' mass='0.8'/>
+    </body>
+
+    <body name='mocap_body' mocap='true' pos='5 5 5'>
+        <geom type='sphere' size='0.01' contype='0' conaffinity='0'/>
+    </body>
+  </worldbody>
+
+  <equality>
+      <connect name='eq_connect' body1='hinge_body' body2='slide_body' anchor='0 0 0'/>
+  </equality>
+
+  <actuator>
+      <motor name='slide_motor' joint='slide_jnt' ctrlrange='-10 10' ctrllimited='true'/>
+      <motor name='hinge_motor' joint='hinge_jnt'/>
+  </actuator>
+
+  <sensor>
+      <touch name='touch_sensor' site='free_site'/>
+      <jointpos name='hinge_pos' joint='hinge_jnt'/>
+      <jointvel name='hinge_vel' joint='hinge_jnt'/>
+  </sensor>
+</mujoco>";
+
+/// End-to-end test: load model, step simulation, verify force-cast array
+/// grouping (xpos [MjtNum;3], xquat [MjtNum;4]) produces correct values
+/// across timesteps by cross-referencing flat FFI pointers.
+#[test]
+fn test_integration_multi_step_array_grouping() {
+    let model = MjModel::from_xml_string(INTEGRATION_MODEL).unwrap();
+    let mut data = model.make_data();
+    let nbody = model.ffi().nbody as usize;
+
+    for step in 0..100 {
+        data.step();
+
+        let xpos = data.xpos();
+        let xquat = data.xquat();
+        assert_eq!(xpos.len(), nbody);
+        assert_eq!(xquat.len(), nbody);
+
+        // Spot-check FFI alignment every 10 steps
+        if step % 10 == 0 {
+            for i in 0..nbody {
+                for j in 0..3 {
+                    assert_eq!(xpos[i][j], unsafe { *data.ffi().xpos.add(i * 3 + j) },
+                        "step={} body={} xpos[{}] FFI mismatch", step, i, j);
+                }
+                for j in 0..4 {
+                    assert_eq!(xquat[i][j], unsafe { *data.ffi().xquat.add(i * 4 + j) },
+                        "step={} body={} xquat[{}] FFI mismatch", step, i, j);
+                }
+            }
+        }
+    }
+
+    // After 100 steps (0.2s), bodies should have fallen under gravity
+    let free_body = data.body("free_body").unwrap();
+    let free_z = data.xpos()[free_body.id][2];
+    assert!(free_z < 3.0, "free body should have fallen from z=3, now at z={}", free_z);
+}
+
+/// Integration test: exercise view fields with force-cast enums over
+/// multiple simulation steps. Views must reflect changing data each step.
+#[test]
+fn test_integration_view_enum_fields_across_steps() {
+    let model = MjModel::from_xml_string(INTEGRATION_MODEL).unwrap();
+    let mut data = model.make_data();
+
+    // Model-side view checks (static properties)
+    let free_jnt_info = model.joint("free_jnt").unwrap();
+    let free_jnt_view = free_jnt_info.view(&model);
+    assert_eq!(free_jnt_view.r#type[0], MjtJoint::mjJNT_FREE);
+    assert_eq!(free_jnt_view.limited[0], false);
+
+    let slide_jnt_info = model.joint("slide_jnt").unwrap();
+    let slide_jnt_view = slide_jnt_info.view(&model);
+    assert_eq!(slide_jnt_view.r#type[0], MjtJoint::mjJNT_SLIDE);
+    assert_eq!(slide_jnt_view.limited[0], true);
+
+    let hinge_jnt_info = model.joint("hinge_jnt").unwrap();
+    let hinge_jnt_view = hinge_jnt_info.view(&model);
+    assert_eq!(hinge_jnt_view.r#type[0], MjtJoint::mjJNT_HINGE);
+
+    // Sensor model view
+    let touch_info = model.sensor("touch_sensor").unwrap();
+    let touch_view = touch_info.view(&model);
+    assert_eq!(touch_view.r#type[0], MjtSensor::mjSENS_TOUCH);
+    assert_eq!(touch_view.objtype[0], MjtObj::mjOBJ_SITE);
+
+    // Data-side: step and verify body views update
+    let free_body_info = data.body("free_body").unwrap();
+    data.forward();
+    let init_z = free_body_info.view(&data).xpos[2];
+
+    for _ in 0..50 {
+        data.step();
+    }
+
+    let post_z = free_body_info.view(&data).xpos[2];
+    assert!(post_z < init_z, "body view xpos z should decrease under gravity");
+}
+
+/// Integration test: actuator control via safe API, step, verify force-cast
+/// arrays (ctrl, actuator_force, qfrc_actuator) reflect the controls.
+#[test]
+fn test_integration_actuator_control_multi_step() {
+    let model = MjModel::from_xml_string(INTEGRATION_MODEL).unwrap();
+    let mut data = model.make_data();
+
+    let nu = model.ffi().nu as usize;
+    assert_eq!(nu, 2);
+
+    // Apply control to slide motor (index 0)
+    data.ctrl_mut()[0] = 8.0;
+    data.ctrl_mut()[1] = -3.0;
+
+    for _ in 0..200 {
+        data.step();
+    }
+
+    // ctrl should persist
+    assert_eq!(data.ctrl()[0], 8.0);
+    assert_eq!(data.ctrl()[1], -3.0);
+
+    // actuator_force should be nonzero
+    let act_force = data.actuator_force();
+    assert_eq!(act_force.len(), nu);
+    assert!(act_force[0].abs() > 1e-6, "slide motor force should be nonzero");
+    assert!(act_force[1].abs() > 1e-6, "hinge motor force should be nonzero");
+
+    // qfrc_actuator should have nonzero entries
+    let nv = model.ffi().nv as usize;
+    let qfrc = data.qfrc_actuator();
+    assert_eq!(qfrc.len(), nv);
+    assert!(qfrc.iter().any(|v| v.abs() > 1e-6));
+
+    // FFI cross-validation
+    for i in 0..nu {
+        assert_eq!(act_force[i], unsafe { *data.ffi().actuator_force.add(i) });
+    }
+}
+
+/// Integration test: modify model arrays via force-cast mutable slices,
+/// create new data, and verify the changes affect simulation.
+#[test]
+fn test_integration_model_mutation_affects_simulation() {
+    let mut model = MjModel::from_xml_string(INTEGRATION_MODEL).unwrap();
+
+    // Get sphere geom id
+    let sphere_info = model.geom("sphere").unwrap();
+    let sphere_id = sphere_info.id;
+
+    // Store original mass
+    let orig_mass = model.body_mass()[1]; // free_body
+
+    // Change sphere size and mass via force-cast mutable arrays
+    model.geom_size_mut()[sphere_id] = [1.0, 0.0, 0.0]; // much bigger sphere
+    model.body_mass_mut()[1] = 100.0; // much heavier
+
+    let mut data = model.make_data();
+    for _ in 0..50 {
+        data.step();
+    }
+
+    // The heavier sphere should fall differently
+    // Verify model arrays were mutated correctly
+    assert_eq!(model.geom_size()[sphere_id][0], 1.0);
+    assert_eq!(model.body_mass()[1], 100.0);
+    assert_ne!(model.body_mass()[1], orig_mass);
+
+    // FFI cross-validation
+    assert_eq!(model.body_mass()[1], unsafe { *model.ffi().body_mass.add(1) });
+    assert_eq!(model.geom_size()[sphere_id][0], unsafe { *model.ffi().geom_size.add(sphere_id * 3) });
+}
+
+/// Integration test: exercise equality constraint toggle (eq_active bool force-cast)
+/// across simulation steps, verify dynamics diverge.
+#[test]
+fn test_integration_eq_active_toggle_divergence() {
+    let model = MjModel::from_xml_string(INTEGRATION_MODEL).unwrap();
+
+    // Run 1: with equality constraint active
+    let mut data1 = model.make_data();
+    for _ in 0..100 {
+        data1.step();
+    }
+    let pos_with_eq = data1.xpos().to_vec();
+
+    // Run 2: with equality constraint disabled
+    let mut data2 = model.make_data();
+    data2.eq_active_mut()[0] = false;
+    for _ in 0..100 {
+        data2.step();
+    }
+    let pos_without_eq = data2.xpos().to_vec();
+
+    // Verify eq_active was correctly set
+    assert_eq!(data2.eq_active()[0], false);
+    assert_eq!(unsafe { *data2.ffi().eq_active }, 0u8);
+
+    // Positions should diverge (at least for constrained bodies)
+    let hinge_body = data2.body("hinge_body").unwrap();
+    let slide_body = data2.body("slide_body").unwrap();
+
+    let hinge_diff: f64 = (0..3)
+        .map(|j| (pos_with_eq[hinge_body.id][j] - pos_without_eq[hinge_body.id][j]).abs())
+        .sum();
+    let slide_diff: f64 = (0..3)
+        .map(|j| (pos_with_eq[slide_body.id][j] - pos_without_eq[slide_body.id][j]).abs())
+        .sum();
+
+    assert!(hinge_diff > 1e-10 || slide_diff > 1e-10,
+        "disabling eq constraint should cause divergence: hinge_diff={}, slide_diff={}",
+        hinge_diff, slide_diff);
+}
+
+/// Integration test: sensor data evolves across simulation steps. Verifies
+/// force-cast sensordata flat array tracks the simulation state.
+#[test]
+fn test_integration_sensor_data_multi_step() {
+    let model = MjModel::from_xml_string(INTEGRATION_MODEL).unwrap();
+    let mut data = model.make_data();
+
+    let nsensordata = model.ffi().nsensordata as usize;
+    assert!(nsensordata >= 3, "model has touch(1d) + jointpos(1d) + jointvel(1d) = 3");
+
+    // Apply hinge control to make the joint move
+    data.ctrl_mut()[1] = 5.0;
+
+    let mut prev_sensor: Vec<f64> = vec![0.0; nsensordata];
+
+    for step in 0..100 {
+        data.step();
+
+        let current = data.sensordata();
+        assert_eq!(current.len(), nsensordata);
+
+        // FFI cross-validation
+        for i in 0..nsensordata {
+            assert_eq!(current[i], unsafe { *data.ffi().sensordata.add(i) },
+                "sensordata[{}] FFI mismatch at step {}", i, step);
+        }
+
+        if step > 0 {
+            // At least some sensor values should be changing
+            // (jointvel should be nonzero once the motor acts)
+            let any_changed = (0..nsensordata).any(|i| (current[i] - prev_sensor[i]).abs() > 1e-15);
+            if step > 5 {
+                assert!(any_changed, "sensor data should evolve after step {}", step);
+            }
+        }
+
+        prev_sensor.copy_from_slice(current);
+    }
+}
+
+/// Integration test: save/restore state round-trip, verifying force-cast arrays
+/// match the saved snapshot exactly after restoration.
+#[test]
+fn test_integration_state_save_restore_force_cast() {
+    let model = MjModel::from_xml_string(INTEGRATION_MODEL).unwrap();
+    let mut data = model.make_data();
+
+    // Apply control and simulate
+    data.ctrl_mut()[0] = 3.0;
+    data.ctrl_mut()[1] = -2.0;
+
+    for _ in 0..50 {
+        data.step();
+    }
+    // Synchronize derived quantities with current qpos after integration
+    data.forward();
+
+    // Save full physics state
+    let saved = data.get_state(MjtState::mjSTATE_FULLPHYSICS as u32);
+    let saved_xpos = data.xpos().to_vec();
+    let saved_qpos = data.qpos().to_vec();
+    let saved_qvel = data.qvel().to_vec();
+    let saved_time = data.time();
+
+    // Simulate further (state diverges)
+    for _ in 0..50 {
+        data.step();
+    }
+    assert_ne!(data.xpos().to_vec(), saved_xpos);
+
+    // Restore
+    data.set_state(&saved, MjtState::mjSTATE_FULLPHYSICS as u32);
+    data.forward();
+
+    // Primary state must match exactly
+    assert_eq!(data.qpos().to_vec(), saved_qpos);
+    assert_eq!(data.qvel().to_vec(), saved_qvel);
+    assert!((data.time() - saved_time).abs() < 1e-15);
+
+    // Derived quantities (xpos) should match closely
+    let restored_xpos = data.xpos();
+    for i in 0..saved_xpos.len() {
+        for j in 0..3 {
+            assert!(
+                (restored_xpos[i][j] - saved_xpos[i][j]).abs() < 1e-10,
+                "xpos[{}][{}] mismatch after restore: {} vs {}",
+                i, j, restored_xpos[i][j], saved_xpos[i][j]
+            );
+        }
+    }
+}
+
+/// Integration test: create two separate MjData instances from the same model
+/// with different controls, verify their force-cast arrays diverge independently.
+#[test]
+fn test_integration_independent_data_instances() {
+    let model = MjModel::from_xml_string(INTEGRATION_MODEL).unwrap();
+    let mut data_a = model.make_data();
+    let mut data_b = model.make_data();
+
+    // Different controls
+    data_a.ctrl_mut()[0] = 10.0;
+    data_b.ctrl_mut()[0] = -10.0;
+
+    for _ in 0..100 {
+        data_a.step();
+        data_b.step();
+    }
+
+    let xpos_a = data_a.xpos();
+    let xpos_b = data_b.xpos();
+
+    // The slide bodies should be in different positions
+    let slide_body_a = data_a.body("slide_body").unwrap();
+    let slide_body_b = data_b.body("slide_body").unwrap();
+
+    // Compare xpos of free body (most affected by different controls
+    // through indirect constraint coupling) — any measurable difference suffices
+    let free_body_a = data_a.body("free_body").unwrap();
+    let free_body_b = data_b.body("free_body").unwrap();
+
+    let diff_slide: f64 = (0..3)
+        .map(|j| (xpos_a[slide_body_a.id][j] - xpos_b[slide_body_b.id][j]).abs())
+        .sum();
+    let diff_free: f64 = (0..3)
+        .map(|j| (xpos_a[free_body_a.id][j] - xpos_b[free_body_b.id][j]).abs())
+        .sum();
+    let total_diff = diff_slide + diff_free;
+
+    assert!(total_diff > 1e-6, "different controls should lead to different positions, diff={}", total_diff);
+
+    // Each must still be FFI-consistent
+    for i in 0..xpos_a.len() {
+        for j in 0..3 {
+            assert_eq!(xpos_a[i][j], unsafe { *data_a.ffi().xpos.add(i * 3 + j) });
+            assert_eq!(xpos_b[i][j], unsafe { *data_b.ffi().xpos.add(i * 3 + j) });
+        }
+    }
+}
+
+/// Integration test: mocap mutation mid-simulation via force-cast arrays,
+/// verify it takes effect in subsequent steps.
+#[test]
+fn test_integration_mocap_mid_simulation_mutation() {
+    let model = MjModel::from_xml_string(INTEGRATION_MODEL).unwrap();
+    let mut data = model.make_data();
+
+    let nmocap = model.ffi().nmocap as usize;
+    assert!(nmocap > 0);
+
+    data.forward();
+    assert_eq!(data.mocap_pos()[0], [5.0, 5.0, 5.0]);
+
+    // Step a bit
+    for _ in 0..20 {
+        data.step();
+    }
+
+    // Mutate mocap position
+    data.mocap_pos_mut()[0] = [0.0, 0.0, 0.0];
+    data.mocap_quat_mut()[0] = [0.0, 1.0, 0.0, 0.0]; // 180 deg rotation
+
+    data.forward();
+
+    assert_eq!(data.mocap_pos()[0], [0.0, 0.0, 0.0]);
+    assert_eq!(data.mocap_quat()[0], [0.0, 1.0, 0.0, 0.0]);
+
+    // FFI cross-validation
+    for j in 0..3 {
+        assert_eq!(unsafe { *data.ffi().mocap_pos.add(j) }, [0.0, 0.0, 0.0][j]);
+    }
+    for j in 0..4 {
+        assert_eq!(unsafe { *data.ffi().mocap_quat.add(j) }, [0.0, 1.0, 0.0, 0.0][j]);
+    }
+}
+
+/// Integration test: model-side force-cast enum arrays (jnt_type, geom_type, etc.)
+/// are accessible from integration test context and match expected values.
+#[test]
+fn test_integration_model_enum_slices() {
+    let model = MjModel::from_xml_string(INTEGRATION_MODEL).unwrap();
+
+    // Joint types
+    let jnt_type = model.jnt_type();
+    let free_jnt = model.joint("free_jnt").unwrap();
+    let hinge_jnt = model.joint("hinge_jnt").unwrap();
+    let slide_jnt = model.joint("slide_jnt").unwrap();
+    assert_eq!(jnt_type[free_jnt.id], MjtJoint::mjJNT_FREE);
+    assert_eq!(jnt_type[hinge_jnt.id], MjtJoint::mjJNT_HINGE);
+    assert_eq!(jnt_type[slide_jnt.id], MjtJoint::mjJNT_SLIDE);
+
+    // Geom types
+    let geom_type = model.geom_type();
+    let floor = model.geom("floor").unwrap();
+    let sphere = model.geom("sphere").unwrap();
+    let capsule = model.geom("capsule").unwrap();
+    let box_geom = model.geom("box").unwrap();
+    assert_eq!(geom_type[floor.id], MjtGeom::mjGEOM_PLANE);
+    assert_eq!(geom_type[sphere.id], MjtGeom::mjGEOM_SPHERE);
+    assert_eq!(geom_type[capsule.id], MjtGeom::mjGEOM_CAPSULE);
+    assert_eq!(geom_type[box_geom.id], MjtGeom::mjGEOM_BOX);
+
+    // Joint limited bools
+    let jnt_limited = model.jnt_limited();
+    assert_eq!(jnt_limited[free_jnt.id], false);
+    assert_eq!(jnt_limited[hinge_jnt.id], false);
+    assert_eq!(jnt_limited[slide_jnt.id], true);
+
+    // Sensor types
+    let sensor_type = model.sensor_type();
+    let touch = model.sensor("touch_sensor").unwrap();
+    let jpos = model.sensor("hinge_pos").unwrap();
+    let jvel = model.sensor("hinge_vel").unwrap();
+    assert_eq!(sensor_type[touch.id], MjtSensor::mjSENS_TOUCH);
+    assert_eq!(sensor_type[jpos.id], MjtSensor::mjSENS_JOINTPOS);
+    assert_eq!(sensor_type[jvel.id], MjtSensor::mjSENS_JOINTVEL);
+
+    // Equality type
+    let eq_type = model.eq_type();
+    let eq = model.equality("eq_connect").unwrap();
+    assert_eq!(eq_type[eq.id], MjtEq::mjEQ_CONNECT);
+
+    // Actuator types
+    let act_trntype = model.actuator_trntype();
+    let slide_motor = model.actuator("slide_motor").unwrap();
+    assert_eq!(act_trntype[slide_motor.id], MjtTrn::mjTRN_JOINT);
+    assert_eq!(model.actuator_ctrllimited()[slide_motor.id], true);
+}
+
+/// Integration test: xfrc_applied force-cast mutation, step, and verify
+/// cacc/cfrc_int/cfrc_ext (stride-6 arrays) reflect the applied force.
+#[test]
+fn test_integration_force_applied_cacc_cfrc() {
+    let model = MjModel::from_xml_string(INTEGRATION_MODEL).unwrap();
+    let mut data = model.make_data();
+    let free_body = data.body("free_body").unwrap();
+    let fid = free_body.id;
+
+    // Apply an upward external force
+    data.xfrc_applied_mut()[fid] = [0.0, 0.0, 50.0, 0.0, 0.0, 0.0];
+
+    // xfrc_applied round-trip: verify the mutation stuck
+    let xfrc = data.xfrc_applied();
+    assert!((xfrc[fid][2] - 50.0).abs() < 1e-10, "xfrc_applied z should be 50");
+
+    // Step to evolve the system (cacc/cfrc are populated during step's internal computations)
+    for _ in 0..30 {
+        data.step();
+    }
+
+    // The free body should have risen (50N > mass*g for a 1kg body)
+    let free_z = data.xpos()[fid][2];
+    assert!(free_z > 3.0, "free body should rise above initial z=3 with 50N upward, got z={}", free_z);
+
+    // FFI cross-validation for stride-6 arrays
+    let cfrc_ext = data.cfrc_ext();
+    let cacc = data.cacc();
+    for j in 0..6 {
+        assert_eq!(cfrc_ext[fid][j], unsafe { *data.ffi().cfrc_ext.add(fid * 6 + j) });
+        assert_eq!(cacc[fid][j], unsafe { *data.ffi().cacc.add(fid * 6 + j) });
+    }
+}


### PR DESCRIPTION
Add extra library test and a single integration test. Specifically, these are meant to test the correctness of macro implementations.