### PR TITLE
MjModel GPU-assets re-uploads

### DIFF
--- a/.github/rules/coding-conventions.md
+++ b/.github/rules/coding-conventions.md
@@ -117,6 +117,11 @@
   Other changes. Additional component-specific subsections (e.g. MjViewer) may appear only when a
   component has substantial standalone changes; they are placed between New features and Bug fixes.
   Not all sections are required for every release, but the relative order must be preserved.
+- **Changelog content scope.** Only document public-facing changes in the changelog. Do NOT add
+  entries for private/internal items (private fields, private methods, internal helpers) unless the
+  change is critical to understanding behaviour visible from the public API. Bug fixes should only
+  be documented if they were present in a previously released version; do not document fixes for
+  bugs that were introduced and fixed within the same (unreleased) development cycle.
 - **Migration guide entry format.** Each breaking change in `migration.rst` gets: a descriptive
   heading (RST `~` underline), a prose explanation, then **Before** and **After** code blocks using
   `.. code-block:: rust`. For simple type changes, use a `.. list-table::` with columns for

--- a/.github/rules/coding-conventions.md
+++ b/.github/rules/coding-conventions.md
@@ -146,6 +146,19 @@
   where `v` and `x` are literal/fixed. Use these when diffing against previous releases
   (e.g. `git diff 2.3.5 HEAD`).
 
+## Examples
+- Every example in `examples/` must be registered in `Cargo.toml` with `[[example]]` and
+  `required-features` if it uses optional features (e.g. `viewer`).
+- Examples are user-facing demos. `use mujoco_rs::prelude::*` is the conventional import
+  pattern; do NOT flag it as a violation of the "avoid crate::prelude" rule.
+- Use `.unwrap()` (not `.expect("msg")`) for failures that are obvious from the function name.
+- Use `/* */` block comments for top-level section headers inside function bodies (matches the
+  established style in all other examples).
+- Only add comments that clarify non-obvious intent. Do not comment self-explanatory builder
+  chains or single-expression statements.
+- New examples should be documented in the changelog under a `.. rubric:: New examples` section,
+  referencing the file with `:gh-example:\`Display name <filename.rs>\``.
+
 ## Testing
 - When adding a new feature or fixing a bug, add a test for it if one does not already exist.
 - Tests must be **correctness tests** (verify behaviour is right), not build tests (verify it compiles).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,10 @@ name = "tendon"
 required-features = ["viewer"]
 
 [[example]]
+name = "asset_reupload"
+required-features = ["viewer"]
+
+[[example]]
 name = "terrain_generation"
 required-features = ["viewer"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,10 @@ name = "tippe_top"
 required-features = ["viewer"]
 
 [[example]]
+name = "renderer_asset_reupload"
+required-features = ["renderer"]
+
+[[example]]
 name = "touch_sensor"
 required-features = ["viewer"]
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -26,9 +26,9 @@ update of MuJoCo alone can increase the major version.
 
 .. Template titles
   .. rubric:: Breaking changes
+  .. rubric:: Error handling
   .. rubric:: New features and improvements
   .. rubric:: Bug fixes
-  .. rubric:: Error handling
   .. rubric:: Other changes
 
 Unreleased

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -55,25 +55,48 @@ Unreleased
   previously returned ``Result<(), MjSceneError>`` (with ``MjSceneError::InvalidAuxBufferIndex``);
   they now return ``Result<(), MjrContextError>`` (with ``MjrContextError::IndexOutOfBounds``).
 
-*MjSceneError::InvalidAuxBufferIndex removed*
+*MjSceneError::InvalidAuxBufferIndex / InvalidViewport / BufferTooSmall removed*
 
-- ``MjSceneError::InvalidAuxBufferIndex`` has been removed from
-  :docs-rs:`~mujoco_rs::error::<enum>MjSceneError`. Code matching on this variant will fail
-  to compile. Replace it with ``MjrContextError::IndexOutOfBounds`` (see migration guide).
+- ``MjSceneError::InvalidAuxBufferIndex``, ``MjSceneError::InvalidViewport``, and
+  ``MjSceneError::BufferTooSmall`` have been removed from
+  :docs-rs:`~mujoco_rs::error::<enum>MjSceneError`. Code matching on these variants will fail
+  to compile. Replace them with the corresponding
+  :docs-rs:`~mujoco_rs::error::<enum>MjrContextError` variants (see migration guide).
+
+*MjrContext::read_pixels error type changed*
+
+- :docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>read_pixels`
+  previously returned ``Result<…, MjSceneError>`` (with ``MjSceneError::InvalidViewport`` and
+  ``MjSceneError::BufferTooSmall``); it now returns ``Result<…, MjrContextError>`` (with
+  ``MjrContextError::InvalidViewport`` and ``MjrContextError::BufferTooSmall``).
+
+*MjModelError::InvalidIndex removed*
+
+- ``MjModelError::InvalidIndex(usize, usize)`` has been removed from
+  :docs-rs:`~mujoco_rs::error::<enum>MjModelError`. Code matching on this variant will fail
+  to compile. Replace it with
+  :docs-rs:`~mujoco_rs::error::<enum>MjModelError::<variant>IndexOutOfBounds`
+  (see migration guide).
 
 .. rubric:: Error handling
 
 New error types:
 
 - :docs-rs:`~mujoco_rs::error::<enum>MjrContextError`: new error enum for
-  :docs-rs:`~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext` operations, with
-  ``IndexOutOfBounds { id, len }`` (an index passed to a rendering-context operation is out of
-  range — covers GPU asset uploads and aux buffer index checks).
+  :docs-rs:`~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext` operations, with variants:
+
+  - ``IndexOutOfBounds { id, len }`` — an index passed to a rendering-context operation is out of
+    range (covers GPU asset uploads and aux buffer index checks).
+  - ``InvalidViewport { width, height }`` — the viewport dimensions are invalid for pixel read-back.
+  - ``BufferTooSmall { name, got, needed }`` — the caller-supplied buffer is too small to hold the
+    read-back data.
 
 New error variants in pre-existing enums:
 
 - :docs-rs:`~mujoco_rs::viewer::<enum>MjViewerError`: ``SignatureMismatch`` (model structure does
-  not match the viewer's passive model), ``IndexOutOfBounds { id, len }`` (asset ID out of range).
+  not match the viewer's passive model), ``IndexOutOfBounds { id, len }`` (asset ID out of range),
+  ``ContextError(MjrContextError)`` (wraps a rendering-context error, e.g. from pixel read-back
+  during screenshot capture).
 - :docs-rs:`~mujoco_rs::renderer::<enum>RendererError`: ``SignatureMismatch`` (model structure does
   not match the renderer's current scene), ``ContextError(MjrContextError)`` (wraps a rendering-context error,
   e.g. an out-of-range asset ID).
@@ -199,7 +222,7 @@ runtime.
 
 - Added a new variant for handling invalid indices in
   :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>try_max_contacts`:
-  :docs-rs:`~~mujoco_rs::error::<enum>MjModelError::<variant>InvalidIndex`.
+  ``MjModelError::InvalidIndex``.
 
 .. rubric:: New features and improvements
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -69,11 +69,12 @@ runtime, mirroring the behaviour of MuJoCo's C++ Simulate viewer.
   :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_textures_from`,
   :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_meshes_from`, and
   :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_hfields_from`.
-  The pending-flag accessors
-  :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>texture_reupload_pending`,
-  :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>mesh_reupload_pending`, and
-  :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>hfield_reupload_pending`
-  can be polled to check whether the render thread has processed the upload.
+
+.. rubric:: New examples
+
+- :gh-example:`Asset re-upload <asset_reupload.rs>` --- demonstrates animated heightfield,
+  texture, and mesh GPU re-uploads with active physics: a ball falls onto a rippling terrain
+  and bounces within a smooth-step wall. Physics and rendering run on separate threads.
 
 .. rubric:: Bug fixes
 .. rubric:: Error handling

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -41,6 +41,8 @@ Unreleased
 - :docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>upload_texture`
   now accepts ``texture_id: usize`` instead of ``texid: u32``.
 
+.. rubric:: Error handling
+
 .. rubric:: New features and improvements
 
 *MjrContext GPU re-upload methods*
@@ -59,16 +61,16 @@ Unreleased
 The Rust viewer now supports re-uploading textures, meshes, and heightfields to the GPU at
 runtime, mirroring the behaviour of MuJoCo's C++ Simulate viewer.
 
-- :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer::<method>update_textures_from`,
-  :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer::<method>update_meshes_from`, and
-  :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer::<method>update_hfields_from` copy the
+- :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_textures_from`,
+  :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_meshes_from`, and
+  :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_hfields_from` copy the
   corresponding asset data from an external model into the viewer's passive model and
-  schedule a GPU upload for the next :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer::<method>render`
+  schedule a GPU upload for the next :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>render`
   call. The upload is complete when ``render()`` returns.
 - For multi-threaded programs the same methods are available on the shared-state guard:
-  :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_textures_from`,
-  :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_meshes_from`, and
-  :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_hfields_from`.
+  :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_textures_from`,
+  :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_meshes_from`, and
+  :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_hfields_from`.
 
 .. rubric:: New examples
 
@@ -77,7 +79,6 @@ runtime, mirroring the behaviour of MuJoCo's C++ Simulate viewer.
   and bounces within a smooth-step wall. Physics and rendering run on separate threads.
 
 .. rubric:: Bug fixes
-.. rubric:: Error handling
 .. rubric:: Other changes
 
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -35,7 +35,31 @@ Unreleased
 ======================
 
 .. rubric:: Breaking changes
+
+*MjrContext::upload_texture parameter type changed*
+
+- :docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>upload_texture`
+  now accepts ``texture_id: usize`` instead of ``texid: u32``.
+
 .. rubric:: New features and improvements
+
+*MjrContext GPU re-upload methods*
+
+- :docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>upload_texture`
+  now takes ``&self`` instead of ``&mut self``, relaxing the mutability requirement.
+- |mjr_context| now provides two additional GPU asset re-upload methods:
+
+  - :docs-rs:`~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>upload_mesh`
+    re-uploads a mesh to the GPU by mesh ID.
+  - :docs-rs:`~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>upload_hfield`
+    re-uploads a height field to the GPU by height-field ID.
+
+*ViewerSharedState height-field update*
+
+- :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_hfields`
+  copies height-field data from an external model to the viewer's internal passive model
+  and triggers a GPU re-upload.
+
 .. rubric:: Bug fixes
 .. rubric:: Error handling
 .. rubric:: Other changes

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -61,16 +61,36 @@ Unreleased
 The Rust viewer now supports re-uploading textures, meshes, and heightfields to the GPU at
 runtime, mirroring the behaviour of MuJoCo's C++ Simulate viewer.
 
-- :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_textures_from`,
+- The singular methods :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_texture_from`,
+  :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_mesh_from`, and
+  :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_hfield_from` copy and mark one
+  asset at a time.
+- The plural methods :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_textures_from`,
   :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_meshes_from`, and
-  :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_hfields_from` copy the
-  corresponding asset data from an external model into the viewer's passive model and
-  schedule a GPU upload for the next :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>render`
-  call. The upload is complete when ``render()`` returns.
-- For multi-threaded programs the same methods are available on the shared-state guard:
+  :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_hfields_from` copy and mark all
+  assets of that type.
+- For multi-threaded programs the same singular and plural methods are available on the
+  shared-state guard:
+  :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_texture_from`,
+  :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_mesh_from`,
+  :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_hfield_from`,
   :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_textures_from`,
   :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_meshes_from`, and
   :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_hfields_from`.
+
+*Renderer GPU asset re-upload*
+
+The Rust renderer now supports re-uploading textures, meshes, and heightfields to the GPU at
+runtime.
+
+- The singular methods :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_texture_from`,
+  :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_mesh_from`, and
+  :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_hfield_from` upload one
+  asset immediately.
+- The plural methods :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_textures_from`,
+  :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_meshes_from`, and
+  :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_hfields_from` upload all
+  assets of that type immediately.
 
 .. rubric:: New examples
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -54,11 +54,26 @@ Unreleased
   - :docs-rs:`~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>upload_hfield`
     re-uploads a height field to the GPU by height-field ID.
 
-*ViewerSharedState height-field update*
+*Viewer GPU asset re-upload*
 
-- :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_hfields`
-  copies height-field data from an external model to the viewer's internal passive model
-  and triggers a GPU re-upload.
+The Rust viewer now supports re-uploading textures, meshes, and heightfields to the GPU at
+runtime, mirroring the behaviour of MuJoCo's C++ Simulate viewer.
+
+- :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer::<method>update_textures_from`,
+  :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer::<method>update_meshes_from`, and
+  :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer::<method>update_hfields_from` copy the
+  corresponding asset data from an external model into the viewer's passive model and
+  schedule a GPU upload for the next :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer::<method>render`
+  call. The upload is complete when ``render()`` returns.
+- For multi-threaded programs the same methods are available on the shared-state guard:
+  :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_textures_from`,
+  :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_meshes_from`, and
+  :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_hfields_from`.
+  The pending-flag accessors
+  :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>texture_reupload_pending`,
+  :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>mesh_reupload_pending`, and
+  :docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState::<method>hfield_reupload_pending`
+  can be polled to check whether the render thread has processed the upload.
 
 .. rubric:: Bug fixes
 .. rubric:: Error handling

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -41,14 +41,42 @@ Unreleased
 - :docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>upload_texture`
   now accepts ``texture_id: usize`` instead of ``texid: u32``.
 
+*MjrContext::upload_texture is now fallible*
+
+- :docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>upload_texture`
+  now returns ``Result<(), MjrContextError>`` instead of ``()`` and no longer panics.
+  Pass an out-of-range ID to receive ``MjrContextError::IndexOutOfBounds { id, len }``
+  instead of a panic.
+
+*MjrContext::add_aux / set_aux error type changed*
+
+- :docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>add_aux` and
+  :docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>set_aux`
+  previously returned ``Result<(), MjSceneError>`` (with ``MjSceneError::InvalidAuxBufferIndex``);
+  they now return ``Result<(), MjrContextError>`` (with ``MjrContextError::IndexOutOfBounds``).
+
+*MjSceneError::InvalidAuxBufferIndex removed*
+
+- ``MjSceneError::InvalidAuxBufferIndex`` has been removed from
+  :docs-rs:`~mujoco_rs::error::<enum>MjSceneError`. Code matching on this variant will fail
+  to compile. Replace it with ``MjrContextError::IndexOutOfBounds`` (see migration guide).
+
 .. rubric:: Error handling
+
+New error types:
+
+- :docs-rs:`~mujoco_rs::error::<enum>MjrContextError`: new error enum for
+  :docs-rs:`~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext` operations, with
+  ``IndexOutOfBounds { id, len }`` (an index passed to a rendering-context operation is out of
+  range — covers GPU asset uploads and aux buffer index checks).
 
 New error variants in pre-existing enums:
 
 - :docs-rs:`~mujoco_rs::viewer::<enum>MjViewerError`: ``SignatureMismatch`` (model structure does
   not match the viewer's passive model), ``IndexOutOfBounds { id, len }`` (asset ID out of range).
 - :docs-rs:`~mujoco_rs::renderer::<enum>RendererError`: ``SignatureMismatch`` (model structure does
-  not match the renderer's current scene), ``IndexOutOfBounds { id, len }`` (asset ID out of range).
+  not match the renderer's current scene), ``ContextError(MjrContextError)`` (wraps a rendering-context error,
+  e.g. an out-of-range asset ID).
 
 .. rubric:: New features and improvements
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -24,6 +24,24 @@ This means that any incompatible changes increase the major version (**X**.y.z).
 This also includes breaking changes that MuJoCo itself introduced, thus even an
 update of MuJoCo alone can increase the major version.
 
+.. Template titles
+  .. rubric:: Breaking changes
+  .. rubric:: New features and improvements
+  .. rubric:: Bug fixes
+  .. rubric:: Error handling
+  .. rubric:: Other changes
+
+Unreleased
+======================
+
+.. rubric:: Breaking changes
+.. rubric:: New features and improvements
+.. rubric:: Bug fixes
+.. rubric:: Error handling
+.. rubric:: Other changes
+
+
+
 4.0.1 (MuJoCo 3.8.0)
 ======================
 .. rubric:: Bug fixes

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -43,6 +43,13 @@ Unreleased
 
 .. rubric:: Error handling
 
+New error variants in pre-existing enums:
+
+- :docs-rs:`~mujoco_rs::viewer::<enum>MjViewerError`: ``SignatureMismatch`` (model structure does
+  not match the viewer's passive model), ``IndexOutOfBounds { id, len }`` (asset ID out of range).
+- :docs-rs:`~mujoco_rs::renderer::<enum>RendererError`: ``SignatureMismatch`` (model structure does
+  not match the renderer's current scene), ``IndexOutOfBounds { id, len }`` (asset ID out of range).
+
 .. rubric:: New features and improvements
 
 *MjrContext GPU re-upload methods*
@@ -64,11 +71,11 @@ runtime, mirroring the behaviour of MuJoCo's C++ Simulate viewer.
 - The singular methods :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_texture_from`,
   :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_mesh_from`, and
   :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_hfield_from` copy and mark one
-  asset at a time.
+  asset at a time. All methods return ``Result<(), MjViewerError>``.
 - The plural methods :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_textures_from`,
   :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_meshes_from`, and
   :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_hfields_from` copy and mark all
-  assets of that type.
+  assets of that type. All methods return ``Result<(), MjViewerError>``.
 - For multi-threaded programs the same singular and plural methods are available on the
   shared-state guard:
   :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>update_texture_from`,
@@ -86,17 +93,20 @@ runtime.
 - The singular methods :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_texture_from`,
   :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_mesh_from`, and
   :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_hfield_from` upload one
-  asset immediately.
+  asset immediately. All methods return ``Result<(), RendererError>``.
 - The plural methods :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_textures_from`,
   :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_meshes_from`, and
   :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_hfields_from` upload all
-  assets of that type immediately.
+  assets of that type immediately. All methods return ``Result<(), RendererError>``.
 
 .. rubric:: New examples
 
 - :gh-example:`Asset re-upload <asset_reupload.rs>` --- demonstrates animated heightfield,
   texture, and mesh GPU re-uploads with active physics: a ball falls onto a rippling terrain
   and bounces within a smooth-step wall. Physics and rendering run on separate threads.
+- :gh-example:`Renderer asset re-upload <renderer_asset_reupload.rs>` --- demonstrates the
+  same animated assets using the offscreen renderer: heightfield, texture, and mesh are
+  mutated each frame and immediately re-uploaded before rendering to PNG frames.
 
 .. rubric:: Bug fixes
 .. rubric:: Other changes

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -92,6 +92,61 @@ The ``MjSceneError::InvalidAuxBufferIndex`` variant has been removed; use
     }
 
 
+``MjrContext::read_pixels`` error type changed
+-----------------------------------------------
+
+:docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>read_pixels`
+now returns ``Result<…, MjrContextError>`` instead of ``Result<…, MjSceneError>``.
+``MjSceneError::InvalidViewport`` and ``MjSceneError::BufferTooSmall`` have been removed;
+use ``MjrContextError::InvalidViewport`` and ``MjrContextError::BufferTooSmall`` instead.
+
+**Before (4.x):**
+
+.. code-block:: rust
+
+    match context.read_pixels(&mut buf, false, &viewport) {
+        Err(MjSceneError::InvalidViewport { .. }) => { /* … */ }
+        Err(MjSceneError::BufferTooSmall { .. }) => { /* … */ }
+        Ok(()) => { /* … */ }
+    }
+
+**After:**
+
+.. code-block:: rust
+
+    match context.read_pixels(&mut buf, false, &viewport) {
+        Err(MjrContextError::InvalidViewport { .. }) => { /* … */ }
+        Err(MjrContextError::BufferTooSmall { .. }) => { /* … */ }
+        Ok(()) => { /* … */ }
+    }
+
+
+``MjModelError::InvalidIndex`` removed
+---------------------------------------
+
+``MjModelError::InvalidIndex(usize, usize)`` has been removed. Use
+:docs-rs:`~mujoco_rs::error::<enum>MjModelError::<variant>IndexOutOfBounds`
+with named fields instead.
+
+**Before (4.x):**
+
+.. code-block:: rust
+
+    match model.try_max_contacts(geom1, geom2, None) {
+        Err(MjModelError::InvalidIndex(id, len)) => { /* … */ }
+        Ok(count) => { /* … */ }
+    }
+
+**After:**
+
+.. code-block:: rust
+
+    match model.try_max_contacts(geom1, geom2, None) {
+        Err(MjModelError::IndexOutOfBounds { id, len }) => { /* … */ }
+        Ok(count) => { /* … */ }
+    }
+
+
 .. _migrate_4_0_0:
 
 Migrating to 4.0.0

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -44,6 +44,54 @@ convert the argument accordingly.
     context.upload_texture(&model, 0usize);
 
 
+``MjrContext::upload_texture`` returns ``Result``
+-------------------------------------------------
+
+:docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>upload_texture`
+now returns ``Result<(), MjrContextError>`` instead of ``()``.
+Handle or propagate the result at each call site.
+
+**Before (4.x):**
+
+.. code-block:: rust
+
+    context.upload_texture(&model, id);
+
+**After:**
+
+.. code-block:: rust
+
+    context.upload_texture(&model, id)?;
+
+
+``MjrContext::add_aux`` / ``set_aux`` error type changed
+---------------------------------------------------------
+
+:docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>add_aux` and
+:docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>set_aux`
+now return ``Result<(), MjrContextError>`` instead of ``Result<(), MjSceneError>``.
+The ``MjSceneError::InvalidAuxBufferIndex`` variant has been removed; use
+``MjrContextError::IndexOutOfBounds`` instead.
+
+**Before (4.x):**
+
+.. code-block:: rust
+
+    match context.add_aux(index, width, height, samples) {
+        Err(MjSceneError::InvalidAuxBufferIndex { index }) => { /* … */ }
+        Ok(()) => { /* … */ }
+    }
+
+**After:**
+
+.. code-block:: rust
+
+    match context.add_aux(index, width, height, samples) {
+        Err(MjrContextError::IndexOutOfBounds { id, len }) => { /* … */ }
+        Ok(()) => { /* … */ }
+    }
+
+
 .. _migrate_4_0_0:
 
 Migrating to 4.0.0

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -19,6 +19,31 @@ This page documents the migration steps for upgrading between major versions of 
 For a full list of changes, see the :ref:`changelog`.
 
 
+.. _migrate_unreleased:
+
+Unreleased
+======================
+
+``MjrContext::upload_texture`` parameter type changed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>upload_texture`
+now accepts ``texture_id: usize`` instead of ``texid: u32``. Update call sites to cast or
+convert the argument accordingly.
+
+**Before (4.x):**
+
+.. code-block:: rust
+
+    context.upload_texture(&model, 0u32);
+
+**After:**
+
+.. code-block:: rust
+
+    context.upload_texture(&model, 0usize);
+
+
 .. _migrate_4_0_0:
 
 Migrating to 4.0.0

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -104,7 +104,7 @@ use ``MjrContextError::InvalidViewport`` and ``MjrContextError::BufferTooSmall``
 
 .. code-block:: rust
 
-    match context.read_pixels(&mut buf, false, &viewport) {
+    match context.read_pixels(Some(&mut rgb_buf), None, &viewport) {
         Err(MjSceneError::InvalidViewport { .. }) => { /* … */ }
         Err(MjSceneError::BufferTooSmall { .. }) => { /* … */ }
         Ok(()) => { /* … */ }
@@ -114,7 +114,7 @@ use ``MjrContextError::InvalidViewport`` and ``MjrContextError::BufferTooSmall``
 
 .. code-block:: rust
 
-    match context.read_pixels(&mut buf, false, &viewport) {
+    match context.read_pixels(Some(&mut rgb_buf), None, &viewport) {
         Err(MjrContextError::InvalidViewport { .. }) => { /* … */ }
         Err(MjrContextError::BufferTooSmall { .. }) => { /* … */ }
         Ok(()) => { /* … */ }

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -25,7 +25,7 @@ Unreleased
 ======================
 
 ``MjrContext::upload_texture`` parameter type changed
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------
 
 :docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>upload_texture`
 now accepts ``texture_id: usize`` instead of ``texid: u32``. Update call sites to cast or

--- a/docs/guide/source/programming/visualization/renderer.rst
+++ b/docs/guide/source/programming/visualization/renderer.rst
@@ -203,7 +203,7 @@ cannot be made current.
     model.tex_data_mut()[..256].fill(128);
     renderer.update_texture_from(&model, 0).unwrap();
 
-    /* Or re-upload all textures at once (single bulk copy) */
+    /* Or re-upload all textures at once (loops over each texture) */
     renderer.update_textures_from(&model).unwrap();
 
     renderer.sync_data(&mut data).unwrap();

--- a/docs/guide/source/programming/visualization/renderer.rst
+++ b/docs/guide/source/programming/visualization/renderer.rst
@@ -186,9 +186,16 @@ the GPU copies held by the renderer must be refreshed explicitly.
   The plural methods perform one contiguous memory copy and are more efficient when the
   majority of assets of a given type are modified.
 
-Unlike the viewer, the renderer uploads asset data **immediately** -- there is no staging or
+Unlike the viewer, the renderer uploads asset data **immediately** --- there is no staging or
 dirty-flag mechanism. The upload takes effect before the next call to
 :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>render`.
+All methods return ``Result<(), RendererError>`` ---
+:docs-rs:`~~mujoco_rs::renderer::<enum>RendererError::<variant>SignatureMismatch` is returned
+when the model signature does not match the renderer's current scene,
+:docs-rs:`~~mujoco_rs::renderer::<enum>RendererError::<variant>IndexOutOfBounds` when the asset
+ID is out of range (singular methods only), and
+:docs-rs:`~~mujoco_rs::renderer::<enum>RendererError::<variant>GlutinError` if the OpenGL context
+cannot be made current.
 
 .. code-block:: rust
 

--- a/docs/guide/source/programming/visualization/renderer.rst
+++ b/docs/guide/source/programming/visualization/renderer.rst
@@ -179,12 +179,12 @@ the GPU copies held by the renderer must be refreshed explicitly.
   These copy only the data for the specified asset ID and are efficient when only a small
   number of assets change per frame.
 
-- **Plural** -- upload all assets of a type in a single bulk array copy:
+- **Plural** -- upload all assets of a type by iterating over every index:
   :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_textures_from`,
   :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_meshes_from`,
   :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_hfields_from`.
-  The plural methods perform one contiguous memory copy and are more efficient when the
-  majority of assets of a given type are modified.
+  The plural methods are more convenient when the majority of assets of a given type
+  are modified, avoiding repeated signature and context checks.
 
 Unlike the viewer, the renderer uploads asset data **immediately** --- there is no staging or
 dirty-flag mechanism. The upload takes effect before the next call to
@@ -192,7 +192,7 @@ dirty-flag mechanism. The upload takes effect before the next call to
 All methods return ``Result<(), RendererError>`` ---
 :docs-rs:`~~mujoco_rs::renderer::<enum>RendererError::<variant>SignatureMismatch` is returned
 when the model signature does not match the renderer's current scene,
-:docs-rs:`~~mujoco_rs::renderer::<enum>RendererError::<variant>IndexOutOfBounds` when the asset
+:docs-rs:`~~mujoco_rs::renderer::<enum>RendererError::<variant>ContextError` when the asset
 ID is out of range (singular methods only), and
 :docs-rs:`~~mujoco_rs::renderer::<enum>RendererError::<variant>GlutinError` if the OpenGL context
 cannot be made current.

--- a/docs/guide/source/programming/visualization/renderer.rst
+++ b/docs/guide/source/programming/visualization/renderer.rst
@@ -160,3 +160,44 @@ and saves both an RGB and a depth image:
         renderer.save_rgb("frame.png").expect("failed to save RGB");
         renderer.save_depth("depth.png", true).expect("failed to save depth");  // true = normalize to 0-65535 range.
     }
+
+
+.. _renderer_asset_reupload:
+
+Asset re-upload
+---------------
+
+When textures, meshes, or heightfields in the simulation model are mutated at runtime,
+the GPU copies held by the renderer must be refreshed explicitly.
+
+:docs-rs:`~mujoco_rs::renderer::<struct>MjRenderer` exposes two sets of methods for this:
+
+- **Singular** -- upload one asset by its zero-based index:
+  :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_texture_from`,
+  :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_mesh_from`,
+  :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_hfield_from`.
+  These copy only the data for the specified asset ID and are efficient when only a small
+  number of assets change per frame.
+
+- **Plural** -- upload all assets of a type in a single bulk array copy:
+  :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_textures_from`,
+  :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_meshes_from`,
+  :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>update_hfields_from`.
+  The plural methods perform one contiguous memory copy and are more efficient when the
+  majority of assets of a given type are modified.
+
+Unlike the viewer, the renderer uploads asset data **immediately** -- there is no staging or
+dirty-flag mechanism. The upload takes effect before the next call to
+:docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>render`.
+
+.. code-block:: rust
+
+    /* Mutate texture 0 in the model, then re-upload just that texture */
+    model.tex_data_mut()[..256].fill(128);
+    renderer.update_texture_from(&model, 0).unwrap();
+
+    /* Or re-upload all textures at once (single bulk copy) */
+    renderer.update_textures_from(&model).unwrap();
+
+    renderer.sync_data(&mut data).unwrap();
+    renderer.render().unwrap();

--- a/docs/guide/source/programming/visualization/viewer.rst
+++ b/docs/guide/source/programming/visualization/viewer.rst
@@ -108,6 +108,7 @@ and mirrors/syncs the simulation state with :docs-rs:`~~mujoco_rs::viewer::<stru
 After synchronization, or in parallel with it, the viewer must also be rendered using the
 :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>render` method.
 
+
 .. code-block:: rust
 
     ...
@@ -363,6 +364,68 @@ and :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>sync_model
     }).unwrap();
 
 This requires the ``M`` bound inside |mj_data| to be ``DerefMut<Target = MjModel>`` (e.g., ``Box<MjModel>``).
+
+
+.. _viewer_asset_reupload:
+
+Asset re-upload
+---------------------------------
+
+When textures, meshes, or heightfields in the simulation model are mutated at runtime,
+the GPU copies held by the viewer must be refreshed explicitly.
+
+Both :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer` and
+:docs-rs:`~mujoco_rs::viewer::<struct>ViewerSharedState` expose two sets of methods for this:
+
+- **Singular** -- upload one asset by its zero-based index:
+  :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_texture_from`,
+  :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_mesh_from`,
+  :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_hfield_from`.
+  These copy only the data for the specified asset ID and are efficient when only a small
+  number of assets change per frame.
+
+- **Plural** -- upload all assets of a type in a single bulk array copy:
+  :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_textures_from`,
+  :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_meshes_from`,
+  :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_hfields_from`.
+  The plural methods perform one contiguous memory copy and are more efficient when the
+  majority of assets of a given type are modified.
+
+Both call paths require ``model.signature()`` to match the viewer's internal passive model.
+If the model has been replaced or reloaded, call
+:docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>sync_model` or
+:docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>sync_data` first to bring the viewer's
+passive copy up to date before issuing any asset re-upload.
+
+The viewer **stages** the upload and applies it on the next call to
+:docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>render`.
+
+.. code-block:: rust
+
+    use mujoco_rs::viewer::MjViewer;
+    use mujoco_rs::prelude::*;
+
+    fn main() {
+        let mut model = MjModel::from_xml("path/to/model.xml").expect("could not load the model");
+        let mut data = MjData::new(&model);
+        let mut viewer = MjViewer::launch_passive(&model, 0).expect("could not launch the viewer");
+
+        while viewer.running() {
+            viewer.sync_data(&mut data);
+
+            /* Mutate texture 0 in the model, then re-upload just that texture */
+            model.tex_data_mut()[..256].fill(128);
+            viewer.update_texture_from(&model, 0).unwrap();
+
+            /* Or re-upload all textures at once (single bulk copy) */
+            viewer.update_textures_from(&model).unwrap();
+
+            /* Staged uploads are applied during render() */
+            viewer.render().unwrap();
+            data.step();
+        }
+    }
+
 
 .. _mj_cpp_viewer:
 

--- a/docs/guide/source/programming/visualization/viewer.rst
+++ b/docs/guide/source/programming/visualization/viewer.rst
@@ -384,12 +384,15 @@ Both :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer` and
   These copy only the data for the specified asset ID and are efficient when only a small
   number of assets change per frame.
 
-- **Plural** -- upload all assets of a type in a single bulk array copy:
+- **Plural** -- upload all assets of a type in bulk:
   :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_textures_from`,
   :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_meshes_from`,
   :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>update_hfields_from`.
-  The plural methods perform one contiguous memory copy and are more efficient when the
-  majority of assets of a given type are modified.
+  The plural methods copy entire asset arrays (skipping per-asset offset calculations)
+  and are more efficient when the majority of assets of a given type are modified.
+  Note that mesh uploads copy multiple arrays (vertex positions, per-vertex normals,
+  UV texture coordinates, face-vertex indices, face-normal indices, face-texcoord indices,
+  and convex hull graph data), so ``update_meshes_from`` issues several array copies.
 
 Both call paths require ``model.signature()`` to match the viewer's internal passive model
 and return ``Result<(), MjViewerError>`` ---
@@ -411,19 +414,21 @@ The viewer **stages** the upload and applies it on the next call to
     use mujoco_rs::prelude::*;
 
     fn main() {
-        let mut model = MjModel::from_xml("path/to/model.xml").expect("could not load the model");
-        let mut data = MjData::new(&model);
-        let mut viewer = MjViewer::launch_passive(&model, 0).expect("could not launch the viewer");
+        // Box the model so MjData takes ownership; the viewer makes its own internal copy.
+        let model = Box::new(MjModel::from_xml("path/to/model.xml").expect("could not load the model"));
+        let mut data = MjData::new(model);
+        let mut viewer = MjViewer::launch_passive(data.model(), 0).expect("could not launch the viewer");
 
         while viewer.running() {
             viewer.sync_data(&mut data);
 
             /* Mutate texture 0 in the model, then re-upload just that texture */
-            model.tex_data_mut()[..256].fill(128);
-            viewer.update_texture_from(&model, 0).unwrap();
+            // SAFETY: only non-structural asset arrays (tex_data) are modified.
+            unsafe { data.model_mut() }.tex_data_mut()[..256].fill(128);
+            viewer.update_texture_from(data.model(), 0).unwrap();
 
-            /* Or re-upload all textures at once (single bulk copy) */
-            viewer.update_textures_from(&model).unwrap();
+            /* Or re-upload all textures at once */
+            viewer.update_textures_from(data.model()).unwrap();
 
             /* Staged uploads are applied during render() */
             viewer.render().unwrap();

--- a/docs/guide/source/programming/visualization/viewer.rst
+++ b/docs/guide/source/programming/visualization/viewer.rst
@@ -391,7 +391,12 @@ Both :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer` and
   The plural methods perform one contiguous memory copy and are more efficient when the
   majority of assets of a given type are modified.
 
-Both call paths require ``model.signature()`` to match the viewer's internal passive model.
+Both call paths require ``model.signature()`` to match the viewer's internal passive model
+and return ``Result<(), MjViewerError>`` ---
+:docs-rs:`~~mujoco_rs::viewer::<enum>MjViewerError::<variant>SignatureMismatch` is returned when
+the signatures differ, and
+:docs-rs:`~~mujoco_rs::viewer::<enum>MjViewerError::<variant>IndexOutOfBounds` when the asset ID
+is out of range (singular methods only).
 If the model has been replaced or reloaded, call
 :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>sync_model` or
 :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>sync_data` first to bring the viewer's

--- a/docs/guide/source/programming/visualization/viewer.rst
+++ b/docs/guide/source/programming/visualization/viewer.rst
@@ -1,3 +1,5 @@
+.. |mj_data| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData`
+
 .. _mj_rust_viewer:
 
 =======================

--- a/examples/asset_reupload.rs
+++ b/examples/asset_reupload.rs
@@ -15,7 +15,7 @@
 //! The physics runs on a dedicated thread, maintaining real-time simulation rate.
 //! The render loop runs on the main thread, as required by OpenGL.
 //!
-//! Asset updates are queued via [`ViewerSharedState::update_hfields_from`] and friends,
+//! Asset updates are queued via [`mujoco_rs::viewer::ViewerSharedState::update_hfields_from`] and friends,
 //! then flushed to the GPU on the next [`MjViewer::render`] call.
 //!
 //! The accessor methods used here are all safe -- no `unsafe` blocks needed.

--- a/examples/asset_reupload.rs
+++ b/examples/asset_reupload.rs
@@ -111,13 +111,13 @@ fn main() {
             data.step();
             {
                 let mut lock = state.lock().unwrap();
-                lock.update_hfield_from(data.model(), 0);   // model, asset (hfield) id
-                lock.update_texture_from(data.model(), 0);
-                lock.update_mesh_from(data.model(), 0);
+                lock.update_hfield_from(data.model(), 0).unwrap();   // model, asset (hfield) id
+                lock.update_texture_from(data.model(), 0).unwrap();
+                lock.update_mesh_from(data.model(), 0).unwrap();
                 // Alternatively upload and update all assets
-                // lock.update_hfields_from(data.model());
-                // lock.update_textures_from(data.model());
-                // lock.update_meshes_from(data.model());
+                // lock.update_hfields_from(data.model()).unwrap();
+                // lock.update_textures_from(data.model()).unwrap();
+                // lock.update_meshes_from(data.model()).unwrap();
                 lock.sync_data(&mut data);
                 viewer_running = lock.running();
             }

--- a/examples/asset_reupload.rs
+++ b/examples/asset_reupload.rs
@@ -1,0 +1,240 @@
+//! Demonstrates runtime GPU asset re-upload in the Rust viewer with multi-threaded simulation.
+//!
+//! Three types of animated assets are rendered in the same scene:
+//!
+//! - **Heightfield** -- elevation data is rewritten each frame, creating a propagating
+//!   ripple wave across the terrain.
+//! - **Texture** -- pixel data is rewritten each frame, producing a shifting colour
+//!   gradient across the surface of the ball.
+//! - **Mesh** -- vertex Z positions are rewritten each frame, making a flat grid mesh
+//!   deform into a wave surface.
+//!
+//! A ball with a free joint is dropped under gravity onto the animated terrain,
+//! bouncing and rolling as the heightfield ripples beneath it.
+//!
+//! The physics runs on a dedicated thread, maintaining real-time simulation rate.
+//! The render loop runs on the main thread, as required by OpenGL.
+//!
+//! Asset updates are queued via [`ViewerSharedState::update_hfields_from`] and friends,
+//! then flushed to the GPU on the next [`MjViewer::render`] call.
+//!
+//! The accessor methods used here are all safe -- no `unsafe` blocks needed.
+//! (Only the mutable `_mut` variants of layout fields like `mesh_vertadr` are
+//! `unsafe`; the read-only variants used to initialise layout offsets are not.)
+use std::time::Instant;
+use std::thread;
+
+use mujoco_rs::viewer::MjViewer;
+use mujoco_rs::prelude::*;
+
+/// Width and height of the 2-D texture in pixels.
+const TEX_SIZE: usize = 64;
+/// Number of rows and columns in the heightfield.
+const HF_N: usize = 32;
+/// Number of quads per edge in the wave mesh (vertex grid is (N+1)^2).
+const MESH_N: usize = 10;
+
+fn main() {
+    let model = Box::new(create_model());
+    let mut data = MjData::new(model);
+    data.forward();
+    // Small initial push so the ball rolls around the bowl.
+    data.qvel_mut()[0] = 1.2; // vx
+    data.qvel_mut()[1] = 0.6; // vy
+
+    // Read layout values once -- these fields are read-only and safe.
+    // Copied to plain integers so no reference is held across later mutable borrows.
+    let tex_adr      = data.model().tex_adr()[0] as usize;
+    let tex_nchannel = data.model().tex_nchannel()[0] as usize;
+    let mesh_adr     = data.model().mesh_vertadr()[0] as usize;
+    let mesh_count   = data.model().mesh_vertnum()[0] as usize;
+    let hf_adr       = data.model().hfield_adr()[0] as usize;
+    let hf_ncol      = data.model().hfield_ncol()[0] as usize;
+    let hf_nrow      = data.model().hfield_nrow()[0] as usize;
+
+    let mut viewer = MjViewer::launch_passive(data.model(), 0).unwrap();
+    let state = viewer.state().clone();
+
+    let physics_thread = thread::spawn(move || {
+        let mut viewer_running = state.lock().unwrap().running();
+        while viewer_running {
+            let timer = Instant::now();
+            let t = data.time() as f32;
+
+            // SAFETY: asset arrays (hfield_data, tex_data, mesh_vert) are
+            // only touched here on the physics thread. No other thread reads
+            // them until we push the changes via update_*_from below.
+            let m = unsafe { data.model_mut() };
+
+            /* Heightfield: propagating ripple wave */
+            // Values must be in [0, 1]; 0 = z_bottom, 1 = z_top (from the `size` parameter).
+            let hf = m.hfield_data_mut();
+            for row in 0..hf_nrow {
+                for col in 0..hf_ncol {
+                    let x    = col as f32 / (hf_ncol - 1) as f32 * 2.0 - 1.0;
+                    let y    = row as f32 / (hf_nrow - 1) as f32 * 2.0 - 1.0;
+                    let dist = (x * x + y * y).sqrt();
+                    let s    = ((dist - 0.6) / 0.4).clamp(0.0, 1.0);
+                    let wall = s * s * (3.0 - 2.0 * s); // Hermite smooth-step
+                    let ripple = (dist * 6.0 - t * 2.0).sin() * 0.25 + 0.3;
+                    hf[hf_adr + row * hf_ncol + col] =
+                        (wall + (1.0 - wall) * ripple).clamp(0.0, 1.0);
+                }
+            }
+
+            /* Texture: animated UV colour gradient */
+            let tex = m.tex_data_mut();
+            for py in 0..TEX_SIZE {
+                for px in 0..TEX_SIZE {
+                    let u = px as f32 / TEX_SIZE as f32;
+                    let v = py as f32 / TEX_SIZE as f32;
+                    let base = tex_adr + (py * TEX_SIZE + px) * tex_nchannel;
+                    tex[base]     = ((u + t * 0.5).sin() * 127.0 + 128.0) as u8;
+                    tex[base + 1] = ((v + t * 0.7).cos() * 127.0 + 128.0) as u8;
+                    tex[base + 2] = (t * 0.3).sin().abs().mul_add(200.0, 55.0) as u8;
+                    if tex_nchannel == 4 {
+                        tex[base + 3] = 255; // alpha
+                    }
+                }
+            }
+
+            /* Mesh: sinusoidal Z deformation based on radial distance + time */
+            // `mesh_vert_mut()` returns `&mut [[f32; 3]]`; each entry is one vertex [x, y, z].
+            let verts = m.mesh_vert_mut();
+            for k in 0..mesh_count {
+                let x = verts[mesh_adr + k][0];
+                let y = verts[mesh_adr + k][1];
+                let dist = (x * x + y * y).sqrt();
+                verts[mesh_adr + k][2] = 0.2 * (dist * 5.0 - t * 2.5).sin();
+            }
+
+            data.step();
+            {
+                let mut lock = state.lock().unwrap();
+                lock.update_hfields_from(data.model());
+                lock.update_textures_from(data.model());
+                lock.update_meshes_from(data.model());
+                lock.sync_data(&mut data);
+                viewer_running = lock.running();
+            }
+
+            // Busy-wait to maintain real-time simulation rate.
+            while timer.elapsed().as_secs_f64() < data.model().opt().timestep {}
+        }
+    });
+
+    while viewer.running() {
+        viewer.render().unwrap();
+    }
+
+    physics_thread.join().unwrap();
+}
+
+
+/// Builds an [`MjModel`] containing a heightfield, a textured ball, and a wave mesh.
+fn create_model() -> MjModel {
+    let mut spec = MjSpec::new();
+
+    /* Heightfield */
+    let hf = spec.add_hfield();
+    hf.set_name("terrain").unwrap();
+    hf.set_nrow(HF_N as i32);
+    hf.set_ncol(HF_N as i32);
+    // size = [x_half, y_half, z_top_scale, z_bottom_thickness]
+    hf.with_size([4.0, 4.0, 1.0, 0.1]);
+    // Flat initial elevation (0.5 = mid-height in [0, 1]).
+    // Smooth wall: inner 60% is pure ripple; outer 40% transitions to a full-height wall.
+    let initial: Vec<f32> = (0..HF_N)
+        .flat_map(|row| {
+            (0..HF_N).map(move |col| {
+                let x    = col as f32 / (HF_N - 1) as f32 * 2.0 - 1.0;
+                let y    = row as f32 / (HF_N - 1) as f32 * 2.0 - 1.0;
+                let dist = (x * x + y * y).sqrt();
+                let s    = ((dist - 0.6) / 0.4).clamp(0.0, 1.0);
+                let wall = s * s * (3.0 - 2.0 * s); // Hermite smooth-step
+                    let ripple = (dist * 6.0).sin() * 0.25 + 0.3;
+                (wall + (1.0 - wall) * ripple).clamp(0.0, 1.0)
+            })
+        })
+        .collect();
+    hf.set_userdata(initial);
+
+    /* Texture + material */
+    // Use set_data() to ensure MuJoCo allocates exactly TEX_SIZE^2 x nchannel bytes.
+    let tex = spec.add_texture();
+    tex.with_name("wave_tex")
+        .with_type(MjtTexture::mjTEXTURE_2D)
+        .with_width(TEX_SIZE as i32)
+        .with_height(TEX_SIZE as i32)
+        .with_nchannel(3);
+    tex.set_data(&vec![128u8; TEX_SIZE * TEX_SIZE * 3]); // grey initially
+
+    let mat = spec.add_material().with_name("tex_mat");
+    mat.set_texture(MjtTextureRole::mjTEXROLE_RGB, "wave_tex");
+
+    /* Wave mesh (MESH_N x MESH_N quads) */
+    let n = MESH_N + 1; // vertices per edge
+    let verts: Vec<f32> = (0..n)
+        .flat_map(|i| {
+            (0..n).flat_map(move |j| {
+                let x = j as f32 / MESH_N as f32 * 2.0 - 1.0;
+                let y = i as f32 / MESH_N as f32 * 2.0 - 1.0;
+                // Non-zero initial Z so Qhull can build a valid convex hull.
+                let dist = (x * x + y * y).sqrt();
+                let z = 0.2 * (dist * 5.0_f32).sin();
+                [x, y, z]
+            })
+        })
+        .collect();
+
+    let faces: Vec<i32> = (0..MESH_N)
+        .flat_map(|i| {
+            (0..MESH_N).flat_map(move |j| {
+                let tl = (i * n + j) as i32;
+                let bl = ((i + 1) * n + j) as i32;
+                let tr = tl + 1;
+                let br = bl + 1;
+                [tl, bl, tr, bl, br, tr]
+            })
+        })
+        .collect();
+
+    let mesh = spec.add_mesh();
+    mesh.set_name("wave").unwrap();
+    mesh.set_uservert(&verts);
+    mesh.set_userface(&faces);
+
+    /* Scene geometry */
+    let world = spec.world_body_mut();
+
+    world
+        .add_light()
+        .with_pos([0.0, 0.0, 5.0])
+        .with_dir([0.0, 0.2, -1.0]);
+
+    world
+        .add_geom()
+        .with_type(MjtGeom::mjGEOM_HFIELD)
+        .with_pos([0.0, 0.0, 0.0])
+        .with_hfieldname("terrain");
+
+    // Ball with a free joint: falls under gravity and bounces on the terrain.
+    let ball = world.add_body();
+    ball.with_name("ball").with_pos([0.0, 0.0, 3.5]);
+    ball.add_joint().with_type(MjtJoint::mjJNT_FREE);
+    ball.add_geom()
+        .with_type(MjtGeom::mjGEOM_SPHERE)
+        .with_size([0.3, 0.0, 0.0])
+        .with_material("tex_mat");
+
+    world
+        .add_body()
+        .with_name("wave_body")
+        .with_pos([3.0, 0.0, 2.0])
+        .add_geom()
+        .with_type(MjtGeom::mjGEOM_MESH)
+        .with_meshname("wave")
+        .with_rgba([0.3, 0.7, 1.0, 1.0]);
+
+    spec.compile().unwrap()
+}

--- a/examples/asset_reupload.rs
+++ b/examples/asset_reupload.rs
@@ -51,7 +51,7 @@ fn main() {
     let hf_ncol      = data.model().hfield_ncol()[0] as usize;
     let hf_nrow      = data.model().hfield_nrow()[0] as usize;
 
-    let mut viewer = MjViewer::launch_passive(data.model(), 0).unwrap();
+    let mut viewer = MjViewer::builder().vsync(true).build_passive(data.model()).unwrap();
     let state = viewer.state().clone();
 
     let physics_thread = thread::spawn(move || {
@@ -111,9 +111,13 @@ fn main() {
             data.step();
             {
                 let mut lock = state.lock().unwrap();
-                lock.update_hfields_from(data.model());
-                lock.update_textures_from(data.model());
-                lock.update_meshes_from(data.model());
+                lock.update_hfield_from(data.model(), 0);   // model, asset (hfield) id
+                lock.update_texture_from(data.model(), 0);
+                lock.update_mesh_from(data.model(), 0);
+                // Alternatively upload and update all assets
+                // lock.update_hfields_from(data.model());
+                // lock.update_textures_from(data.model());
+                // lock.update_meshes_from(data.model());
                 lock.sync_data(&mut data);
                 viewer_running = lock.running();
             }

--- a/examples/asset_reupload.rs
+++ b/examples/asset_reupload.rs
@@ -18,9 +18,8 @@
 //! Asset updates are queued via [`mujoco_rs::viewer::ViewerSharedState::update_hfields_from`] and friends,
 //! then flushed to the GPU on the next [`MjViewer::render`] call.
 //!
-//! The accessor methods used here are all safe -- no `unsafe` blocks needed.
-//! (Only the mutable `_mut` variants of layout fields like `mesh_vertadr` are
-//! `unsafe`; the read-only variants used to initialise layout offsets are not.)
+//! Mutating asset arrays requires `unsafe { data.model_mut() }`; reading layout
+//! offsets (addresses and counts) uses safe read-only accessors.
 use std::time::Instant;
 use std::thread;
 
@@ -61,9 +60,10 @@ fn main() {
             let timer = Instant::now();
             let t = data.time() as f32;
 
-            // SAFETY: asset arrays (hfield_data, tex_data, mesh_vert) are
-            // only touched here on the physics thread. No other thread reads
-            // them until we push the changes via update_*_from below.
+            // SAFETY: `data` is moved exclusively into this thread; no other
+            // thread holds any reference to it or its embedded model. Only
+            // non-structural asset arrays are modified, leaving MjData's
+            // simulation state consistent.
             let m = unsafe { data.model_mut() };
 
             /* Heightfield: propagating ripple wave */

--- a/examples/renderer_asset_reupload.rs
+++ b/examples/renderer_asset_reupload.rs
@@ -1,0 +1,251 @@
+//! Demonstrates runtime GPU asset re-upload with the [`MjRenderer`].
+//!
+//! Three types of animated assets are rendered across multiple frames, each saved as a PNG:
+//!
+//! - **Heightfield** -- elevation data is rewritten each frame, creating a propagating
+//!   ripple wave across the terrain.
+//! - **Texture** -- pixel data is rewritten each frame, producing a shifting colour
+//!   gradient across the surface of the ball.
+//! - **Mesh** -- vertex Z positions are rewritten each frame, making a flat grid mesh
+//!   deform into a wave surface.
+//!
+//! After modifying the raw asset arrays directly on the `MjData`'s embedded model, the
+//! changes are uploaded to the GPU via [`MjRenderer::update_hfield_from`],
+//! [`MjRenderer::update_texture_from`], and [`MjRenderer::update_mesh_from`] before
+//! calling [`MjRenderer::render`].  The output PNGs are written to `./output_renderer_asset_reupload/`.
+use std::fs;
+
+use mujoco_rs::renderer::MjRenderer;
+use mujoco_rs::prelude::*;
+
+/// Width and height of the 2-D texture in pixels.
+const TEX_SIZE: usize = 64;
+/// Number of rows and columns in the heightfield.
+const HF_N: usize = 32;
+/// Number of quads per edge in the wave mesh (vertex grid is (N+1)^2).
+const MESH_N: usize = 10;
+/// Number of frames to render.
+const NUM_FRAMES: usize = 60;
+/// Number of frames between renders.
+const FRAME_SKIP: usize = 100;
+/// Output directory for saved images.
+const OUTPUT_DIR: &str = "./output_renderer_asset_reupload/";
+
+fn main() {
+    fs::create_dir_all(OUTPUT_DIR).unwrap();
+
+    let model = Box::new(create_model());
+    let mut data = MjData::new(model);
+
+    // Read layout values once from the model. These are read-only and do not change.
+    // Copied to plain integers so no reference is held across later mutable borrows.
+    let tex_adr      = data.model().tex_adr()[0] as usize;
+    let tex_nchannel = data.model().tex_nchannel()[0] as usize;
+    let mesh_adr     = data.model().mesh_vertadr()[0] as usize;
+    let mesh_count   = data.model().mesh_vertnum()[0] as usize;
+    let hf_adr       = data.model().hfield_adr()[0] as usize;
+    let hf_ncol      = data.model().hfield_ncol()[0] as usize;
+    let hf_nrow      = data.model().hfield_nrow()[0] as usize;
+
+    let model = data.model();
+    let mut renderer = MjRenderer::builder()
+        .width(0)   // 0 = inherit offwidth from model's visual.global settings
+        .height(0)  // 0 = inherit offheight from model's visual.global settings
+        .build(model)
+        .expect("failed to initialise renderer");
+
+    let mut camera = MjvCamera::new_free(model);
+    camera.move_(MjtMouse::mjMOUSE_ZOOM, model,-10.0, 0.0, renderer.scene());
+    renderer.set_camera(camera);
+
+    let mut frames_processed = 0;
+    for i in 0.. {
+        if frames_processed >= NUM_FRAMES {
+            break;
+        }
+
+        data.step();
+        renderer.sync_data(&mut data).unwrap();
+
+        if i % FRAME_SKIP != 0 {
+            continue;
+        }
+
+        let t = data.time() as f32;
+
+        // Mutate the asset arrays on the embedded model.
+        //
+        // SAFETY: only non-structural asset data arrays are modified; the layout
+        // (address / count fields) is unchanged, keeping `MjData` internally consistent.
+        let m = unsafe { data.model_mut() };
+
+        /* Heightfield: propagating ripple wave */
+        let hf = m.hfield_data_mut();
+        for row in 0..hf_nrow {
+            for col in 0..hf_ncol {
+                let x    = col as f32 / (hf_ncol - 1) as f32 * 2.0 - 1.0;
+                let y    = row as f32 / (hf_nrow - 1) as f32 * 2.0 - 1.0;
+                let dist = (x * x + y * y).sqrt();
+                let s    = ((dist - 0.6) / 0.4).clamp(0.0, 1.0);
+                let wall = s * s * (3.0 - 2.0 * s);
+                let ripple = (dist * 6.0 - t * 2.0).sin() * 0.25 + 0.3;
+                hf[hf_adr + row * hf_ncol + col] =
+                    (wall + (1.0 - wall) * ripple).clamp(0.0, 1.0);
+            }
+        }
+
+        /* Texture: animated UV colour gradient */
+        let tex = m.tex_data_mut();
+        for py in 0..TEX_SIZE {
+            for px in 0..TEX_SIZE {
+                let u = px as f32 / TEX_SIZE as f32;
+                let v = py as f32 / TEX_SIZE as f32;
+                let base = tex_adr + (py * TEX_SIZE + px) * tex_nchannel;
+                tex[base]     = ((u + t * 0.5).sin() * 127.0 + 128.0) as u8;
+                tex[base + 1] = ((v + t * 0.7).cos() * 127.0 + 128.0) as u8;
+                tex[base + 2] = (t * 0.3).sin().abs().mul_add(200.0, 55.0) as u8;
+                if tex_nchannel == 4 {
+                    tex[base + 3] = 255;
+                }
+            }
+        }
+
+        /* Mesh: sinusoidal Z deformation based on radial distance + time */
+        let verts = m.mesh_vert_mut();
+        for k in 0..mesh_count {
+            let x = verts[mesh_adr + k][0];
+            let y = verts[mesh_adr + k][1];
+            let dist = (x * x + y * y).sqrt();
+            verts[mesh_adr + k][2] = 0.2 * (dist * 5.0 - t * 2.5).sin();
+        }
+
+        // Upload the modified assets to the GPU, then render.
+        renderer.update_hfield_from(data.model(), 0);
+        renderer.update_texture_from(data.model(), 0);
+        renderer.update_mesh_from(data.model(), 0);
+        // Alternatively upload all assets at once:
+        // renderer.update_hfields_from(data.model());
+        // renderer.update_textures_from(data.model());
+        // renderer.update_meshes_from(data.model());
+
+        renderer.render().unwrap();
+        renderer
+            .save_rgb(format!("{OUTPUT_DIR}/frame_{frames_processed:04}.png"))
+            .unwrap();
+
+        frames_processed += 1;
+    }
+
+    println!("Saved {NUM_FRAMES} frames to {OUTPUT_DIR}");
+}
+
+/// Builds an [`MjModel`] containing a heightfield, a textured ball, and a wave mesh.
+///
+/// The offscreen buffer is sized to 1280×720 via the spec's `visual.global` settings so
+/// that callers can construct an [`MjRenderer`] with `width(0).height(0)` to inherit the
+/// model's configured resolution.
+fn create_model() -> MjModel {
+    let mut spec = MjSpec::new();
+
+    // Configure offscreen resolution: 1280 × 720.
+    let visual = spec.visual_mut();
+    visual.global.offwidth  = 1280;
+    visual.global.offheight = 720;
+
+    /* Heightfield */
+    let hf = spec.add_hfield();
+    hf.set_name("terrain").unwrap();
+    hf.set_nrow(HF_N as i32);
+    hf.set_ncol(HF_N as i32);
+    hf.with_size([4.0, 4.0, 1.0, 0.1]);
+    let initial: Vec<f32> = (0..HF_N)
+        .flat_map(|row| {
+            (0..HF_N).map(move |col| {
+                let x    = col as f32 / (HF_N - 1) as f32 * 2.0 - 1.0;
+                let y    = row as f32 / (HF_N - 1) as f32 * 2.0 - 1.0;
+                let dist = (x * x + y * y).sqrt();
+                let s    = ((dist - 0.6) / 0.4).clamp(0.0, 1.0);
+                let wall = s * s * (3.0 - 2.0 * s);
+                let ripple = (dist * 6.0).sin() * 0.25 + 0.3;
+                (wall + (1.0 - wall) * ripple).clamp(0.0, 1.0)
+            })
+        })
+        .collect();
+    hf.set_userdata(initial);
+
+    /* Texture + material */
+    let tex = spec.add_texture();
+    tex.with_name("wave_tex")
+        .with_type(MjtTexture::mjTEXTURE_2D)
+        .with_width(TEX_SIZE as i32)
+        .with_height(TEX_SIZE as i32)
+        .with_nchannel(3);
+    tex.set_data(&vec![128u8; TEX_SIZE * TEX_SIZE * 3]);
+
+    let mat = spec.add_material().with_name("tex_mat");
+    mat.set_texture(MjtTextureRole::mjTEXROLE_RGB, "wave_tex");
+
+    /* Wave mesh */
+    let n = MESH_N + 1;
+    let verts: Vec<f32> = (0..n)
+        .flat_map(|i| {
+            (0..n).flat_map(move |j| {
+                let x = j as f32 / MESH_N as f32 * 2.0 - 1.0;
+                let y = i as f32 / MESH_N as f32 * 2.0 - 1.0;
+                let dist = (x * x + y * y).sqrt();
+                let z = 0.2 * (dist * 5.0_f32).sin();
+                [x, y, z]
+            })
+        })
+        .collect();
+
+    let faces: Vec<i32> = (0..MESH_N)
+        .flat_map(|i| {
+            (0..MESH_N).flat_map(move |j| {
+                let tl = (i * n + j) as i32;
+                let bl = ((i + 1) * n + j) as i32;
+                let tr = tl + 1;
+                let br = bl + 1;
+                [tl, bl, tr, bl, br, tr]
+            })
+        })
+        .collect();
+
+    let mesh = spec.add_mesh();
+    mesh.set_name("wave").unwrap();
+    mesh.set_uservert(&verts);
+    mesh.set_userface(&faces);
+
+    /* Scene geometry */
+    let world = spec.world_body_mut();
+
+    world
+        .add_light()
+        .with_pos([0.0, 0.0, 5.0])
+        .with_dir([0.0, 0.2, -1.0]);
+
+    world
+        .add_geom()
+        .with_type(MjtGeom::mjGEOM_HFIELD)
+        .with_pos([0.0, 0.0, 0.0])
+        .with_hfieldname("terrain");
+
+    let ball = world.add_body();
+    ball.with_name("ball").with_pos([0.0, 0.0, 3.5]);
+    ball.add_joint().with_type(MjtJoint::mjJNT_FREE);
+    ball.add_geom()
+        .with_type(MjtGeom::mjGEOM_SPHERE)
+        .with_size([0.3, 0.0, 0.0])
+        .with_material("tex_mat");
+
+    world
+        .add_body()
+        .with_name("wave_body")
+        .with_pos([3.0, 0.0, 2.0])
+        .add_geom()
+        .with_type(MjtGeom::mjGEOM_MESH)
+        .with_meshname("wave")
+        .with_rgba([0.3, 0.7, 1.0, 1.0]);
+
+    spec.compile().unwrap()
+}

--- a/examples/renderer_asset_reupload.rs
+++ b/examples/renderer_asset_reupload.rs
@@ -120,13 +120,13 @@ fn main() {
         }
 
         // Upload the modified assets to the GPU, then render.
-        renderer.update_hfield_from(data.model(), 0);
-        renderer.update_texture_from(data.model(), 0);
-        renderer.update_mesh_from(data.model(), 0);
+        renderer.update_hfield_from(data.model(), 0).unwrap();
+        renderer.update_texture_from(data.model(), 0).unwrap();
+        renderer.update_mesh_from(data.model(), 0).unwrap();
         // Alternatively upload all assets at once:
-        // renderer.update_hfields_from(data.model());
-        // renderer.update_textures_from(data.model());
-        // renderer.update_meshes_from(data.model());
+        // renderer.update_hfields_from(data.model()).unwrap();
+        // renderer.update_textures_from(data.model()).unwrap();
+        // renderer.update_meshes_from(data.model()).unwrap();
 
         renderer.render().unwrap();
         renderer

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,22 +139,6 @@ pub enum MjSceneError {
         /// Maximum number of bytes (excluding the NUL terminator) the buffer can hold.
         capacity: usize,
     },
-    /// A viewport has invalid (negative) dimensions.
-    InvalidViewport {
-        /// The viewport width that was provided.
-        width: i32,
-        /// The viewport height that was provided.
-        height: i32,
-    },
-    /// A pixel buffer passed to a rendering operation is too small.
-    BufferTooSmall {
-        /// Descriptive name of the buffer (e.g. `"rgb"`, `"depth"`).
-        name: &'static str,
-        /// Actual length of the buffer that was provided.
-        got: usize,
-        /// Minimum length the buffer must have.
-        needed: usize,
-    },
     /// The figure's line-data buffer for a given plot is full.
     FigureBufferFull {
         /// Index of the plot whose buffer is full.
@@ -203,19 +187,6 @@ impl fmt::Display for MjSceneError {
                     "label of {len} bytes exceeds the fixed buffer capacity of {capacity} bytes"
                 )
             }
-            Self::InvalidViewport { width, height } => {
-                write!(
-                    f,
-                    "viewport dimensions must be non-negative, got {width}x{height}"
-                )
-            }
-            Self::BufferTooSmall { name, got, needed } => {
-                write!(
-                    f,
-                    "{name} buffer is too small: got {got} elements, \
-                     but need at least {needed}"
-                )
-            }
             Self::FigureBufferFull { plot_index, capacity } => {
                 write!(
                     f,
@@ -260,6 +231,22 @@ pub enum MjrContextError {
         /// Exclusive upper bound of the valid range.
         len: usize,
     },
+    /// A viewport has invalid (negative) dimensions.
+    InvalidViewport {
+        /// The viewport width that was provided.
+        width: i32,
+        /// The viewport height that was provided.
+        height: i32,
+    },
+    /// A pixel buffer passed to a rendering-context operation is too small.
+    BufferTooSmall {
+        /// Descriptive name of the buffer (e.g. `"rgb"`, `"depth"`).
+        name: &'static str,
+        /// Actual length of the buffer that was provided.
+        got: usize,
+        /// Minimum length the buffer must have.
+        needed: usize,
+    },
 }
 
 impl fmt::Display for MjrContextError {
@@ -267,6 +254,19 @@ impl fmt::Display for MjrContextError {
         match self {
             Self::IndexOutOfBounds { id, len } => {
                 write!(f, "index {id} is out of range [0, {len})")
+            }
+            Self::InvalidViewport { width, height } => {
+                write!(
+                    f,
+                    "viewport dimensions must be non-negative, got {width}x{height}"
+                )
+            }
+            Self::BufferTooSmall { name, got, needed } => {
+                write!(
+                    f,
+                    "{name} buffer is too small: got {got} elements, \
+                     but need at least {needed}"
+                )
             }
         }
     }
@@ -372,8 +372,13 @@ pub enum MjModelError {
     },
     /// A virtual-file-system operation failed while loading a model from a string.
     VfsError(MjVfsError),
-    /// The given index is invalid or out of range.
-    InvalidIndex(usize, usize),
+    /// The given index is out of range.
+    IndexOutOfBounds {
+        /// The index that was supplied.
+        id: usize,
+        /// Exclusive upper bound of the valid range.
+        len: usize,
+    },
 }
 
 impl fmt::Display for MjModelError {
@@ -404,9 +409,9 @@ impl fmt::Display for MjModelError {
                 )
             }
             Self::VfsError(e) => write!(f, "VFS error: {e}"),
-            Self::InvalidIndex(index, length) => write!(
+            Self::IndexOutOfBounds { id, len } => write!(
                 f,
-                "invalid index: {index} is out of bounds (there are {length} elements available)"
+                "index {id} is out of bounds (length is {len})"
             ),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,8 @@
 //! Error types for MuJoCo-rs operations.
 //!
 //! - [`MjDataError`] - physics data, view-signature, and Jacobian operations.
-//! - [`MjSceneError`] - 3-D scene and visualization operations (`MjvScene`, `MjrContext`).
+//! - [`MjSceneError`] - 3-D scene and visualization operations (`MjvScene`).
+//! - [`MjrContextError`] - GPU rendering-context operations (`MjrContext`).
 //! - [`MjEditError`] - model-specification editing operations (`MjSpec`).
 //! - [`MjModelError`] - model loading, saving, and state operations (`MjModel`).
 //! - [`MjVfsError`] - virtual file system operations (`MjVfs`).
@@ -119,7 +120,7 @@ impl std::error::Error for MjDataError {}
 
 
 /// Errors that can occur in 3-D scene and visualization operations
-/// ([`MjvScene`](crate::wrappers::MjvScene), [`MjrContext`](crate::wrappers::MjrContext)).
+/// ([`MjvScene`](crate::wrappers::MjvScene)).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum MjSceneError {
@@ -137,11 +138,6 @@ pub enum MjSceneError {
         len: usize,
         /// Maximum number of bytes (excluding the NUL terminator) the buffer can hold.
         capacity: usize,
-    },
-    /// An auxiliary buffer index is out of the valid range `[0, mjNAUX)`.
-    InvalidAuxBufferIndex {
-        /// The out-of-range index that was provided.
-        index: usize,
     },
     /// A viewport has invalid (negative) dimensions.
     InvalidViewport {
@@ -207,9 +203,6 @@ impl fmt::Display for MjSceneError {
                     "label of {len} bytes exceeds the fixed buffer capacity of {capacity} bytes"
                 )
             }
-            Self::InvalidAuxBufferIndex { index } => {
-                write!(f, "aux buffer index {index} is out of range [0, mjNAUX)")
-            }
             Self::InvalidViewport { width, height } => {
                 write!(
                     f,
@@ -254,6 +247,32 @@ impl fmt::Display for MjSceneError {
 }
 
 impl std::error::Error for MjSceneError {}
+
+
+/// Errors that can occur in GPU rendering-context ([`MjrContext`](crate::wrappers::MjrContext)) operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MjrContextError {
+    /// An index passed to a rendering-context operation is out of the valid range.
+    IndexOutOfBounds {
+        /// The index that was supplied.
+        id: usize,
+        /// Exclusive upper bound of the valid range.
+        len: usize,
+    },
+}
+
+impl fmt::Display for MjrContextError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IndexOutOfBounds { id, len } => {
+                write!(f, "index {id} is out of range [0, {len})")
+            }
+        }
+    }
+}
+
+impl std::error::Error for MjrContextError {}
 
 
 /// Errors that can occur in model-specification editing operations

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -389,6 +389,116 @@ impl MjRenderer {
         self.option = options;
     }
 
+    /// Re-uploads the texture with `texture_id` from `model` to the GPU immediately.
+    ///
+    /// # Panics
+    /// Panics if `texture_id` is out of range, if the OpenGL context cannot be made current,
+    /// or if `model`'s signature does not match the renderer's current scene.
+    /// Call [`MjRenderer::sync_data`] first to ensure the models are in sync.
+    pub fn update_texture_from(&self, model: &MjModel, texture_id: usize) {
+        assert_eq!(
+            model.signature(), self.scene.signature(),
+            "model signature mismatch: call sync_data first"
+        );
+        self.gl_state.make_current().unwrap();
+        self.context.upload_texture(model, texture_id);
+    }
+
+    /// Re-uploads all textures from `model` to the GPU immediately.
+    ///
+    /// # Panics
+    /// Panics if the OpenGL context cannot be made current or if `model`'s signature does not
+    /// match the renderer's current scene.
+    /// Call [`MjRenderer::sync_data`] first to ensure the models are in sync.
+    pub fn update_textures_from(&self, model: &MjModel) {
+        assert_eq!(
+            model.signature(), self.scene.signature(),
+            "model signature mismatch: call sync_data first"
+        );
+        self.gl_state.make_current().unwrap();
+        for texture_id in 0..model.ntex() as usize {
+            self.context.upload_texture(model, texture_id);
+        }
+    }
+
+    /// Re-uploads the mesh with `mesh_id` from `model` to the GPU immediately.
+    ///
+    /// All data arrays read by `mjr_uploadMesh` are copied: vertex positions
+    /// (`mesh_vert`), per-vertex normals (`mesh_normal`), UV texture coordinates
+    /// (`mesh_texcoord`), face--vertex indices (`mesh_face`), face--normal indices
+    /// (`mesh_facenormal`), face--texcoord indices (`mesh_facetexcoord`), and convex
+    /// hull graph data (`mesh_graph`). Layout fields (address and count arrays) are
+    /// not copied because they are fixed by the model signature.
+    ///
+    /// # Panics
+    /// Panics if `mesh_id` is out of range, if the OpenGL context cannot be made current,
+    /// or if `model`'s signature does not match the renderer's current scene.
+    /// Call [`MjRenderer::sync_data`] first to ensure the models are in sync.
+    pub fn update_mesh_from(&self, model: &MjModel, mesh_id: usize) {
+        assert_eq!(
+            model.signature(), self.scene.signature(),
+            "model signature mismatch: call sync_data first"
+        );
+        self.gl_state.make_current().unwrap();
+        self.context.upload_mesh(model, mesh_id);
+    }
+
+    /// Re-uploads all meshes from `model` to the GPU immediately.
+    ///
+    /// All data arrays read by `mjr_uploadMesh` are copied: vertex positions
+    /// (`mesh_vert`), per-vertex normals (`mesh_normal`), UV texture coordinates
+    /// (`mesh_texcoord`), face--vertex indices (`mesh_face`), face--normal indices
+    /// (`mesh_facenormal`), face--texcoord indices (`mesh_facetexcoord`), and convex
+    /// hull graph data (`mesh_graph`). Layout fields (address and count arrays) are
+    /// not copied because they are fixed by the model signature.
+    ///
+    /// # Panics
+    /// Panics if the OpenGL context cannot be made current or if `model`'s signature does not
+    /// match the renderer's current scene.
+    /// Call [`MjRenderer::sync_data`] first to ensure the models are in sync.
+    pub fn update_meshes_from(&self, model: &MjModel) {
+        assert_eq!(
+            model.signature(), self.scene.signature(),
+            "model signature mismatch: call sync_data first"
+        );
+        self.gl_state.make_current().unwrap();
+        for mesh_id in 0..model.nmesh() as usize {
+            self.context.upload_mesh(model, mesh_id);
+        }
+    }
+
+    /// Re-uploads the heightfield with `hfield_id` from `model` to the GPU immediately.
+    ///
+    /// # Panics
+    /// Panics if `hfield_id` is out of range, if the OpenGL context cannot be made current,
+    /// or if `model`'s signature does not match the renderer's current scene.
+    /// Call [`MjRenderer::sync_data`] first to ensure the models are in sync.
+    pub fn update_hfield_from(&self, model: &MjModel, hfield_id: usize) {
+        assert_eq!(
+            model.signature(), self.scene.signature(),
+            "model signature mismatch: call sync_data first"
+        );
+        self.gl_state.make_current().unwrap();
+        self.context.upload_hfield(model, hfield_id);
+    }
+
+    /// Re-uploads all heightfields from `model` to the GPU immediately.
+    ///
+    /// # Panics
+    /// Panics if the OpenGL context cannot be made current or if `model`'s signature does not
+    /// match the renderer's current scene.
+    /// Call [`MjRenderer::sync_data`] first to ensure the models are in sync.
+    pub fn update_hfields_from(&self, model: &MjModel) {
+        assert_eq!(
+            model.signature(), self.scene.signature(),
+            "model signature mismatch: call sync_data first"
+        );
+        self.gl_state.make_current().unwrap();
+        for hfield_id in 0..model.nhfield() as usize {
+            self.context.upload_hfield(model, hfield_id);
+        }
+    }
+
     /// Set the camera used for rendering.
     pub fn set_camera(&mut self, camera: MjvCamera)  {
         self.camera = camera;
@@ -456,7 +566,7 @@ impl MjRenderer {
     ///
     /// # Errors
     /// - [`RendererError::GlutinError`] if the OpenGL context could not be made current
-    ///   (only when the [`MjModel`] in `data` differs from the internal model).
+    ///   (only when the [`MjModel`] in `data` differs from the model that created the internal [`MjvScene`]).
     pub fn sync_data<M: Deref<Target = MjModel>>(&mut self, data: &mut MjData<M>) -> Result<(), RendererError> {
         if data.model().signature() != self.scene.signature() {
             /* Model changed: preserve the extra-geom headroom and user-geom

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -389,36 +389,48 @@ impl MjRenderer {
         self.option = options;
     }
 
+    fn update_x_from(
+        &self,
+        model: &MjModel,
+        id: usize,
+        len: usize,
+        upload: fn(&MjrContext, &MjModel, usize),
+    ) -> Result<(), RendererError> {
+        if model.signature() != self.scene.signature() {
+            return Err(RendererError::SignatureMismatch);
+        }
+        if id >= len {
+            return Err(RendererError::IndexOutOfBounds { id, len });
+        }
+        self.gl_state.make_current().map_err(RendererError::GlutinError)?;
+        upload(&self.context, model, id);
+        Ok(())
+    }
+
     /// Re-uploads the texture with `texture_id` from `model` to the GPU immediately.
     ///
-    /// # Panics
-    /// Panics if `texture_id` is out of range, if the OpenGL context cannot be made current,
-    /// or if `model`'s signature does not match the renderer's current scene.
-    /// Call [`MjRenderer::sync_data`] first to ensure the models are in sync.
-    pub fn update_texture_from(&self, model: &MjModel, texture_id: usize) {
-        assert_eq!(
-            model.signature(), self.scene.signature(),
-            "model signature mismatch: call sync_data first"
-        );
-        self.gl_state.make_current().unwrap();
-        self.context.upload_texture(model, texture_id);
+    /// # Errors
+    /// - [`RendererError::SignatureMismatch`] if `model`'s signature does not match the renderer's scene.
+    /// - [`RendererError::IndexOutOfBounds`] if `texture_id >= model.ntex()`.
+    /// - [`RendererError::GlutinError`] if the OpenGL context cannot be made current.
+    pub fn update_texture_from(&self, model: &MjModel, texture_id: usize) -> Result<(), RendererError> {
+        self.update_x_from(model, texture_id, model.ntex() as usize, MjrContext::upload_texture)
     }
 
     /// Re-uploads all textures from `model` to the GPU immediately.
     ///
-    /// # Panics
-    /// Panics if the OpenGL context cannot be made current or if `model`'s signature does not
-    /// match the renderer's current scene.
-    /// Call [`MjRenderer::sync_data`] first to ensure the models are in sync.
-    pub fn update_textures_from(&self, model: &MjModel) {
-        assert_eq!(
-            model.signature(), self.scene.signature(),
-            "model signature mismatch: call sync_data first"
-        );
-        self.gl_state.make_current().unwrap();
-        for texture_id in 0..model.ntex() as usize {
-            self.context.upload_texture(model, texture_id);
+    /// # Errors
+    /// - [`RendererError::SignatureMismatch`] if `model`'s signature does not match the renderer's scene.
+    /// - [`RendererError::GlutinError`] if the OpenGL context cannot be made current.
+    pub fn update_textures_from(&self, model: &MjModel) -> Result<(), RendererError> {
+        if model.signature() != self.scene.signature() {
+            return Err(RendererError::SignatureMismatch);
         }
+        self.gl_state.make_current().map_err(RendererError::GlutinError)?;
+        for id in 0..model.ntex() as usize {
+            self.context.upload_texture(model, id);
+        }
+        Ok(())
     }
 
     /// Re-uploads the mesh with `mesh_id` from `model` to the GPU immediately.
@@ -430,73 +442,61 @@ impl MjRenderer {
     /// hull graph data (`mesh_graph`). Layout fields (address and count arrays) are
     /// not copied because they are fixed by the model signature.
     ///
-    /// # Panics
-    /// Panics if `mesh_id` is out of range, if the OpenGL context cannot be made current,
-    /// or if `model`'s signature does not match the renderer's current scene.
-    /// Call [`MjRenderer::sync_data`] first to ensure the models are in sync.
-    pub fn update_mesh_from(&self, model: &MjModel, mesh_id: usize) {
-        assert_eq!(
-            model.signature(), self.scene.signature(),
-            "model signature mismatch: call sync_data first"
-        );
-        self.gl_state.make_current().unwrap();
-        self.context.upload_mesh(model, mesh_id);
+    /// # Errors
+    /// - [`RendererError::SignatureMismatch`] if `model`'s signature does not match the renderer's scene.
+    /// - [`RendererError::IndexOutOfBounds`] if `mesh_id >= model.nmesh()`.
+    /// - [`RendererError::GlutinError`] if the OpenGL context cannot be made current.
+    pub fn update_mesh_from(&self, model: &MjModel, mesh_id: usize) -> Result<(), RendererError> {
+        self.update_x_from(model, mesh_id, model.nmesh() as usize, MjrContext::upload_mesh)
     }
 
     /// Re-uploads all meshes from `model` to the GPU immediately.
     ///
-    /// All data arrays read by `mjr_uploadMesh` are copied: vertex positions
+    /// All data arrays read by `mjr_uploadMesh` are bulk-uploaded: vertex positions
     /// (`mesh_vert`), per-vertex normals (`mesh_normal`), UV texture coordinates
     /// (`mesh_texcoord`), face--vertex indices (`mesh_face`), face--normal indices
     /// (`mesh_facenormal`), face--texcoord indices (`mesh_facetexcoord`), and convex
     /// hull graph data (`mesh_graph`). Layout fields (address and count arrays) are
     /// not copied because they are fixed by the model signature.
     ///
-    /// # Panics
-    /// Panics if the OpenGL context cannot be made current or if `model`'s signature does not
-    /// match the renderer's current scene.
-    /// Call [`MjRenderer::sync_data`] first to ensure the models are in sync.
-    pub fn update_meshes_from(&self, model: &MjModel) {
-        assert_eq!(
-            model.signature(), self.scene.signature(),
-            "model signature mismatch: call sync_data first"
-        );
-        self.gl_state.make_current().unwrap();
-        for mesh_id in 0..model.nmesh() as usize {
-            self.context.upload_mesh(model, mesh_id);
+    /// # Errors
+    /// - [`RendererError::SignatureMismatch`] if `model`'s signature does not match the renderer's scene.
+    /// - [`RendererError::GlutinError`] if the OpenGL context cannot be made current.
+    pub fn update_meshes_from(&self, model: &MjModel) -> Result<(), RendererError> {
+        if model.signature() != self.scene.signature() {
+            return Err(RendererError::SignatureMismatch);
         }
+        self.gl_state.make_current().map_err(RendererError::GlutinError)?;
+        for id in 0..model.nmesh() as usize {
+            self.context.upload_mesh(model, id);
+        }
+        Ok(())
     }
 
     /// Re-uploads the heightfield with `hfield_id` from `model` to the GPU immediately.
     ///
-    /// # Panics
-    /// Panics if `hfield_id` is out of range, if the OpenGL context cannot be made current,
-    /// or if `model`'s signature does not match the renderer's current scene.
-    /// Call [`MjRenderer::sync_data`] first to ensure the models are in sync.
-    pub fn update_hfield_from(&self, model: &MjModel, hfield_id: usize) {
-        assert_eq!(
-            model.signature(), self.scene.signature(),
-            "model signature mismatch: call sync_data first"
-        );
-        self.gl_state.make_current().unwrap();
-        self.context.upload_hfield(model, hfield_id);
+    /// # Errors
+    /// - [`RendererError::SignatureMismatch`] if `model`'s signature does not match the renderer's scene.
+    /// - [`RendererError::IndexOutOfBounds`] if `hfield_id >= model.nhfield()`.
+    /// - [`RendererError::GlutinError`] if the OpenGL context cannot be made current.
+    pub fn update_hfield_from(&self, model: &MjModel, hfield_id: usize) -> Result<(), RendererError> {
+        self.update_x_from(model, hfield_id, model.nhfield() as usize, MjrContext::upload_hfield)
     }
 
     /// Re-uploads all heightfields from `model` to the GPU immediately.
     ///
-    /// # Panics
-    /// Panics if the OpenGL context cannot be made current or if `model`'s signature does not
-    /// match the renderer's current scene.
-    /// Call [`MjRenderer::sync_data`] first to ensure the models are in sync.
-    pub fn update_hfields_from(&self, model: &MjModel) {
-        assert_eq!(
-            model.signature(), self.scene.signature(),
-            "model signature mismatch: call sync_data first"
-        );
-        self.gl_state.make_current().unwrap();
-        for hfield_id in 0..model.nhfield() as usize {
-            self.context.upload_hfield(model, hfield_id);
+    /// # Errors
+    /// - [`RendererError::SignatureMismatch`] if `model`'s signature does not match the renderer's scene.
+    /// - [`RendererError::GlutinError`] if the OpenGL context cannot be made current.
+    pub fn update_hfields_from(&self, model: &MjModel) -> Result<(), RendererError> {
+        if model.signature() != self.scene.signature() {
+            return Err(RendererError::SignatureMismatch);
         }
+        self.gl_state.make_current().map_err(RendererError::GlutinError)?;
+        for id in 0..model.nhfield() as usize {
+            self.context.upload_hfield(model, id);
+        }
+        Ok(())
     }
 
     /// Set the camera used for rendering.
@@ -840,6 +840,16 @@ pub enum RendererError {
     IoError(io::Error),
     /// A scene operation failed (e.g. user-scene sync overflowed the geom buffer).
     SceneError(crate::error::MjSceneError),
+    /// The model's structure signature does not match the renderer's scene.
+    /// Call [`MjRenderer::sync_data`] first.
+    SignatureMismatch,
+    /// The asset ID is out of range.
+    IndexOutOfBounds {
+        /// The ID that was supplied.
+        id: usize,
+        /// The number of assets in the model (the valid range is `0..len`).
+        len: usize,
+    },
 }
 
 /// Formats a human-readable description of the renderer error.
@@ -857,6 +867,10 @@ impl Display for RendererError {
             Self::DimensionMismatch => write!(f, "the input width and height don't match the renderer's configuration"),
             Self::IoError(e) => write!(f, "I/O error: {e}"),
             Self::SceneError(e) => write!(f, "scene error: {e}"),
+            Self::SignatureMismatch =>
+                write!(f, "model signature mismatch: call sync_data first"),
+            Self::IndexOutOfBounds { id, len } =>
+                write!(f, "asset id {id} is out of range [0, {len})"),
         }
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -393,17 +393,13 @@ impl MjRenderer {
         &self,
         model: &MjModel,
         id: usize,
-        len: usize,
-        upload: fn(&MjrContext, &MjModel, usize),
+        upload: fn(&MjrContext, &MjModel, usize) -> Result<(), crate::error::MjrContextError>,
     ) -> Result<(), RendererError> {
         if model.signature() != self.scene.signature() {
             return Err(RendererError::SignatureMismatch);
         }
-        if id >= len {
-            return Err(RendererError::IndexOutOfBounds { id, len });
-        }
         self.gl_state.make_current().map_err(RendererError::GlutinError)?;
-        upload(&self.context, model, id);
+        upload(&self.context, model, id)?;
         Ok(())
     }
 
@@ -411,10 +407,10 @@ impl MjRenderer {
     ///
     /// # Errors
     /// - [`RendererError::SignatureMismatch`] if `model`'s signature does not match the renderer's scene.
-    /// - [`RendererError::IndexOutOfBounds`] if `texture_id >= model.ntex()`.
+    /// - [`RendererError::ContextError`] if `texture_id >= model.ntex()`.
     /// - [`RendererError::GlutinError`] if the OpenGL context cannot be made current.
     pub fn update_texture_from(&self, model: &MjModel, texture_id: usize) -> Result<(), RendererError> {
-        self.update_x_from(model, texture_id, model.ntex() as usize, MjrContext::upload_texture)
+        self.update_x_from(model, texture_id, MjrContext::upload_texture)
     }
 
     /// Re-uploads all textures from `model` to the GPU immediately.
@@ -428,7 +424,7 @@ impl MjRenderer {
         }
         self.gl_state.make_current().map_err(RendererError::GlutinError)?;
         for id in 0..model.ntex() as usize {
-            self.context.upload_texture(model, id);
+            self.context.upload_texture(model, id).unwrap();
         }
         Ok(())
     }
@@ -444,10 +440,10 @@ impl MjRenderer {
     ///
     /// # Errors
     /// - [`RendererError::SignatureMismatch`] if `model`'s signature does not match the renderer's scene.
-    /// - [`RendererError::IndexOutOfBounds`] if `mesh_id >= model.nmesh()`.
+    /// - [`RendererError::ContextError`] if `mesh_id >= model.nmesh()`.
     /// - [`RendererError::GlutinError`] if the OpenGL context cannot be made current.
     pub fn update_mesh_from(&self, model: &MjModel, mesh_id: usize) -> Result<(), RendererError> {
-        self.update_x_from(model, mesh_id, model.nmesh() as usize, MjrContext::upload_mesh)
+        self.update_x_from(model, mesh_id, MjrContext::upload_mesh)
     }
 
     /// Re-uploads all meshes from `model` to the GPU immediately.
@@ -468,7 +464,7 @@ impl MjRenderer {
         }
         self.gl_state.make_current().map_err(RendererError::GlutinError)?;
         for id in 0..model.nmesh() as usize {
-            self.context.upload_mesh(model, id);
+            self.context.upload_mesh(model, id).unwrap();
         }
         Ok(())
     }
@@ -477,10 +473,10 @@ impl MjRenderer {
     ///
     /// # Errors
     /// - [`RendererError::SignatureMismatch`] if `model`'s signature does not match the renderer's scene.
-    /// - [`RendererError::IndexOutOfBounds`] if `hfield_id >= model.nhfield()`.
+    /// - [`RendererError::ContextError`] if `hfield_id >= model.nhfield()`.
     /// - [`RendererError::GlutinError`] if the OpenGL context cannot be made current.
     pub fn update_hfield_from(&self, model: &MjModel, hfield_id: usize) -> Result<(), RendererError> {
-        self.update_x_from(model, hfield_id, model.nhfield() as usize, MjrContext::upload_hfield)
+        self.update_x_from(model, hfield_id, MjrContext::upload_hfield)
     }
 
     /// Re-uploads all heightfields from `model` to the GPU immediately.
@@ -494,7 +490,7 @@ impl MjRenderer {
         }
         self.gl_state.make_current().map_err(RendererError::GlutinError)?;
         for id in 0..model.nhfield() as usize {
-            self.context.upload_hfield(model, id);
+            self.context.upload_hfield(model, id).unwrap();
         }
         Ok(())
     }
@@ -840,16 +836,11 @@ pub enum RendererError {
     IoError(io::Error),
     /// A scene operation failed (e.g. user-scene sync overflowed the geom buffer).
     SceneError(crate::error::MjSceneError),
+    /// A rendering-context operation failed (e.g. an asset or aux-buffer ID is out of range).
+    ContextError(crate::error::MjrContextError),
     /// The model's structure signature does not match the renderer's scene.
     /// Call [`MjRenderer::sync_data`] first.
     SignatureMismatch,
-    /// The asset ID is out of range.
-    IndexOutOfBounds {
-        /// The ID that was supplied.
-        id: usize,
-        /// The number of assets in the model (the valid range is `0..len`).
-        len: usize,
-    },
 }
 
 /// Formats a human-readable description of the renderer error.
@@ -867,10 +858,9 @@ impl Display for RendererError {
             Self::DimensionMismatch => write!(f, "the input width and height don't match the renderer's configuration"),
             Self::IoError(e) => write!(f, "I/O error: {e}"),
             Self::SceneError(e) => write!(f, "scene error: {e}"),
+            Self::ContextError(e) => write!(f, "rendering context error: {e}"),
             Self::SignatureMismatch =>
                 write!(f, "model signature mismatch: call sync_data first"),
-            Self::IndexOutOfBounds { id, len } =>
-                write!(f, "asset id {id} is out of range [0, {len})"),
         }
     }
 }
@@ -886,6 +876,7 @@ impl Error for RendererError {
             Self::GlutinError(e) => Some(e),
             Self::IoError(e) => Some(e),
             Self::SceneError(e) => Some(e),
+            Self::ContextError(e) => Some(e),
             _ => None,
         }
     }
@@ -909,6 +900,13 @@ impl From<png::EncodingError> for RendererError {
 impl From<crate::error::MjSceneError> for RendererError {
     fn from(e: crate::error::MjSceneError) -> Self {
         Self::SceneError(e)
+    }
+}
+
+/// Converts an [`MjrContextError`] into [`RendererError::ContextError`].
+impl From<crate::error::MjrContextError> for RendererError {
+    fn from(e: crate::error::MjrContextError) -> Self {
+        Self::ContextError(e)
     }
 }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -771,8 +771,8 @@ impl MjRenderer {
     ///
     /// # Errors
     /// - [`RendererError::GlutinError`] if the OpenGL context could not be made current.
-    /// - [`RendererError::SceneError`] if the user-scene sync overflows the geom buffer
-    ///   or if reading pixels from the framebuffer fails.
+    /// - [`RendererError::SceneError`] if the user-scene sync overflows the geom buffer.
+    /// - [`RendererError::ContextError`] if reading pixels from the framebuffer fails.
     pub fn render(&mut self) -> Result<(), RendererError> {
         /* Sync user scene geoms into the main scene before rendering */
         sync_geoms(&self.user_scene, &mut self.scene).map_err(RendererError::SceneError)?;
@@ -790,7 +790,7 @@ impl MjRenderer {
             flat_rgb,
             flat_depth,
             &vp
-        ).map_err(RendererError::SceneError)?;
+        ).map_err(RendererError::ContextError)?;
 
         /* Flip the read pixels vertically, as OpenGL reads bottom-up */
         if let Some(rgb) = self.rgb.as_deref_mut() {
@@ -903,7 +903,7 @@ impl From<crate::error::MjSceneError> for RendererError {
     }
 }
 
-/// Converts an [`MjrContextError`] into [`RendererError::ContextError`].
+/// Converts an [`crate::error::MjrContextError`] into [`RendererError::ContextError`].
 impl From<crate::error::MjrContextError> for RendererError {
     fn from(e: crate::error::MjrContextError) -> Self {
         Self::ContextError(e)

--- a/src/util.rs
+++ b/src/util.rs
@@ -40,6 +40,7 @@ pub(crate) fn write_ascii_to_buf(buf: &mut [c_char], value: &str) {
 /// ```ignore
 /// let len = optional_addr_len(model.mesh_graphadr(), mesh_id, model.mesh_graph().len());
 /// ```
+#[cfg(feature = "viewer")]
 pub(crate) fn optional_addr_len(addr_array: &[i32], id: usize, data_len: usize) -> usize {
     let adr = addr_array[id];
     if adr < 0 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,7 +25,38 @@ pub(crate) fn write_ascii_to_buf(buf: &mut [c_char], value: &str) {
     dest[bytes.len()..].fill(0);
 }
 
-/// Sets or clears a bit flag based on a boolean value.
+/// Returns the number of elements belonging to item `id` inside a packed data array,
+/// given an address array where each entry is either the item's start offset in the data
+/// array or `-1` (meaning the item has no data).
+///
+/// The length is determined by scanning `addr_array[id + 1..]` for the first entry that
+/// is `!= -1` (i.e., the next item that *does* have data). If no such entry exists the
+/// region extends to the end of the data array (`data_len`).
+///
+/// # Panics
+/// Panics if `addr_array[id]` is negative but not `-1` (malformed model data).
+///
+/// # Examples
+/// ```ignore
+/// let len = optional_addr_len(model.mesh_graphadr(), mesh_id, model.mesh_graph().len());
+/// ```
+pub(crate) fn optional_addr_len(addr_array: &[i32], id: usize, data_len: usize) -> usize {
+    let adr = addr_array[id];
+    if adr < 0 {
+        return 0;
+    }
+    let adr = adr as usize;
+    addr_array
+        .get(id + 1..)
+        .unwrap_or(&[])
+        .iter()
+        .find(|&&next| next != -1)
+        .map(|&next| next as usize)
+        .unwrap_or(data_len)
+        - adr
+}
+
+
 ///
 /// # Examples
 /// ```ignore

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -23,11 +23,11 @@ use bitflags::bitflags;
 
 use crate::wrappers::mj_rendering::{MjrContext, MjrRectangle, MjtFont, MjtGridPos};
 use crate::vis_common::{sync_geoms, flip_image_vertically, write_png};
+use crate::util::{optional_addr_len, LockUnpoison, ThreeWayMerge};
 use crate::wrappers::mj_auxiliary::{MjVisual, MjStatistic};
 use crate::winit_gl_base::{RenderBaseGlState, RenderBase};
 use crate::wrappers::mj_primitive::{MjtNum, MjtSize};
 use crate::wrappers::mj_data::{MjData, MjtState};
-use crate::util::{LockUnpoison, ThreeWayMerge};
 use crate::{builder_setters, mujoco_version};
 use crate::wrappers::mj_option::MjOption;
 use crate::wrappers::mj_visualization::*;
@@ -216,10 +216,10 @@ pub struct ViewerSharedState {
     prev_vis: MjVisual,
     prev_stat: MjStatistic,
 
-    /* Pending GPU asset re-uploads */
-    texture_reupload_pending: bool,
-    mesh_reupload_pending: bool,
-    hfield_reupload_pending: bool,
+    /* Pending GPU asset re-uploads: contains the IDs to upload on the next render call */
+    texture_reupload_pending: Vec<usize>,
+    mesh_reupload_pending: Vec<usize>,
+    hfield_reupload_pending: Vec<usize>,
 }
 
 impl ViewerSharedState {
@@ -248,9 +248,9 @@ impl ViewerSharedState {
             prev_vis: MjVisual::default(),
             prev_stat: MjStatistic::default(),
             /* Pending GPU asset re-uploads */
-            texture_reupload_pending: false,
-            mesh_reupload_pending: false,
-            hfield_reupload_pending: false,
+            texture_reupload_pending: Vec::new(),
+            mesh_reupload_pending: Vec::new(),
+            hfield_reupload_pending: Vec::new(),
         };
 
         shared_state.reload_model(&model, max_user_geom);
@@ -281,9 +281,9 @@ impl ViewerSharedState {
         self.pert = MjvPerturb::default();
         // Clear pending re-uploads: the new context will already have the model's
         // GPU resources loaded from scratch.
-        self.texture_reupload_pending = false;
-        self.mesh_reupload_pending = false;
-        self.hfield_reupload_pending = false;
+        self.texture_reupload_pending.clear();
+        self.mesh_reupload_pending.clear();
+        self.hfield_reupload_pending.clear();
     }
 
     /// Checks whether the viewer is still running or is supposed to run.
@@ -365,11 +365,38 @@ impl ViewerSharedState {
         self.last_stat_sync_time
     }
 
-    /// Copies texture pixel data from `model` into the viewer's internal passive model
+    /// Copies the texture with `texture_id` from `model` into the viewer's internal passive model
     /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
     ///
     /// The upload is processed on the next call to [`MjViewer::render`], at which point
-    /// all textures will reflect the data copied here.
+    /// the updated texture will be reflected in the scene.
+    ///
+    /// # Panics
+    /// Panics if `texture_id` is out of range or if `model`'s signature does not match the
+    /// viewer's passive model (the models have a different structure). Call
+    /// [`ViewerSharedState::sync_model`] or [`ViewerSharedState::sync_data`] first to ensure
+    /// the models are in sync.
+    pub fn update_texture_from(&mut self, model: &MjModel, texture_id: usize) {
+        assert_eq!(
+            model.signature(), self.data_passive.model().signature(),
+            "model signature mismatch: call sync_model / sync_data first"
+        );
+        let tex_adr = model.tex_adr()[texture_id] as usize;
+        let tex_width = model.tex_width()[texture_id] as usize;
+        let tex_height = model.tex_height()[texture_id] as usize;
+        let tex_nchannel = model.tex_nchannel()[texture_id] as usize;
+        let tex_len = tex_width * tex_height * tex_nchannel;
+
+        // SAFETY: The model signature is verified above, so the texture layout matches.
+        // The selected texture slice is bounded by its own width/height/channel metadata.
+        unsafe { self.data_passive.model_mut() }
+            .tex_data_mut()[tex_adr..tex_adr + tex_len]
+            .copy_from_slice(&model.tex_data()[tex_adr..tex_adr + tex_len]);
+        self.texture_reupload_pending.push(texture_id);
+    }
+
+    /// Copies all textures from `model` into the viewer's internal passive model
+    /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
     ///
     /// # Panics
     /// Panics if `model`'s signature does not match the viewer's passive model (the models
@@ -380,17 +407,14 @@ impl ViewerSharedState {
             model.signature(), self.data_passive.model().signature(),
             "model signature mismatch: call sync_model / sync_data first"
         );
-        // SAFETY: We only overwrite texture pixel data (`tex_data`). This array has a
-        // fixed layout determined by the model signature, which we verified above, so
-        // the sizes are guaranteed to match. No structural MuJoCo invariants are affected
-        // by changing pixel values.
+        // SAFETY: Signature verified above, so tex_data layouts match exactly.
         unsafe { self.data_passive.model_mut() }
             .tex_data_mut()
             .copy_from_slice(model.tex_data());
-        self.texture_reupload_pending = true;
+        self.texture_reupload_pending.extend(0..model.ntex() as usize);
     }
 
-    /// Copies mesh geometry data from `model` into the viewer's internal passive model
+    /// Copies the mesh with `mesh_id` from `model` into the viewer's internal passive model
     /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
     ///
     /// All data arrays read by `mjr_uploadMesh` are copied: vertex positions
@@ -401,7 +425,66 @@ impl ViewerSharedState {
     /// not copied because they are fixed by the model signature.
     ///
     /// The upload is processed on the next call to [`MjViewer::render`], at which point
-    /// all meshes will reflect the data copied here.
+    /// the updated mesh will be reflected in the scene.
+    ///
+    /// # Panics
+    /// Panics if `mesh_id` is out of range or if `model`'s signature does not match the
+    /// viewer's passive model (the models have a different structure). Call
+    /// [`ViewerSharedState::sync_model`] or [`ViewerSharedState::sync_data`] first to ensure
+    /// the models are in sync.
+    pub fn update_mesh_from(&mut self, model: &MjModel, mesh_id: usize) {
+        assert_eq!(
+            model.signature(), self.data_passive.model().signature(),
+            "model signature mismatch: call sync_model / sync_data first"
+        );
+
+        let vert_adr = model.mesh_vertadr()[mesh_id] as usize;
+        let vert_num = model.mesh_vertnum()[mesh_id] as usize;
+        let normal_adr = model.mesh_normaladr()[mesh_id] as usize;
+        let normal_num = model.mesh_normalnum()[mesh_id] as usize;
+        let texcoord_adr = model.mesh_texcoordadr()[mesh_id];
+        let texcoord_num = model.mesh_texcoordnum()[mesh_id] as usize;
+        let face_adr = model.mesh_faceadr()[mesh_id] as usize;
+        let face_num = model.mesh_facenum()[mesh_id] as usize;
+        let graph_adr = model.mesh_graphadr()[mesh_id];
+        let mesh_graph_len = optional_addr_len(model.mesh_graphadr(), mesh_id, model.mesh_graph().len());
+
+        // SAFETY: The model signature is verified above, so the mesh layout matches.
+        // Indices and counts are taken from the selected mesh's own metadata.
+        let passive = unsafe { self.data_passive.model_mut() };
+        passive.mesh_vert_mut()[vert_adr..vert_adr + vert_num]
+            .copy_from_slice(&model.mesh_vert()[vert_adr..vert_adr + vert_num]);
+        passive.mesh_normal_mut()[normal_adr..normal_adr + normal_num]
+            .copy_from_slice(&model.mesh_normal()[normal_adr..normal_adr + normal_num]);
+        if texcoord_adr >= 0 {
+            let texcoord_adr = texcoord_adr as usize;
+            passive.mesh_texcoord_mut()[texcoord_adr..texcoord_adr + texcoord_num]
+                .copy_from_slice(&model.mesh_texcoord()[texcoord_adr..texcoord_adr + texcoord_num]);
+        }
+        unsafe {
+            passive.mesh_face_mut()[face_adr..face_adr + face_num]
+                .copy_from_slice(&model.mesh_face()[face_adr..face_adr + face_num]);
+            passive.mesh_facenormal_mut()[face_adr..face_adr + face_num]
+                .copy_from_slice(&model.mesh_facenormal()[face_adr..face_adr + face_num]);
+            passive.mesh_facetexcoord_mut()[face_adr..face_adr + face_num]
+                .copy_from_slice(&model.mesh_facetexcoord()[face_adr..face_adr + face_num]);
+            if let Some(graph_adr) = (graph_adr >= 0).then_some(graph_adr as usize) {
+                passive.mesh_graph_mut()[graph_adr..graph_adr + mesh_graph_len]
+                    .copy_from_slice(&model.mesh_graph()[graph_adr..graph_adr + mesh_graph_len]);
+            }
+        }
+        self.mesh_reupload_pending.push(mesh_id);
+    }
+
+    /// Copies all meshes from `model` into the viewer's internal passive model
+    /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
+    ///
+    /// All data arrays read by `mjr_uploadMesh` are bulk-copied: vertex positions
+    /// (`mesh_vert`), per-vertex normals (`mesh_normal`), UV texture coordinates
+    /// (`mesh_texcoord`), face--vertex indices (`mesh_face`), face--normal indices
+    /// (`mesh_facenormal`), face--texcoord indices (`mesh_facetexcoord`), and convex
+    /// hull graph data (`mesh_graph`). Layout fields (address and count arrays) are
+    /// not copied because they are fixed by the model signature.
     ///
     /// # Panics
     /// Panics if `model`'s signature does not match the viewer's passive model (the models
@@ -412,11 +495,9 @@ impl ViewerSharedState {
             model.signature(), self.data_passive.model().signature(),
             "model signature mismatch: call sync_model / sync_data first"
         );
-        // SAFETY: We overwrite all data arrays that `mjr_uploadMesh` reads from the model.
-        // The model signature is verified above, guaranteeing that all array lengths match
-        // between source and destination. The face/graph accessors are `unsafe` on `MjModel`
-        // because supplying out-of-range indices is UB; here we are only copying from one
-        // same-layout model to another, so no indices are constructed or validated.
+        // SAFETY: Signature verified above, ensuring all mesh array layouts match exactly.
+        // The face/graph accessors are `unsafe` on `MjModel` because supplying out-of-range
+        // indices is UB; here we are only bulk-copying between same-layout models.
         let passive = unsafe { self.data_passive.model_mut() };
         passive.mesh_vert_mut().copy_from_slice(model.mesh_vert());
         passive.mesh_normal_mut().copy_from_slice(model.mesh_normal());
@@ -427,14 +508,40 @@ impl ViewerSharedState {
             passive.mesh_facetexcoord_mut().copy_from_slice(model.mesh_facetexcoord());
             passive.mesh_graph_mut().copy_from_slice(model.mesh_graph());
         }
-        self.mesh_reupload_pending = true;
+        self.mesh_reupload_pending.extend(0..model.nmesh() as usize);
     }
 
-    /// Copies heightfield elevation data from `model` into the viewer's internal passive model
+    /// Copies the heightfield with `hfield_id` from `model` into the viewer's internal passive model
     /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
     ///
     /// The upload is processed on the next call to [`MjViewer::render`], at which point
-    /// all heightfields will reflect the data copied here.
+    /// the updated heightfield will be reflected in the scene.
+    ///
+    /// # Panics
+    /// Panics if `hfield_id` is out of range or if `model`'s signature does not match the
+    /// viewer's passive model (the models have a different structure). Call
+    /// [`ViewerSharedState::sync_model`] or [`ViewerSharedState::sync_data`] first to ensure
+    /// the models are in sync.
+    pub fn update_hfield_from(&mut self, model: &MjModel, hfield_id: usize) {
+        assert_eq!(
+            model.signature(), self.data_passive.model().signature(),
+            "model signature mismatch: call sync_model / sync_data first"
+        );
+        let hfield_adr = model.hfield_adr()[hfield_id] as usize;
+        let hfield_nrow = model.hfield_nrow()[hfield_id] as usize;
+        let hfield_ncol = model.hfield_ncol()[hfield_id] as usize;
+        let hfield_len = hfield_nrow * hfield_ncol;
+
+        // SAFETY: The model signature is verified above, so the heightfield layout matches.
+        // The selected heightfield slice is bounded by its row/column metadata.
+        unsafe { self.data_passive.model_mut() }
+            .hfield_data_mut()[hfield_adr..hfield_adr + hfield_len]
+            .copy_from_slice(&model.hfield_data()[hfield_adr..hfield_adr + hfield_len]);
+        self.hfield_reupload_pending.push(hfield_id);
+    }
+
+    /// Copies all heightfields from `model` into the viewer's internal passive model
+    /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
     ///
     /// # Panics
     /// Panics if `model`'s signature does not match the viewer's passive model (the models
@@ -445,12 +552,11 @@ impl ViewerSharedState {
             model.signature(), self.data_passive.model().signature(),
             "model signature mismatch: call sync_model / sync_data first"
         );
-        // SAFETY: We only overwrite heightfield elevation data (`hfield_data`). The
-        // model signature is verified above, so the array length matches.
+        // SAFETY: Signature verified above, so hfield_data layouts match exactly.
         unsafe { self.data_passive.model_mut() }
             .hfield_data_mut()
             .copy_from_slice(model.hfield_data());
-        self.hfield_reupload_pending = true;
+        self.hfield_reupload_pending.extend(0..model.nhfield() as usize);
     }
 
 
@@ -862,7 +968,19 @@ impl MjViewer {
         self.shared_state.lock_unpoison().sync_model_stat(stat);
     }
 
-    /// Copies texture pixel data from `model` into the viewer's internal passive model
+    /// Copies the texture with `texture_id` from `model` into the viewer's internal passive model
+    /// and schedules a GPU re-upload for the next [`render`](Self::render) call.
+    ///
+    /// This is a proxy to [`ViewerSharedState::update_texture_from`].
+    ///
+    /// # Panics
+    /// Panics if `model`'s signature does not match the viewer's passive model.
+    /// Call [`sync_model`](Self::sync_model) or [`sync_data`](Self::sync_data) first.
+    pub fn update_texture_from(&mut self, model: &MjModel, texture_id: usize) {
+        self.shared_state.lock_unpoison().update_texture_from(model, texture_id);
+    }
+
+    /// Copies all textures from `model` into the viewer's internal passive model
     /// and schedules a GPU re-upload for the next [`render`](Self::render) call.
     ///
     /// This is a proxy to [`ViewerSharedState::update_textures_from`].
@@ -874,7 +992,19 @@ impl MjViewer {
         self.shared_state.lock_unpoison().update_textures_from(model);
     }
 
-    /// Copies mesh geometry data from `model` into the viewer's internal passive model
+    /// Copies the mesh with `mesh_id` from `model` into the viewer's internal passive model
+    /// and schedules a GPU re-upload for the next [`render`](Self::render) call.
+    ///
+    /// This is a proxy to [`ViewerSharedState::update_mesh_from`].
+    ///
+    /// # Panics
+    /// Panics if `model`'s signature does not match the viewer's passive model.
+    /// Call [`sync_model`](Self::sync_model) or [`sync_data`](Self::sync_data) first.
+    pub fn update_mesh_from(&mut self, model: &MjModel, mesh_id: usize) {
+        self.shared_state.lock_unpoison().update_mesh_from(model, mesh_id);
+    }
+
+    /// Copies all meshes from `model` into the viewer's internal passive model
     /// and schedules a GPU re-upload for the next [`render`](Self::render) call.
     ///
     /// This is a proxy to [`ViewerSharedState::update_meshes_from`].
@@ -886,7 +1016,19 @@ impl MjViewer {
         self.shared_state.lock_unpoison().update_meshes_from(model);
     }
 
-    /// Copies heightfield elevation data from `model` into the viewer's internal passive model
+    /// Copies the heightfield with `hfield_id` from `model` into the viewer's internal passive model
+    /// and schedules a GPU re-upload for the next [`render`](Self::render) call.
+    ///
+    /// This is a proxy to [`ViewerSharedState::update_hfield_from`].
+    ///
+    /// # Panics
+    /// Panics if `model`'s signature does not match the viewer's passive model.
+    /// Call [`sync_model`](Self::sync_model) or [`sync_data`](Self::sync_data) first.
+    pub fn update_hfield_from(&mut self, model: &MjModel, hfield_id: usize) {
+        self.shared_state.lock_unpoison().update_hfield_from(model, hfield_id);
+    }
+
+    /// Copies all heightfields from `model` into the viewer's internal passive model
     /// and schedules a GPU re-upload for the next [`render`](Self::render) call.
     ///
     /// This is a proxy to [`ViewerSharedState::update_hfields_from`].
@@ -1096,24 +1238,15 @@ impl MjViewer {
             }
 
             // Process any pending GPU asset re-uploads. The GL context is current here
-            // (ensured by render()). Each dirty flag is cleared after the upload.
-            if *texture_reupload_pending {
-                for id in 0..data_passive.model().ntex() as usize {
-                    self.context.upload_texture(data_passive.model(), id);
-                }
-                *texture_reupload_pending = false;
+            // (ensured by render()). Each vec is drained after uploading.
+            for id in texture_reupload_pending.drain(..) {
+                self.context.upload_texture(data_passive.model(), id);
             }
-            if *mesh_reupload_pending {
-                for id in 0..data_passive.model().nmesh() as usize {
-                    self.context.upload_mesh(data_passive.model(), id);
-                }
-                *mesh_reupload_pending = false;
+            for id in mesh_reupload_pending.drain(..) {
+                self.context.upload_mesh(data_passive.model(), id);
             }
-            if *hfield_reupload_pending {
-                for id in 0..data_passive.model().nhfield() as usize {
-                    self.context.upload_hfield(data_passive.model(), id);
-                }
-                *hfield_reupload_pending = false;
+            for id in hfield_reupload_pending.drain(..) {
+                self.context.upload_hfield(data_passive.model(), id);
             }
 
             // Update and render the scene from the MjData state
@@ -1870,4 +2003,3 @@ bitflags! {
         const RIGHT = 1 << 2;
     }
 }
-

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -454,6 +454,7 @@ impl ViewerSharedState {
     }
 
 
+    /// Same as [`ViewerSharedState::sync_data`], except it copies the entire [`MjData`]
     /// struct (including large Jacobian and other arrays), not just the state needed for visualization.
     ///
     /// # Panics
@@ -898,7 +899,9 @@ impl MjViewer {
     }
 
 
+    /// Processes the UI (when enabled), processes events, draws the scene
     /// and swaps buffers in OpenGL.
+    ///
     /// # Errors
     /// - [`MjViewerError::GlutinError`] if the OpenGL context cannot be made current or the buffer swap fails.
     /// - [`MjViewerError::SceneError`] if synchronizing user scene geoms fails (e.g. the scene is

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 use std::ops::{Deref, DerefMut};
+use std::collections::BTreeSet;
 use std::num::NonZero;
 use std::error::Error;
 use std::fmt::Display;
@@ -217,9 +218,9 @@ pub struct ViewerSharedState {
     prev_stat: MjStatistic,
 
     /* Pending GPU asset re-uploads: contains the IDs to upload on the next render call */
-    texture_reupload_pending: Vec<usize>,
-    mesh_reupload_pending: Vec<usize>,
-    hfield_reupload_pending: Vec<usize>,
+    texture_reupload_pending: BTreeSet<usize>,
+    mesh_reupload_pending: BTreeSet<usize>,
+    hfield_reupload_pending: BTreeSet<usize>,
 }
 
 impl ViewerSharedState {
@@ -248,9 +249,9 @@ impl ViewerSharedState {
             prev_vis: MjVisual::default(),
             prev_stat: MjStatistic::default(),
             /* Pending GPU asset re-uploads */
-            texture_reupload_pending: Vec::new(),
-            mesh_reupload_pending: Vec::new(),
-            hfield_reupload_pending: Vec::new(),
+            texture_reupload_pending: BTreeSet::new(),
+            mesh_reupload_pending: BTreeSet::new(),
+            hfield_reupload_pending: BTreeSet::new(),
         };
 
         shared_state.reload_model(&model, max_user_geom);
@@ -392,7 +393,7 @@ impl ViewerSharedState {
         unsafe { self.data_passive.model_mut() }
             .tex_data_mut()[tex_adr..tex_adr + tex_len]
             .copy_from_slice(&model.tex_data()[tex_adr..tex_adr + tex_len]);
-        self.texture_reupload_pending.push(texture_id);
+        self.texture_reupload_pending.insert(texture_id);
     }
 
     /// Copies all textures from `model` into the viewer's internal passive model
@@ -473,7 +474,7 @@ impl ViewerSharedState {
                     .copy_from_slice(&model.mesh_graph()[graph_adr..graph_adr + mesh_graph_len]);
             }
         }
-        self.mesh_reupload_pending.push(mesh_id);
+        self.mesh_reupload_pending.insert(mesh_id);
     }
 
     /// Copies all meshes from `model` into the viewer's internal passive model
@@ -537,7 +538,7 @@ impl ViewerSharedState {
         unsafe { self.data_passive.model_mut() }
             .hfield_data_mut()[hfield_adr..hfield_adr + hfield_len]
             .copy_from_slice(&model.hfield_data()[hfield_adr..hfield_adr + hfield_len]);
-        self.hfield_reupload_pending.push(hfield_id);
+        self.hfield_reupload_pending.insert(hfield_id);
     }
 
     /// Copies all heightfields from `model` into the viewer's internal passive model
@@ -1238,14 +1239,14 @@ impl MjViewer {
             }
 
             // Process any pending GPU asset re-uploads. The GL context is current here
-            // (ensured by render()). Each vec is drained after uploading.
-            for id in texture_reupload_pending.drain(..) {
+            // (ensured by render()). Each set is taken (leaving an empty set) and iterated.
+            for id in std::mem::take(texture_reupload_pending) {
                 self.context.upload_texture(data_passive.model(), id);
             }
-            for id in mesh_reupload_pending.drain(..) {
+            for id in std::mem::take(mesh_reupload_pending) {
                 self.context.upload_mesh(data_passive.model(), id);
             }
-            for id in hfield_reupload_pending.drain(..) {
+            for id in std::mem::take(hfield_reupload_pending) {
                 self.context.upload_hfield(data_passive.model(), id);
             }
 

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -214,7 +214,12 @@ pub struct ViewerSharedState {
     /* Model parameter change tracking */
     prev_opt: MjOption,
     prev_vis: MjVisual,
-    prev_stat: MjStatistic
+    prev_stat: MjStatistic,
+
+    /* Pending GPU asset re-uploads */
+    texture_reupload_pending: bool,
+    mesh_reupload_pending: bool,
+    hfield_reupload_pending: bool,
 }
 
 impl ViewerSharedState {
@@ -242,6 +247,10 @@ impl ViewerSharedState {
             prev_opt: MjOption::default(),
             prev_vis: MjVisual::default(),
             prev_stat: MjStatistic::default(),
+            /* Pending GPU asset re-uploads */
+            texture_reupload_pending: false,
+            mesh_reupload_pending: false,
+            hfield_reupload_pending: false,
         };
 
         shared_state.reload_model(&model, max_user_geom);
@@ -270,6 +279,11 @@ impl ViewerSharedState {
         self.data_state_buffer = self.data_passive_state.clone();
         self.realtime_factor_smooth = 1.0;
         self.pert = MjvPerturb::default();
+        // Clear pending re-uploads: the new context will already have the model's
+        // GPU resources loaded from scratch.
+        self.texture_reupload_pending = false;
+        self.mesh_reupload_pending = false;
+        self.hfield_reupload_pending = false;
     }
 
     /// Checks whether the viewer is still running or is supposed to run.
@@ -336,15 +350,6 @@ impl ViewerSharedState {
         self.last_stat_sync_time = Instant::now();
     }
 
-    /// Copies [`MjModel::hfield_data`] from `model` to the internal passive model,
-    /// and performs a GPU reupload.
-    /// 
-    /// # Panics
-    /// Panics when the input `model` has a different length of height-field data.
-    pub fn update_hfields(&mut self, model: &MjModel) {
-        unsafe { self.data_passive.model_mut() }.hfield_data_mut().copy_from_slice(model.hfield_data());
-    }
-
     /// Returns the last time physics options (opt) were synced.
     pub fn last_opt_sync_time(&self) -> Instant {
         self.last_opt_sync_time
@@ -360,7 +365,106 @@ impl ViewerSharedState {
         self.last_stat_sync_time
     }
 
-    /// Same as [`ViewerSharedState::sync_data`], except it copies the entire [`MjData`]
+    /// Copies texture pixel data from `model` into the viewer's internal passive model
+    /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
+    ///
+    /// The upload is processed asynchronously on the next call to
+    /// [`MjViewer::render`] / [`MjViewer::update_scene`], at which point all textures
+    /// will reflect the data copied here.
+    ///
+    /// # Panics
+    /// Panics if `model`'s signature does not match the viewer's passive model (the models
+    /// have a different structure). Call [`ViewerSharedState::sync_model`] or
+    /// [`ViewerSharedState::sync_data`] first to ensure the models are in sync.
+    pub fn update_textures_from(&mut self, model: &MjModel) {
+        assert_eq!(
+            model.signature(), self.data_passive.model().signature(),
+            "model signature mismatch: call sync_model / sync_data first"
+        );
+        // SAFETY: We only overwrite texture pixel data (`tex_data`). This array has a
+        // fixed layout determined by the model signature, which we verified above, so
+        // the sizes are guaranteed to match. No structural MuJoCo invariants are affected
+        // by changing pixel values.
+        unsafe { self.data_passive.model_mut() }
+            .tex_data_mut()
+            .copy_from_slice(model.tex_data());
+        self.texture_reupload_pending = true;
+    }
+
+    /// Copies mesh geometry data from `model` into the viewer's internal passive model
+    /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
+    ///
+    /// The upload is processed asynchronously on the next call to
+    /// [`MjViewer::render`] / [`MjViewer::update_scene`], at which point all meshes
+    /// will reflect the data copied here.
+    ///
+    /// # Panics
+    /// Panics if `model`'s signature does not match the viewer's passive model (the models
+    /// have a different structure). Call [`ViewerSharedState::sync_model`] or
+    /// [`ViewerSharedState::sync_data`] first to ensure the models are in sync.
+    pub fn update_meshes_from(&mut self, model: &MjModel) {
+        assert_eq!(
+            model.signature(), self.data_passive.model().signature(),
+            "model signature mismatch: call sync_model / sync_data first"
+        );
+        // SAFETY: We copy mesh geometry arrays (vertex positions, normals, texcoords,
+        // face indices). The model signature is verified above, so all array lengths
+        // match between source and destination.
+        let passive = unsafe { self.data_passive.model_mut() };
+        passive.mesh_vert_mut().copy_from_slice(model.mesh_vert());
+        passive.mesh_normal_mut().copy_from_slice(model.mesh_normal());
+        passive.mesh_texcoord_mut().copy_from_slice(model.mesh_texcoord());
+        unsafe {
+            passive.mesh_face_mut().copy_from_slice(model.mesh_face());
+            passive.mesh_facenormal_mut().copy_from_slice(model.mesh_facenormal());
+            passive.mesh_facetexcoord_mut().copy_from_slice(model.mesh_facetexcoord());
+        }
+        self.mesh_reupload_pending = true;
+    }
+
+    /// Copies heightfield elevation data from `model` into the viewer's internal passive model
+    /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
+    ///
+    /// The upload is processed asynchronously on the next call to
+    /// [`MjViewer::render`] / [`MjViewer::update_scene`], at which point all heightfields
+    /// will reflect the data copied here.
+    ///
+    /// # Panics
+    /// Panics if `model`'s signature does not match the viewer's passive model (the models
+    /// have a different structure). Call [`ViewerSharedState::sync_model`] or
+    /// [`ViewerSharedState::sync_data`] first to ensure the models are in sync.
+    pub fn update_hfields_from(&mut self, model: &MjModel) {
+        assert_eq!(
+            model.signature(), self.data_passive.model().signature(),
+            "model signature mismatch: call sync_model / sync_data first"
+        );
+        // SAFETY: We only overwrite heightfield elevation data (`hfield_data`). The
+        // model signature is verified above, so the array length matches.
+        unsafe { self.data_passive.model_mut() }
+            .hfield_data_mut()
+            .copy_from_slice(model.hfield_data());
+        self.hfield_reupload_pending = true;
+    }
+
+    /// Returns `true` if a texture re-upload is pending (scheduled but not yet processed
+    /// by the render thread).
+    pub fn texture_reupload_pending(&self) -> bool {
+        self.texture_reupload_pending
+    }
+
+    /// Returns `true` if a mesh re-upload is pending (scheduled but not yet processed
+    /// by the render thread).
+    pub fn mesh_reupload_pending(&self) -> bool {
+        self.mesh_reupload_pending
+    }
+
+    /// Returns `true` if a heightfield re-upload is pending (scheduled but not yet processed
+    /// by the render thread).
+    pub fn hfield_reupload_pending(&self) -> bool {
+        self.hfield_reupload_pending
+    }
+
+
     /// struct (including large Jacobian and other arrays), not just the state needed for visualization.
     ///
     /// # Panics
@@ -768,7 +872,43 @@ impl MjViewer {
         self.shared_state.lock_unpoison().sync_model_stat(stat);
     }
 
-    /// Processes the UI (when enabled), processes events, draws the scene
+    /// Copies texture pixel data from `model` into the viewer's internal passive model
+    /// and schedules a GPU re-upload for the next [`render`](Self::render) call.
+    ///
+    /// This is a proxy to [`ViewerSharedState::update_textures_from`].
+    ///
+    /// # Panics
+    /// Panics if `model`'s signature does not match the viewer's passive model.
+    /// Call [`sync_model`](Self::sync_model) or [`sync_data`](Self::sync_data) first.
+    pub fn update_textures_from(&mut self, model: &MjModel) {
+        self.shared_state.lock_unpoison().update_textures_from(model);
+    }
+
+    /// Copies mesh geometry data from `model` into the viewer's internal passive model
+    /// and schedules a GPU re-upload for the next [`render`](Self::render) call.
+    ///
+    /// This is a proxy to [`ViewerSharedState::update_meshes_from`].
+    ///
+    /// # Panics
+    /// Panics if `model`'s signature does not match the viewer's passive model.
+    /// Call [`sync_model`](Self::sync_model) or [`sync_data`](Self::sync_data) first.
+    pub fn update_meshes_from(&mut self, model: &MjModel) {
+        self.shared_state.lock_unpoison().update_meshes_from(model);
+    }
+
+    /// Copies heightfield elevation data from `model` into the viewer's internal passive model
+    /// and schedules a GPU re-upload for the next [`render`](Self::render) call.
+    ///
+    /// This is a proxy to [`ViewerSharedState::update_hfields_from`].
+    ///
+    /// # Panics
+    /// Panics if `model`'s signature does not match the viewer's passive model.
+    /// Call [`sync_model`](Self::sync_model) or [`sync_data`](Self::sync_data) first.
+    pub fn update_hfields_from(&mut self, model: &MjModel) {
+        self.shared_state.lock_unpoison().update_hfields_from(model);
+    }
+
+
     /// and swaps buffers in OpenGL.
     /// # Errors
     /// - [`MjViewerError::GlutinError`] if the OpenGL context cannot be made current or the buffer swap fails.
@@ -934,7 +1074,11 @@ impl MjViewer {
     fn update_scene(&mut self) -> Result<(), MjViewerError> {
         {
             let mut lock = self.shared_state.lock_unpoison();
-            let ViewerSharedState { data_passive, pert, user_scene, .. } = lock.deref_mut();
+            let ViewerSharedState {
+                data_passive, pert, user_scene,
+                texture_reupload_pending, mesh_reupload_pending, hfield_reupload_pending,
+                ..
+            } = lock.deref_mut();
 
             // Recreate scene when the model changes
             if data_passive.model().signature() != self.scene.signature() {
@@ -956,6 +1100,28 @@ impl MjViewer {
                 self.ncam = new_model.ffi().ncam;
                 #[cfg(feature = "viewer-ui")]
                 self.ui.update_names(new_model);
+                // reload_model already cleared the pending flags and notified waiters.
+            }
+
+            // Process any pending GPU asset re-uploads. The GL context is current here
+            // (ensured by render()). Each dirty flag is cleared after the upload.
+            if *texture_reupload_pending {
+                for id in 0..data_passive.model().ntex() as usize {
+                    self.context.upload_texture(data_passive.model(), id);
+                }
+                *texture_reupload_pending = false;
+            }
+            if *mesh_reupload_pending {
+                for id in 0..data_passive.model().nmesh() as usize {
+                    self.context.upload_mesh(data_passive.model(), id);
+                }
+                *mesh_reupload_pending = false;
+            }
+            if *hfield_reupload_pending {
+                for id in 0..data_passive.model().nhfield() as usize {
+                    self.context.upload_hfield(data_passive.model(), id);
+                }
+                *hfield_reupload_pending = false;
             }
 
             // Update and render the scene from the MjData state

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -130,6 +130,9 @@ pub enum MjViewerError {
     GlInitFailed(crate::error::GlInitError),
     /// A scene operation failed (e.g. user-scene sync overflowed the geom buffer).
     SceneError(crate::error::MjSceneError),
+    /// A rendering-context operation failed (e.g. a pixel-read buffer is too small or the
+    /// viewport has invalid dimensions).
+    ContextError(crate::error::MjrContextError),
     /// The model's structure signature does not match the viewer's passive model.
     /// Call [`ViewerSharedState::sync_model`] or [`ViewerSharedState::sync_data`] first.
     SignatureMismatch,
@@ -151,6 +154,7 @@ impl Display for MjViewerError {
             Self::PainterInitError(e) => write!(f, "failed to initialize egui painter: {e}"),
             Self::GlInitFailed(e) => write!(f, "GL initialization failed: {e}"),
             Self::SceneError(e) => write!(f, "scene error: {e}"),
+            Self::ContextError(e) => write!(f, "rendering context error: {e}"),
             Self::SignatureMismatch =>
                 write!(f, "model signature mismatch: call sync_model / sync_data first"),
             Self::IndexOutOfBounds { id, len } =>
@@ -168,6 +172,7 @@ impl Error for MjViewerError {
             Self::PainterInitError(_) => None,
             Self::GlInitFailed(e) => Some(e),
             Self::SceneError(e) => Some(e),
+            Self::ContextError(e) => Some(e),
             Self::SignatureMismatch | Self::IndexOutOfBounds { .. } => None,
         }
     }
@@ -184,6 +189,13 @@ impl From<crate::error::MjSceneError> for MjViewerError {
 impl From<crate::error::GlInitError> for MjViewerError {
     fn from(e: crate::error::GlInitError) -> Self {
         Self::GlInitFailed(e)
+    }
+}
+
+/// Converts an [`MjrContextError`](crate::error::MjrContextError) into [`MjViewerError::ContextError`].
+impl From<crate::error::MjrContextError> for MjViewerError {
+    fn from(e: crate::error::MjrContextError) -> Self {
+        Self::ContextError(e)
     }
 }
 
@@ -1054,7 +1066,8 @@ impl MjViewer {
     /// # Errors
     /// - [`MjViewerError::GlutinError`] if the OpenGL context cannot be made current or the buffer swap fails.
     /// - [`MjViewerError::SceneError`] if synchronizing user scene geoms fails (e.g. the scene is
-    ///   full) or if reading pixels for a pending screenshot fails.
+    ///   full).
+    /// - [`MjViewerError::ContextError`] if reading pixels for a pending screenshot fails.
     pub fn render(&mut self) -> Result<(), MjViewerError> {
         let RenderBaseGlState {
             gl_context,
@@ -1118,7 +1131,7 @@ impl MjViewer {
     /// grayscale depth image is saved instead of an RGB image.
     ///
     /// # Errors
-    /// Returns [`MjViewerError::SceneError`] if reading pixels from the framebuffer fails.
+    /// Returns [`MjViewerError::ContextError`] if reading pixels from the framebuffer fails.
     fn capture_screenshot(&self, depth: bool) -> Result<(), MjViewerError> {
         let rect = &self.rect_full;
 
@@ -1137,7 +1150,7 @@ impl MjViewer {
         if depth {
             let mut depth_buf = vec![0.0f32; w * h];
             self.context.read_pixels(None, Some(&mut depth_buf), rect)
-                .map_err(MjViewerError::SceneError)?;
+                .map_err(MjViewerError::ContextError)?;
 
             // OpenGL reads bottom-up; flip for top-down PNG row order.
             flip_image_vertically(&mut depth_buf, h, w);
@@ -1180,7 +1193,7 @@ impl MjViewer {
         } else {
             let mut rgb = vec![0u8; w * h * 3];
             self.context.read_pixels(Some(&mut rgb), None, rect)
-                .map_err(MjViewerError::SceneError)?;
+                .map_err(MjViewerError::ContextError)?;
 
             // OpenGL reads bottom-up; flip for top-down PNG row order.
             flip_image_vertically(&mut rgb, h, w * 3);

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -368,9 +368,8 @@ impl ViewerSharedState {
     /// Copies texture pixel data from `model` into the viewer's internal passive model
     /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
     ///
-    /// The upload is processed asynchronously on the next call to
-    /// [`MjViewer::render`] / [`MjViewer::update_scene`], at which point all textures
-    /// will reflect the data copied here.
+    /// The upload is processed on the next call to [`MjViewer::render`], at which point
+    /// all textures will reflect the data copied here.
     ///
     /// # Panics
     /// Panics if `model`'s signature does not match the viewer's passive model (the models
@@ -394,9 +393,15 @@ impl ViewerSharedState {
     /// Copies mesh geometry data from `model` into the viewer's internal passive model
     /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
     ///
-    /// The upload is processed asynchronously on the next call to
-    /// [`MjViewer::render`] / [`MjViewer::update_scene`], at which point all meshes
-    /// will reflect the data copied here.
+    /// All data arrays read by `mjr_uploadMesh` are copied: vertex positions
+    /// (`mesh_vert`), per-vertex normals (`mesh_normal`), UV texture coordinates
+    /// (`mesh_texcoord`), face--vertex indices (`mesh_face`), face--normal indices
+    /// (`mesh_facenormal`), face--texcoord indices (`mesh_facetexcoord`), and convex
+    /// hull graph data (`mesh_graph`). Layout fields (address and count arrays) are
+    /// not copied because they are fixed by the model signature.
+    ///
+    /// The upload is processed on the next call to [`MjViewer::render`], at which point
+    /// all meshes will reflect the data copied here.
     ///
     /// # Panics
     /// Panics if `model`'s signature does not match the viewer's passive model (the models
@@ -407,9 +412,11 @@ impl ViewerSharedState {
             model.signature(), self.data_passive.model().signature(),
             "model signature mismatch: call sync_model / sync_data first"
         );
-        // SAFETY: We copy mesh geometry arrays (vertex positions, normals, texcoords,
-        // face indices). The model signature is verified above, so all array lengths
-        // match between source and destination.
+        // SAFETY: We overwrite all data arrays that `mjr_uploadMesh` reads from the model.
+        // The model signature is verified above, guaranteeing that all array lengths match
+        // between source and destination. The face/graph accessors are `unsafe` on `MjModel`
+        // because supplying out-of-range indices is UB; here we are only copying from one
+        // same-layout model to another, so no indices are constructed or validated.
         let passive = unsafe { self.data_passive.model_mut() };
         passive.mesh_vert_mut().copy_from_slice(model.mesh_vert());
         passive.mesh_normal_mut().copy_from_slice(model.mesh_normal());
@@ -418,6 +425,7 @@ impl ViewerSharedState {
             passive.mesh_face_mut().copy_from_slice(model.mesh_face());
             passive.mesh_facenormal_mut().copy_from_slice(model.mesh_facenormal());
             passive.mesh_facetexcoord_mut().copy_from_slice(model.mesh_facetexcoord());
+            passive.mesh_graph_mut().copy_from_slice(model.mesh_graph());
         }
         self.mesh_reupload_pending = true;
     }
@@ -425,9 +433,8 @@ impl ViewerSharedState {
     /// Copies heightfield elevation data from `model` into the viewer's internal passive model
     /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
     ///
-    /// The upload is processed asynchronously on the next call to
-    /// [`MjViewer::render`] / [`MjViewer::update_scene`], at which point all heightfields
-    /// will reflect the data copied here.
+    /// The upload is processed on the next call to [`MjViewer::render`], at which point
+    /// all heightfields will reflect the data copied here.
     ///
     /// # Panics
     /// Panics if `model`'s signature does not match the viewer's passive model (the models

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -446,24 +446,6 @@ impl ViewerSharedState {
         self.hfield_reupload_pending = true;
     }
 
-    /// Returns `true` if a texture re-upload is pending (scheduled but not yet processed
-    /// by the render thread).
-    pub fn texture_reupload_pending(&self) -> bool {
-        self.texture_reupload_pending
-    }
-
-    /// Returns `true` if a mesh re-upload is pending (scheduled but not yet processed
-    /// by the render thread).
-    pub fn mesh_reupload_pending(&self) -> bool {
-        self.mesh_reupload_pending
-    }
-
-    /// Returns `true` if a heightfield re-upload is pending (scheduled but not yet processed
-    /// by the render thread).
-    pub fn hfield_reupload_pending(&self) -> bool {
-        self.hfield_reupload_pending
-    }
-
 
     /// struct (including large Jacobian and other arrays), not just the state needed for visualization.
     ///

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -130,6 +130,16 @@ pub enum MjViewerError {
     GlInitFailed(crate::error::GlInitError),
     /// A scene operation failed (e.g. user-scene sync overflowed the geom buffer).
     SceneError(crate::error::MjSceneError),
+    /// The model's structure signature does not match the viewer's passive model.
+    /// Call [`ViewerSharedState::sync_model`] or [`ViewerSharedState::sync_data`] first.
+    SignatureMismatch,
+    /// The asset ID is out of range.
+    IndexOutOfBounds {
+        /// The ID that was supplied.
+        id: usize,
+        /// The number of assets in the model (the valid range is `0..len`).
+        len: usize,
+    },
 }
 
 /// Formats a human-readable description of the viewer error.
@@ -141,6 +151,10 @@ impl Display for MjViewerError {
             Self::PainterInitError(e) => write!(f, "failed to initialize egui painter: {e}"),
             Self::GlInitFailed(e) => write!(f, "GL initialization failed: {e}"),
             Self::SceneError(e) => write!(f, "scene error: {e}"),
+            Self::SignatureMismatch =>
+                write!(f, "model signature mismatch: call sync_model / sync_data first"),
+            Self::IndexOutOfBounds { id, len } =>
+                write!(f, "asset id {id} is out of range [0, {len})"),
         }
     }
 }
@@ -154,6 +168,7 @@ impl Error for MjViewerError {
             Self::PainterInitError(_) => None,
             Self::GlInitFailed(e) => Some(e),
             Self::SceneError(e) => Some(e),
+            Self::SignatureMismatch | Self::IndexOutOfBounds { .. } => None,
         }
     }
 }
@@ -372,47 +387,46 @@ impl ViewerSharedState {
     /// The upload is processed on the next call to [`MjViewer::render`], at which point
     /// the updated texture will be reflected in the scene.
     ///
-    /// # Panics
-    /// Panics if `texture_id` is out of range or if `model`'s signature does not match the
-    /// viewer's passive model (the models have a different structure). Call
-    /// [`ViewerSharedState::sync_model`] or [`ViewerSharedState::sync_data`] first to ensure
-    /// the models are in sync.
-    pub fn update_texture_from(&mut self, model: &MjModel, texture_id: usize) {
-        assert_eq!(
-            model.signature(), self.data_passive.model().signature(),
-            "model signature mismatch: call sync_model / sync_data first"
-        );
+    /// # Errors
+    /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
+    /// - [`MjViewerError::IndexOutOfBounds`] if `texture_id >= model.ntex()`.
+    pub fn update_texture_from(&mut self, model: &MjModel, texture_id: usize) -> Result<(), MjViewerError> {
+        if model.signature() != self.data_passive.model().signature() {
+            return Err(MjViewerError::SignatureMismatch);
+        }
+        let ntex = model.ntex() as usize;
+        if texture_id >= ntex {
+            return Err(MjViewerError::IndexOutOfBounds { id: texture_id, len: ntex });
+        }
         let tex_adr = model.tex_adr()[texture_id] as usize;
         let tex_width = model.tex_width()[texture_id] as usize;
         let tex_height = model.tex_height()[texture_id] as usize;
         let tex_nchannel = model.tex_nchannel()[texture_id] as usize;
         let tex_len = tex_width * tex_height * tex_nchannel;
-
-        // SAFETY: The model signature is verified above, so the texture layout matches.
-        // The selected texture slice is bounded by its own width/height/channel metadata.
+        // SAFETY: Signature and bounds verified above; tex_len is derived from the texture's
+        // own metadata, so the slice cannot exceed the allocation.
         unsafe { self.data_passive.model_mut() }
             .tex_data_mut()[tex_adr..tex_adr + tex_len]
             .copy_from_slice(&model.tex_data()[tex_adr..tex_adr + tex_len]);
         self.texture_reupload_pending.insert(texture_id);
+        Ok(())
     }
 
     /// Copies all textures from `model` into the viewer's internal passive model
     /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
     ///
-    /// # Panics
-    /// Panics if `model`'s signature does not match the viewer's passive model (the models
-    /// have a different structure). Call [`ViewerSharedState::sync_model`] or
-    /// [`ViewerSharedState::sync_data`] first to ensure the models are in sync.
-    pub fn update_textures_from(&mut self, model: &MjModel) {
-        assert_eq!(
-            model.signature(), self.data_passive.model().signature(),
-            "model signature mismatch: call sync_model / sync_data first"
-        );
+    /// # Errors
+    /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
+    pub fn update_textures_from(&mut self, model: &MjModel) -> Result<(), MjViewerError> {
+        if model.signature() != self.data_passive.model().signature() {
+            return Err(MjViewerError::SignatureMismatch);
+        }
         // SAFETY: Signature verified above, so tex_data layouts match exactly.
         unsafe { self.data_passive.model_mut() }
             .tex_data_mut()
             .copy_from_slice(model.tex_data());
         self.texture_reupload_pending.extend(0..model.ntex() as usize);
+        Ok(())
     }
 
     /// Copies the mesh with `mesh_id` from `model` into the viewer's internal passive model
@@ -428,17 +442,17 @@ impl ViewerSharedState {
     /// The upload is processed on the next call to [`MjViewer::render`], at which point
     /// the updated mesh will be reflected in the scene.
     ///
-    /// # Panics
-    /// Panics if `mesh_id` is out of range or if `model`'s signature does not match the
-    /// viewer's passive model (the models have a different structure). Call
-    /// [`ViewerSharedState::sync_model`] or [`ViewerSharedState::sync_data`] first to ensure
-    /// the models are in sync.
-    pub fn update_mesh_from(&mut self, model: &MjModel, mesh_id: usize) {
-        assert_eq!(
-            model.signature(), self.data_passive.model().signature(),
-            "model signature mismatch: call sync_model / sync_data first"
-        );
-
+    /// # Errors
+    /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
+    /// - [`MjViewerError::IndexOutOfBounds`] if `mesh_id >= model.nmesh()`.
+    pub fn update_mesh_from(&mut self, model: &MjModel, mesh_id: usize) -> Result<(), MjViewerError> {
+        if model.signature() != self.data_passive.model().signature() {
+            return Err(MjViewerError::SignatureMismatch);
+        }
+        let nmesh = model.nmesh() as usize;
+        if mesh_id >= nmesh {
+            return Err(MjViewerError::IndexOutOfBounds { id: mesh_id, len: nmesh });
+        }
         let vert_adr = model.mesh_vertadr()[mesh_id] as usize;
         let vert_num = model.mesh_vertnum()[mesh_id] as usize;
         let normal_adr = model.mesh_normaladr()[mesh_id] as usize;
@@ -449,9 +463,8 @@ impl ViewerSharedState {
         let face_num = model.mesh_facenum()[mesh_id] as usize;
         let graph_adr = model.mesh_graphadr()[mesh_id];
         let mesh_graph_len = optional_addr_len(model.mesh_graphadr(), mesh_id, model.mesh_graph().len());
-
-        // SAFETY: The model signature is verified above, so the mesh layout matches.
-        // Indices and counts are taken from the selected mesh's own metadata.
+        // SAFETY: Signature and bounds verified above; all offsets and counts are taken
+        // from the mesh's own metadata in a model with matching layout.
         let passive = unsafe { self.data_passive.model_mut() };
         passive.mesh_vert_mut()[vert_adr..vert_adr + vert_num]
             .copy_from_slice(&model.mesh_vert()[vert_adr..vert_adr + vert_num]);
@@ -475,6 +488,7 @@ impl ViewerSharedState {
             }
         }
         self.mesh_reupload_pending.insert(mesh_id);
+        Ok(())
     }
 
     /// Copies all meshes from `model` into the viewer's internal passive model
@@ -487,18 +501,13 @@ impl ViewerSharedState {
     /// hull graph data (`mesh_graph`). Layout fields (address and count arrays) are
     /// not copied because they are fixed by the model signature.
     ///
-    /// # Panics
-    /// Panics if `model`'s signature does not match the viewer's passive model (the models
-    /// have a different structure). Call [`ViewerSharedState::sync_model`] or
-    /// [`ViewerSharedState::sync_data`] first to ensure the models are in sync.
-    pub fn update_meshes_from(&mut self, model: &MjModel) {
-        assert_eq!(
-            model.signature(), self.data_passive.model().signature(),
-            "model signature mismatch: call sync_model / sync_data first"
-        );
+    /// # Errors
+    /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
+    pub fn update_meshes_from(&mut self, model: &MjModel) -> Result<(), MjViewerError> {
+        if model.signature() != self.data_passive.model().signature() {
+            return Err(MjViewerError::SignatureMismatch);
+        }
         // SAFETY: Signature verified above, ensuring all mesh array layouts match exactly.
-        // The face/graph accessors are `unsafe` on `MjModel` because supplying out-of-range
-        // indices is UB; here we are only bulk-copying between same-layout models.
         let passive = unsafe { self.data_passive.model_mut() };
         passive.mesh_vert_mut().copy_from_slice(model.mesh_vert());
         passive.mesh_normal_mut().copy_from_slice(model.mesh_normal());
@@ -510,6 +519,7 @@ impl ViewerSharedState {
             passive.mesh_graph_mut().copy_from_slice(model.mesh_graph());
         }
         self.mesh_reupload_pending.extend(0..model.nmesh() as usize);
+        Ok(())
     }
 
     /// Copies the heightfield with `hfield_id` from `model` into the viewer's internal passive model
@@ -518,46 +528,45 @@ impl ViewerSharedState {
     /// The upload is processed on the next call to [`MjViewer::render`], at which point
     /// the updated heightfield will be reflected in the scene.
     ///
-    /// # Panics
-    /// Panics if `hfield_id` is out of range or if `model`'s signature does not match the
-    /// viewer's passive model (the models have a different structure). Call
-    /// [`ViewerSharedState::sync_model`] or [`ViewerSharedState::sync_data`] first to ensure
-    /// the models are in sync.
-    pub fn update_hfield_from(&mut self, model: &MjModel, hfield_id: usize) {
-        assert_eq!(
-            model.signature(), self.data_passive.model().signature(),
-            "model signature mismatch: call sync_model / sync_data first"
-        );
+    /// # Errors
+    /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
+    /// - [`MjViewerError::IndexOutOfBounds`] if `hfield_id >= model.nhfield()`.
+    pub fn update_hfield_from(&mut self, model: &MjModel, hfield_id: usize) -> Result<(), MjViewerError> {
+        if model.signature() != self.data_passive.model().signature() {
+            return Err(MjViewerError::SignatureMismatch);
+        }
+        let nhfield = model.nhfield() as usize;
+        if hfield_id >= nhfield {
+            return Err(MjViewerError::IndexOutOfBounds { id: hfield_id, len: nhfield });
+        }
         let hfield_adr = model.hfield_adr()[hfield_id] as usize;
         let hfield_nrow = model.hfield_nrow()[hfield_id] as usize;
         let hfield_ncol = model.hfield_ncol()[hfield_id] as usize;
         let hfield_len = hfield_nrow * hfield_ncol;
-
-        // SAFETY: The model signature is verified above, so the heightfield layout matches.
-        // The selected heightfield slice is bounded by its row/column metadata.
+        // SAFETY: Signature and bounds verified above; hfield_len is derived from the
+        // heightfield's own row/column metadata.
         unsafe { self.data_passive.model_mut() }
             .hfield_data_mut()[hfield_adr..hfield_adr + hfield_len]
             .copy_from_slice(&model.hfield_data()[hfield_adr..hfield_adr + hfield_len]);
         self.hfield_reupload_pending.insert(hfield_id);
+        Ok(())
     }
 
     /// Copies all heightfields from `model` into the viewer's internal passive model
     /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
     ///
-    /// # Panics
-    /// Panics if `model`'s signature does not match the viewer's passive model (the models
-    /// have a different structure). Call [`ViewerSharedState::sync_model`] or
-    /// [`ViewerSharedState::sync_data`] first to ensure the models are in sync.
-    pub fn update_hfields_from(&mut self, model: &MjModel) {
-        assert_eq!(
-            model.signature(), self.data_passive.model().signature(),
-            "model signature mismatch: call sync_model / sync_data first"
-        );
+    /// # Errors
+    /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
+    pub fn update_hfields_from(&mut self, model: &MjModel) -> Result<(), MjViewerError> {
+        if model.signature() != self.data_passive.model().signature() {
+            return Err(MjViewerError::SignatureMismatch);
+        }
         // SAFETY: Signature verified above, so hfield_data layouts match exactly.
         unsafe { self.data_passive.model_mut() }
             .hfield_data_mut()
             .copy_from_slice(model.hfield_data());
         self.hfield_reupload_pending.extend(0..model.nhfield() as usize);
+        Ok(())
     }
 
 
@@ -974,11 +983,11 @@ impl MjViewer {
     ///
     /// This is a proxy to [`ViewerSharedState::update_texture_from`].
     ///
-    /// # Panics
-    /// Panics if `model`'s signature does not match the viewer's passive model.
-    /// Call [`sync_model`](Self::sync_model) or [`sync_data`](Self::sync_data) first.
-    pub fn update_texture_from(&mut self, model: &MjModel, texture_id: usize) {
-        self.shared_state.lock_unpoison().update_texture_from(model, texture_id);
+    /// # Errors
+    /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
+    /// - [`MjViewerError::IndexOutOfBounds`] if `texture_id >= model.ntex()`.
+    pub fn update_texture_from(&mut self, model: &MjModel, texture_id: usize) -> Result<(), MjViewerError> {
+        self.shared_state.lock_unpoison().update_texture_from(model, texture_id)
     }
 
     /// Copies all textures from `model` into the viewer's internal passive model
@@ -986,11 +995,10 @@ impl MjViewer {
     ///
     /// This is a proxy to [`ViewerSharedState::update_textures_from`].
     ///
-    /// # Panics
-    /// Panics if `model`'s signature does not match the viewer's passive model.
-    /// Call [`sync_model`](Self::sync_model) or [`sync_data`](Self::sync_data) first.
-    pub fn update_textures_from(&mut self, model: &MjModel) {
-        self.shared_state.lock_unpoison().update_textures_from(model);
+    /// # Errors
+    /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
+    pub fn update_textures_from(&mut self, model: &MjModel) -> Result<(), MjViewerError> {
+        self.shared_state.lock_unpoison().update_textures_from(model)
     }
 
     /// Copies the mesh with `mesh_id` from `model` into the viewer's internal passive model
@@ -998,11 +1006,11 @@ impl MjViewer {
     ///
     /// This is a proxy to [`ViewerSharedState::update_mesh_from`].
     ///
-    /// # Panics
-    /// Panics if `model`'s signature does not match the viewer's passive model.
-    /// Call [`sync_model`](Self::sync_model) or [`sync_data`](Self::sync_data) first.
-    pub fn update_mesh_from(&mut self, model: &MjModel, mesh_id: usize) {
-        self.shared_state.lock_unpoison().update_mesh_from(model, mesh_id);
+    /// # Errors
+    /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
+    /// - [`MjViewerError::IndexOutOfBounds`] if `mesh_id >= model.nmesh()`.
+    pub fn update_mesh_from(&mut self, model: &MjModel, mesh_id: usize) -> Result<(), MjViewerError> {
+        self.shared_state.lock_unpoison().update_mesh_from(model, mesh_id)
     }
 
     /// Copies all meshes from `model` into the viewer's internal passive model
@@ -1010,11 +1018,10 @@ impl MjViewer {
     ///
     /// This is a proxy to [`ViewerSharedState::update_meshes_from`].
     ///
-    /// # Panics
-    /// Panics if `model`'s signature does not match the viewer's passive model.
-    /// Call [`sync_model`](Self::sync_model) or [`sync_data`](Self::sync_data) first.
-    pub fn update_meshes_from(&mut self, model: &MjModel) {
-        self.shared_state.lock_unpoison().update_meshes_from(model);
+    /// # Errors
+    /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
+    pub fn update_meshes_from(&mut self, model: &MjModel) -> Result<(), MjViewerError> {
+        self.shared_state.lock_unpoison().update_meshes_from(model)
     }
 
     /// Copies the heightfield with `hfield_id` from `model` into the viewer's internal passive model
@@ -1022,11 +1029,11 @@ impl MjViewer {
     ///
     /// This is a proxy to [`ViewerSharedState::update_hfield_from`].
     ///
-    /// # Panics
-    /// Panics if `model`'s signature does not match the viewer's passive model.
-    /// Call [`sync_model`](Self::sync_model) or [`sync_data`](Self::sync_data) first.
-    pub fn update_hfield_from(&mut self, model: &MjModel, hfield_id: usize) {
-        self.shared_state.lock_unpoison().update_hfield_from(model, hfield_id);
+    /// # Errors
+    /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
+    /// - [`MjViewerError::IndexOutOfBounds`] if `hfield_id >= model.nhfield()`.
+    pub fn update_hfield_from(&mut self, model: &MjModel, hfield_id: usize) -> Result<(), MjViewerError> {
+        self.shared_state.lock_unpoison().update_hfield_from(model, hfield_id)
     }
 
     /// Copies all heightfields from `model` into the viewer's internal passive model
@@ -1034,11 +1041,10 @@ impl MjViewer {
     ///
     /// This is a proxy to [`ViewerSharedState::update_hfields_from`].
     ///
-    /// # Panics
-    /// Panics if `model`'s signature does not match the viewer's passive model.
-    /// Call [`sync_model`](Self::sync_model) or [`sync_data`](Self::sync_data) first.
-    pub fn update_hfields_from(&mut self, model: &MjModel) {
-        self.shared_state.lock_unpoison().update_hfields_from(model);
+    /// # Errors
+    /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
+    pub fn update_hfields_from(&mut self, model: &MjModel) -> Result<(), MjViewerError> {
+        self.shared_state.lock_unpoison().update_hfields_from(model)
     }
 
 

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -289,15 +289,10 @@ impl ViewerSharedState {
         &mut self.user_scene
     }
 
-    /// Performs a bidirectional three-way merge of model parameters between the
-    /// viewer's passive model and the incoming model.
+    /// Performs a bidirectional three-way merge of model's `opt`, `vis`, and `stat` parameters
+    /// between the viewer's passive model and the incoming model.
     ///
     /// Detects model changes via signature comparison and reloads internal state if needed.
-    /// After a reload, the passive model mirrors the incoming model's current defaults, so
-    /// the first merge after reload is effectively a no-op (both sides agree).
-    /// On subsequent calls, changes made by the viewer UI (e.g., modified physics options)
-    /// are propagated to the incoming model, and changes made by the simulation are
-    /// propagated back to the viewer.
     pub fn sync_model(&mut self, model: &mut MjModel) {
         // Check if model signature changed
         if model.signature() != self.data_passive.model().signature() {
@@ -339,6 +334,15 @@ impl ViewerSharedState {
     pub fn sync_model_stat(&mut self, stat: &mut MjStatistic) {
         ThreeWayMerge::merge(stat, self.data_passive.model_stat_mut(), &mut self.prev_stat);
         self.last_stat_sync_time = Instant::now();
+    }
+
+    /// Copies [`MjModel::hfield_data`] from `model` to the internal passive model,
+    /// and performs a GPU reupload.
+    /// 
+    /// # Panics
+    /// Panics when the input `model` has a different length of height-field data.
+    pub fn update_hfields(&mut self, model: &MjModel) {
+        unsafe { self.data_passive.model_mut() }.hfield_data_mut().copy_from_slice(model.hfield_data());
     }
 
     /// Returns the last time physics options (opt) were synced.

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -1247,13 +1247,13 @@ impl MjViewer {
             // Process any pending GPU asset re-uploads. The GL context is current here
             // (ensured by render()). Each set is taken (leaving an empty set) and iterated.
             for id in std::mem::take(texture_reupload_pending) {
-                self.context.upload_texture(data_passive.model(), id);
+                self.context.upload_texture(data_passive.model(), id).unwrap();
             }
             for id in std::mem::take(mesh_reupload_pending) {
-                self.context.upload_mesh(data_passive.model(), id);
+                self.context.upload_mesh(data_passive.model(), id).unwrap();
             }
             for id in std::mem::take(hfield_reupload_pending) {
-                self.context.upload_hfield(data_passive.model(), id);
+                self.context.upload_hfield(data_passive.model(), id).unwrap();
             }
 
             // Update and render the scene from the MjData state

--- a/src/wrappers/mj_model.rs
+++ b/src/wrappers/mj_model.rs
@@ -794,16 +794,16 @@ impl MjModel {
 
     /// Fallible version of [`MjModel::max_contacts`].
     /// # Errors
-    /// Returns [`MjModelError::InvalidIndex`] when either `geom1` or `geom2` are equal or greater than [`MjModel::ngeom`].
+    /// Returns [`MjModelError::IndexOutOfBounds`] when either `geom1` or `geom2` are equal or greater than [`MjModel::ngeom`].
     pub fn try_max_contacts(&self, geom1: usize, geom2: usize, has_margin: Option<bool>) -> Result<u32, MjModelError> {
         let ngeom = self.ngeom() as usize;
 
         if geom1 >= ngeom {
-            return Err(MjModelError::InvalidIndex(geom1, ngeom));
+            return Err(MjModelError::IndexOutOfBounds { id: geom1, len: ngeom });
         }
 
         if geom2 >= ngeom {
-            return Err(MjModelError::InvalidIndex(geom2, ngeom));
+            return Err(MjModelError::IndexOutOfBounds { id: geom2, len: ngeom });
         }
 
         Ok(unsafe { mj_maxContact(

--- a/src/wrappers/mj_rendering.rs
+++ b/src/wrappers/mj_rendering.rs
@@ -1,6 +1,6 @@
 //! Definitions related to rendering.
 use crate::{array_slice_dyn, getter_setter, mujoco_c::*};
-use crate::error::MjSceneError;
+use crate::error::{MjSceneError, MjrContextError};
 
 use super::mj_model::{MjModel, MjtTexture, MjtTextureRole};
 
@@ -135,10 +135,10 @@ impl MjrContext {
 
     /// Add Aux buffer with given index to context; free previous Aux buffer.
     /// # Errors
-    /// Returns [`MjSceneError::InvalidAuxBufferIndex`] when `index >= mjNAUX` (10).
-    pub fn add_aux(&mut self, index: usize, width: u32, height: u32, samples: usize) -> Result<(), MjSceneError> {
+    /// Returns [`MjrContextError::IndexOutOfBounds`] when `index >= mjNAUX` (10).
+    pub fn add_aux(&mut self, index: usize, width: u32, height: u32, samples: usize) -> Result<(), MjrContextError> {
         if index >= mjNAUX as usize {
-            return Err(MjSceneError::InvalidAuxBufferIndex { index });
+            return Err(MjrContextError::IndexOutOfBounds { id: index, len: mjNAUX as usize });
         }
         // SAFETY: index is bounds-checked above; self.ffi is valid.
         unsafe { mjr_addAux(index as i32, width as i32, height as i32, samples as i32, self.ffi_mut()); }
@@ -153,26 +153,26 @@ impl MjrContext {
 
     /// Re-upload texture to GPU, overwriting previous upload if any.
     ///
-    /// # Panics
-    /// Panics if `texture_id >= model.ntex()`.
-    pub fn upload_texture(&self, model: &MjModel, texture_id: usize) {
-        self.upload_x(model, texture_id, model.ntex() as usize, mjr_uploadTexture);
+    /// # Errors
+    /// Returns [`MjrContextError::IndexOutOfBounds`] if `texture_id >= model.ntex()`.
+    pub fn upload_texture(&self, model: &MjModel, texture_id: usize) -> Result<(), MjrContextError> {
+        self.upload_x(model, texture_id, model.ntex() as usize, mjr_uploadTexture)
     }
 
     /// Re-upload mesh to GPU, overwriting previous upload if any.
     ///
-    /// # Panics
-    /// Panics if `mesh_id >= model.nmesh()`.
-    pub fn upload_mesh(&self, model: &MjModel, mesh_id: usize) {
-        self.upload_x(model, mesh_id, model.nmesh() as usize, mjr_uploadMesh);
+    /// # Errors
+    /// Returns [`MjrContextError::IndexOutOfBounds`] if `mesh_id >= model.nmesh()`.
+    pub fn upload_mesh(&self, model: &MjModel, mesh_id: usize) -> Result<(), MjrContextError> {
+        self.upload_x(model, mesh_id, model.nmesh() as usize, mjr_uploadMesh)
     }
 
     /// Re-upload heightfield to GPU, overwriting previous upload if any.
     ///
-    /// # Panics
-    /// Panics if `hfield_id >= model.nhfield()`.
-    pub fn upload_hfield(&self, model: &MjModel, hfield_id: usize) {
-        self.upload_x(model, hfield_id, model.nhfield() as usize, mjr_uploadHField);
+    /// # Errors
+    /// Returns [`MjrContextError::IndexOutOfBounds`] if `hfield_id >= model.nhfield()`.
+    pub fn upload_hfield(&self, model: &MjModel, hfield_id: usize) -> Result<(), MjrContextError> {
+        self.upload_x(model, hfield_id, model.nhfield() as usize, mjr_uploadHField)
     }
 
     /// Make the context's buffer current again.
@@ -242,10 +242,10 @@ impl MjrContext {
 
     /// Set Aux buffer for custom OpenGL rendering (call restoreBuffer when done).
     /// # Errors
-    /// Returns [`MjSceneError::InvalidAuxBufferIndex`] when `index >= mjNAUX` (10).
-    pub fn set_aux(&mut self, index: usize) -> Result<(), MjSceneError> {
+    /// Returns [`MjrContextError::IndexOutOfBounds`] when `index >= mjNAUX` (10).
+    pub fn set_aux(&mut self, index: usize) -> Result<(), MjrContextError> {
         if index >= mjNAUX as usize {
-            return Err(MjSceneError::InvalidAuxBufferIndex { index });
+            return Err(MjrContextError::IndexOutOfBounds { id: index, len: mjNAUX as usize });
         }
         // SAFETY: index is bounds-checked above; self.ffi is valid.
         unsafe { mjr_setAux(index as i32, self.ffi_mut()); }
@@ -288,11 +288,14 @@ impl MjrContext {
     fn upload_x(
         &self, model: &MjModel, item_id: usize, n_items: usize,
         upload_fn: unsafe extern "C" fn (m: *const mjModel, con: *const mjrContext, hfieldid: ::std::ffi::c_int)
-    )
+    ) -> Result<(), MjrContextError>
     {
-        assert!(item_id < n_items, "{item_id} is out of range [0, {n_items})");
+        if item_id >= n_items {
+            return Err(MjrContextError::IndexOutOfBounds { id: item_id, len: n_items });
+        }
         // SAFETY: item_id is bounds-checked above; model and context are valid.
         unsafe { upload_fn(model.ffi(), self.ffi(), item_id as i32); }
+        Ok(())
     }
 }
 

--- a/src/wrappers/mj_rendering.rs
+++ b/src/wrappers/mj_rendering.rs
@@ -151,15 +151,28 @@ impl MjrContext {
         unsafe { mjr_resizeOffscreen(width as i32, height as i32, self.ffi_mut()); }
     }
 
-    /// Upload texture to GPU, overwriting previous upload if any.
+    /// Re-upload texture to GPU, overwriting previous upload if any.
     ///
     /// # Panics
-    /// Panics if `texid >= model.ntex()`.
-    pub fn upload_texture(&mut self, model: &MjModel, texid: u32) {
-        let ntex = model.ntex();
-        assert!((texid as i64) < ntex, "texid {texid} is out of range [0, {ntex})");
-        // SAFETY: texid is bounds-checked above; model and context are valid.
-        unsafe { mjr_uploadTexture(model.ffi(), self.ffi_mut(), texid as i32); }
+    /// Panics if `texture_id >= model.ntex()`.
+    pub fn upload_texture(&self, model: &MjModel, texture_id: usize) {
+        self.upload_x(model, texture_id, mjr_uploadTexture);
+    }
+
+    /// Re-upload mesh to GPU, overwriting previous upload if any.
+    ///
+    /// # Panics
+    /// Panics if `mesh_id >= model.nmesh()`.
+    pub fn upload_mesh(&self, model: &MjModel, mesh_id: usize) {
+        self.upload_x(model, mesh_id, mjr_uploadMesh);
+    }
+
+    /// Re-upload mesh to GPU, overwriting previous upload if any.
+    ///
+    /// # Panics
+    /// Panics if `hfield_id >= model.nhfield()`.
+    pub fn upload_hfield(&self, model: &MjModel, hfield_id: usize) {
+        self.upload_x(model, hfield_id, mjr_uploadHField);
     }
 
     /// Make the context's buffer current again.
@@ -268,6 +281,19 @@ impl MjrContext {
     /// upheld by the `mujoco-rs` wrappers and cause undefined behavior.
     pub unsafe fn ffi_mut(&mut self) -> &mut mjrContext {
         &mut self.ffi
+    }
+
+    /// Common implementation of GPU upload methods. Specific item upload is made
+    /// by giving the corresponding `mjr_uploadX` to `upload_fn`.   
+    fn upload_x(
+        &self, model: &MjModel, item_id: usize,
+        upload_fn: unsafe extern "C" fn (m: *const mjModel, con: *const mjrContext, hfieldid: ::std::ffi::c_int)
+    )
+    {
+        let nitem = model.nhfield();
+        assert!((item_id as i64) < nitem, "{item_id} is out of range [0, {nitem})");
+        // SAFETY: texid is bounds-checked above; model and context are valid.
+        unsafe { upload_fn(model.ffi(), self.ffi(), item_id as i32); }
     }
 }
 

--- a/src/wrappers/mj_rendering.rs
+++ b/src/wrappers/mj_rendering.rs
@@ -1,6 +1,6 @@
 //! Definitions related to rendering.
 use crate::{array_slice_dyn, getter_setter, mujoco_c::*};
-use crate::error::{MjSceneError, MjrContextError};
+use crate::error::MjrContextError;
 
 use super::mj_model::{MjModel, MjtTexture, MjtTextureRole};
 
@@ -192,17 +192,17 @@ impl MjrContext {
     /// The `rgb` array is of size `[width * height * 3]`, while `depth` is of size `[width * height]`.
     ///
     /// # Errors
-    /// Returns [`MjSceneError::InvalidViewport`] if the viewport has negative
-    /// dimensions, or [`MjSceneError::BufferTooSmall`] if `rgb` or `depth`
+    /// Returns [`MjrContextError::InvalidViewport`] if the viewport has negative
+    /// dimensions, or [`MjrContextError::BufferTooSmall`] if `rgb` or `depth`
     /// buffers are too small.
     pub fn read_pixels(
         &self,
         rgb: Option<&mut [u8]>,
         depth: Option<&mut [f32]>,
         viewport: &MjrRectangle,
-    ) -> Result<(), MjSceneError> {
+    ) -> Result<(), MjrContextError> {
         if viewport.width < 0 || viewport.height < 0 {
-            return Err(MjSceneError::InvalidViewport {
+            return Err(MjrContextError::InvalidViewport {
                 width: viewport.width,
                 height: viewport.height,
             });
@@ -211,7 +211,7 @@ impl MjrContext {
         if let Some(buf) = rgb.as_ref() {
             let needed = size * 3;
             if buf.len() < needed {
-                return Err(MjSceneError::BufferTooSmall {
+                return Err(MjrContextError::BufferTooSmall {
                     name: "rgb",
                     got: buf.len(),
                     needed,
@@ -221,7 +221,7 @@ impl MjrContext {
         if let Some(buf) = depth.as_ref()
             && buf.len() < size
         {
-            return Err(MjSceneError::BufferTooSmall {
+            return Err(MjrContextError::BufferTooSmall {
                 name: "depth",
                 got: buf.len(),
                 needed: size,

--- a/src/wrappers/mj_rendering.rs
+++ b/src/wrappers/mj_rendering.rs
@@ -156,7 +156,7 @@ impl MjrContext {
     /// # Panics
     /// Panics if `texture_id >= model.ntex()`.
     pub fn upload_texture(&self, model: &MjModel, texture_id: usize) {
-        self.upload_x(model, texture_id, mjr_uploadTexture);
+        self.upload_x(model, texture_id, model.ntex() as i64, mjr_uploadTexture);
     }
 
     /// Re-upload mesh to GPU, overwriting previous upload if any.
@@ -164,15 +164,15 @@ impl MjrContext {
     /// # Panics
     /// Panics if `mesh_id >= model.nmesh()`.
     pub fn upload_mesh(&self, model: &MjModel, mesh_id: usize) {
-        self.upload_x(model, mesh_id, mjr_uploadMesh);
+        self.upload_x(model, mesh_id, model.nmesh() as i64, mjr_uploadMesh);
     }
 
-    /// Re-upload mesh to GPU, overwriting previous upload if any.
+    /// Re-upload heightfield to GPU, overwriting previous upload if any.
     ///
     /// # Panics
     /// Panics if `hfield_id >= model.nhfield()`.
     pub fn upload_hfield(&self, model: &MjModel, hfield_id: usize) {
-        self.upload_x(model, hfield_id, mjr_uploadHField);
+        self.upload_x(model, hfield_id, model.nhfield() as i64, mjr_uploadHField);
     }
 
     /// Make the context's buffer current again.
@@ -286,13 +286,12 @@ impl MjrContext {
     /// Common implementation of GPU upload methods. Specific item upload is made
     /// by giving the corresponding `mjr_uploadX` to `upload_fn`.   
     fn upload_x(
-        &self, model: &MjModel, item_id: usize,
+        &self, model: &MjModel, item_id: usize, n_items: i64,
         upload_fn: unsafe extern "C" fn (m: *const mjModel, con: *const mjrContext, hfieldid: ::std::ffi::c_int)
     )
     {
-        let nitem = model.nhfield();
-        assert!((item_id as i64) < nitem, "{item_id} is out of range [0, {nitem})");
-        // SAFETY: texid is bounds-checked above; model and context are valid.
+        assert!((item_id as i64) < n_items, "{item_id} is out of range [0, {n_items})");
+        // SAFETY: item_id is bounds-checked above; model and context are valid.
         unsafe { upload_fn(model.ffi(), self.ffi(), item_id as i32); }
     }
 }

--- a/src/wrappers/mj_rendering.rs
+++ b/src/wrappers/mj_rendering.rs
@@ -156,7 +156,7 @@ impl MjrContext {
     /// # Panics
     /// Panics if `texture_id >= model.ntex()`.
     pub fn upload_texture(&self, model: &MjModel, texture_id: usize) {
-        self.upload_x(model, texture_id, model.ntex() as i64, mjr_uploadTexture);
+        self.upload_x(model, texture_id, model.ntex() as usize, mjr_uploadTexture);
     }
 
     /// Re-upload mesh to GPU, overwriting previous upload if any.
@@ -164,7 +164,7 @@ impl MjrContext {
     /// # Panics
     /// Panics if `mesh_id >= model.nmesh()`.
     pub fn upload_mesh(&self, model: &MjModel, mesh_id: usize) {
-        self.upload_x(model, mesh_id, model.nmesh() as i64, mjr_uploadMesh);
+        self.upload_x(model, mesh_id, model.nmesh() as usize, mjr_uploadMesh);
     }
 
     /// Re-upload heightfield to GPU, overwriting previous upload if any.
@@ -172,7 +172,7 @@ impl MjrContext {
     /// # Panics
     /// Panics if `hfield_id >= model.nhfield()`.
     pub fn upload_hfield(&self, model: &MjModel, hfield_id: usize) {
-        self.upload_x(model, hfield_id, model.nhfield() as i64, mjr_uploadHField);
+        self.upload_x(model, hfield_id, model.nhfield() as usize, mjr_uploadHField);
     }
 
     /// Make the context's buffer current again.
@@ -286,11 +286,11 @@ impl MjrContext {
     /// Common implementation of GPU upload methods. Specific item upload is made
     /// by giving the corresponding `mjr_uploadX` to `upload_fn`.   
     fn upload_x(
-        &self, model: &MjModel, item_id: usize, n_items: i64,
+        &self, model: &MjModel, item_id: usize, n_items: usize,
         upload_fn: unsafe extern "C" fn (m: *const mjModel, con: *const mjrContext, hfieldid: ::std::ffi::c_int)
     )
     {
-        assert!((item_id as i64) < n_items, "{item_id} is out of range [0, {n_items})");
+        assert!(item_id < n_items, "{item_id} is out of range [0, {n_items})");
         // SAFETY: item_id is bounds-checked above; model and context are valid.
         unsafe { upload_fn(model.ffi(), self.ffi(), item_id as i32); }
     }
@@ -379,4 +379,3 @@ impl Drop for MjrContext {
         }
     }
 }
-


### PR DESCRIPTION
## MjModel GPU-assets re-uploads
This PR implements methods for syncing texture, mesh, and height-field asset data with the GPU. This results in any updates to the three mentions being visible inside the viewer.

