### PR TITLE
Reduce amount of generate code from view macros 

### DIFF
--- a/.github/rules/coding-conventions.md
+++ b/.github/rules/coding-conventions.md
@@ -87,6 +87,9 @@
   the field-column alignment.
 - **Import organization**: Group by module (std, external, internal), sort by line length
   (longest first), separate groups with empty lines.
+- **Opening brace placement**: When a function signature fits on one line, place `{` on the
+  same line (K&R style). When parameters are split across multiple lines, place `{` on its
+  own line (Allman style) so the body is visually separated from the signature.
 - **Avoid crate::prelude imports**: Import from actual modules instead of `crate::prelude`.
 - Do NOT flag or fix integer truncation casts (e.g., `usize as i32`, `len() as i32`) when the
   underlying C API already validates or clamps the value (e.g., passing a count that MuJoCo itself
@@ -140,7 +143,7 @@
   be documented if they were present in a previously released version; do not document fixes for
   bugs that were introduced and fixed within the same (unreleased) development cycle.
 - **Migration guide entry format.** Each breaking change in `migration.rst` gets: a descriptive
-  heading (RST `~` underline), a prose explanation, then **Before** and **After** code blocks using
+  heading (RST `-` underline, matching the second-level subsection style already established in the file), a prose explanation, then **Before** and **After** code blocks using
   `.. code-block:: rust`. For simple type changes, use a `.. list-table::` with columns for
   type/method, old signature, and new signature. Group related changes under the same heading.
 - **Verify changelog/migration after major doc changes.** After substantial edits to

--- a/.github/rules/coding-conventions.md
+++ b/.github/rules/coding-conventions.md
@@ -43,6 +43,23 @@
 - **`src/wrappers/fun/` functions stay panicking**: functions in this module should panic on failure,
   not return `Result`.
 
+## Code minimality (DRY, YAGNI, KISS)
+
+- **DRY**: Every piece of logic must have a single representation. If two functions share the same
+  body differing only in a type or a minor parameter, make the function generic or extract a shared
+  helper. Never duplicate an implementation.
+- **YAGNI**: Only implement what is explicitly asked for. Do NOT add speculative parameters, extra
+  overloads, "just in case" variants, or helper types that no caller currently uses.
+- **KISS**: Prefer the simplest solution that fully solves the problem. Avoid clever or convoluted
+  designs. A longer but readable solution is better than a short but tricky one.
+- **Generics over duplication**: When two or more functions share identical logic but differ only
+  in numeric type (e.g. `i32` vs `i64`), make the function generic with an appropriate trait bound
+  (e.g. `Into<i64> + Copy`) rather than writing separate `_sz`/`_typed` variants.
+- **No redundant wrappers**: Do not create a new function that solely delegates to another function
+  of the same name with no added logic. Prefer a single function with a clear signature.
+- **No unused parameters**: Every macro and function parameter must be used. Remove any parameter
+  that was introduced speculatively but has no current caller.
+
 ## Code style
 - Read existing code in the file you're modifying to understand naming, safety, and documentation conventions.
 - Follow the existing error handling patterns used in the same file.

--- a/docs/guide/source/programming/visualization/viewer.rst
+++ b/docs/guide/source/programming/visualization/viewer.rst
@@ -190,7 +190,8 @@ the refresh rate to be equal to the simulation stepping frequency, which puts st
 To prevent slowdowns and allow V-Sync, the viewer can run in the **main thread**, while
 the actual physics simulation runs in another.
 
-Here's an adapted excerpt from the :gh-example:`example <visualization/viewer/rust_viewer_threaded.rs>` on how to use the viewer in a multi-threaded way:
+Here's an adapted excerpt from the :gh-example:`example <visualization/viewer/rust_viewer_threaded.rs>`
+on how to use the viewer in a multi-threaded way:
 
 .. code-block:: rust
     :emphasize-lines: 12-13, 18-22, 30-34

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -394,12 +394,31 @@ impl MjRenderer {
         model: &MjModel,
         id: usize,
         upload: fn(&MjrContext, &MjModel, usize) -> Result<(), crate::error::MjrContextError>,
-    ) -> Result<(), RendererError> {
+    ) -> Result<(), RendererError>
+    {
+        self.prepare_upload(model)?;
+        upload(&self.context, model, id)?;
+        Ok(())
+    }
+
+    fn prepare_upload(&self, model: &MjModel) -> Result<(), RendererError> {
         if model.signature() != self.scene.signature() {
             return Err(RendererError::SignatureMismatch);
         }
-        self.gl_state.make_current().map_err(RendererError::GlutinError)?;
-        upload(&self.context, model, id)?;
+        self.gl_state.make_current().map_err(RendererError::GlutinError)
+    }
+
+    fn update_all_from_impl(
+        &self,
+        model: &MjModel,
+        n: usize,
+        upload: fn(&MjrContext, &MjModel, usize) -> Result<(), crate::error::MjrContextError>,
+    ) -> Result<(), RendererError>
+    {
+        self.prepare_upload(model)?;
+        for id in 0..n {
+            upload(&self.context, model, id)?;
+        }
         Ok(())
     }
 
@@ -419,14 +438,7 @@ impl MjRenderer {
     /// - [`RendererError::SignatureMismatch`] if `model`'s signature does not match the renderer's scene.
     /// - [`RendererError::GlutinError`] if the OpenGL context cannot be made current.
     pub fn update_textures_from(&self, model: &MjModel) -> Result<(), RendererError> {
-        if model.signature() != self.scene.signature() {
-            return Err(RendererError::SignatureMismatch);
-        }
-        self.gl_state.make_current().map_err(RendererError::GlutinError)?;
-        for id in 0..model.ntex() as usize {
-            self.context.upload_texture(model, id).unwrap();
-        }
-        Ok(())
+        self.update_all_from_impl(model, model.ntex() as usize, MjrContext::upload_texture)
     }
 
     /// Re-uploads the mesh with `mesh_id` from `model` to the GPU immediately.
@@ -459,14 +471,7 @@ impl MjRenderer {
     /// - [`RendererError::SignatureMismatch`] if `model`'s signature does not match the renderer's scene.
     /// - [`RendererError::GlutinError`] if the OpenGL context cannot be made current.
     pub fn update_meshes_from(&self, model: &MjModel) -> Result<(), RendererError> {
-        if model.signature() != self.scene.signature() {
-            return Err(RendererError::SignatureMismatch);
-        }
-        self.gl_state.make_current().map_err(RendererError::GlutinError)?;
-        for id in 0..model.nmesh() as usize {
-            self.context.upload_mesh(model, id).unwrap();
-        }
-        Ok(())
+        self.update_all_from_impl(model, model.nmesh() as usize, MjrContext::upload_mesh)
     }
 
     /// Re-uploads the heightfield with `hfield_id` from `model` to the GPU immediately.
@@ -485,14 +490,7 @@ impl MjRenderer {
     /// - [`RendererError::SignatureMismatch`] if `model`'s signature does not match the renderer's scene.
     /// - [`RendererError::GlutinError`] if the OpenGL context cannot be made current.
     pub fn update_hfields_from(&self, model: &MjModel) -> Result<(), RendererError> {
-        if model.signature() != self.scene.signature() {
-            return Err(RendererError::SignatureMismatch);
-        }
-        self.gl_state.make_current().map_err(RendererError::GlutinError)?;
-        for id in 0..model.nhfield() as usize {
-            self.context.upload_hfield(model, id).unwrap();
-        }
-        Ok(())
+        self.update_all_from_impl(model, model.nhfield() as usize, MjrContext::upload_hfield)
     }
 
     /// Set the camera used for rendering.
@@ -859,8 +857,7 @@ impl Display for RendererError {
             Self::IoError(e) => write!(f, "I/O error: {e}"),
             Self::SceneError(e) => write!(f, "scene error: {e}"),
             Self::ContextError(e) => write!(f, "rendering context error: {e}"),
-            Self::SignatureMismatch =>
-                write!(f, "model signature mismatch: call sync_data first"),
+            Self::SignatureMismatch => write!(f, "model signature mismatch: call sync_data first"),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -92,42 +92,33 @@ macro_rules! set_flag {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! mj_model_dyn_range {
-    ($model:expr, $id:expr, nq) => {{
-        let slice = $model.jnt_qposadr();
-        $crate::util::optional_sparse_addr_range(slice, $id, $model.nq() as usize).unwrap_or((0, 0))
-    }};
-    ($model:expr, $id:expr, nv) => {{
-        let slice = $model.jnt_dofadr();
-        $crate::util::optional_sparse_addr_range(slice, $id, $model.nv() as usize).unwrap_or((0, 0))
-    }};
-    ($model:expr, $id:expr, nsensordata) => {{
-        let slice = $model.sensor_adr();
-        $crate::util::optional_sparse_addr_range(slice, $id, $model.nsensordata() as usize).unwrap_or((0, 0))
-    }};
-    ($model:expr, $id:expr, ntupledata) => {{
-        let slice = $model.tuple_adr();
-        $crate::util::optional_sparse_addr_range(slice, $id, $model.ntupledata() as usize).unwrap_or((0, 0))
-    }};
-    ($model:expr, $id:expr, ntexdata) => {{
-        let slice = $model.tex_adr();
-        $crate::util::optional_sparse_addr_range(slice, $id, $model.ntexdata() as usize).unwrap_or((0, 0))
-    }};
-    ($model:expr, $id:expr, nnumericdata) => {{
-        let slice = $model.numeric_adr();
-        $crate::util::optional_sparse_addr_range(slice, $id, $model.nnumericdata() as usize).unwrap_or((0, 0))
-    }};
-    ($model:expr, $id:expr, nhfielddata) => {{
-        let slice = $model.hfield_adr();
-        $crate::util::optional_sparse_addr_range(slice, $id, $model.nhfielddata() as usize).unwrap_or((0, 0))
-    }};
-    ($model:expr, $id:expr, na) => {{
-        let slice = $model.actuator_actadr();
-        $crate::util::optional_sparse_addr_range(slice, $id, $model.na() as usize).unwrap_or((0, 0))
-    }};
-    ($model:expr, $id:expr, nJten) => {{
-        let slice = $model.ten_j_rowadr();
-        $crate::util::optional_sparse_addr_range(slice, $id, $model.n_jten() as usize).unwrap_or((0, 0))
-    }};
+    ($model:expr, $id:expr, nq) => {
+        $crate::util::optional_sparse_addr_range($model.jnt_qposadr(), $id, $model.nq() as usize).unwrap_or((0, 0))
+    };
+    ($model:expr, $id:expr, nv) => {
+        $crate::util::optional_sparse_addr_range($model.jnt_dofadr(), $id, $model.nv() as usize).unwrap_or((0, 0))
+    };
+    ($model:expr, $id:expr, nsensordata) => {
+        $crate::util::optional_sparse_addr_range($model.sensor_adr(), $id, $model.nsensordata() as usize).unwrap_or((0, 0))
+    };
+    ($model:expr, $id:expr, ntupledata) => {
+        $crate::util::optional_sparse_addr_range($model.tuple_adr(), $id, $model.ntupledata() as usize).unwrap_or((0, 0))
+    };
+    ($model:expr, $id:expr, ntexdata) => {
+        $crate::util::optional_sparse_addr_range($model.tex_adr(), $id, $model.ntexdata() as usize).unwrap_or((0, 0))
+    };
+    ($model:expr, $id:expr, nnumericdata) => {
+        $crate::util::optional_sparse_addr_range($model.numeric_adr(), $id, $model.nnumericdata() as usize).unwrap_or((0, 0))
+    };
+    ($model:expr, $id:expr, nhfielddata) => {
+        $crate::util::optional_sparse_addr_range($model.hfield_adr(), $id, $model.nhfielddata() as usize).unwrap_or((0, 0))
+    };
+    ($model:expr, $id:expr, na) => {
+        $crate::util::optional_sparse_addr_range($model.actuator_actadr(), $id, $model.na() as usize).unwrap_or((0, 0))
+    };
+    ($model:expr, $id:expr, nJten) => {
+        $crate::util::optional_sparse_addr_range($model.ten_j_rowadr(), $id, $model.n_jten() as usize).unwrap_or((0, 0))
+    };
 }
 
 /// Provides a more direct view to a C array.
@@ -403,8 +394,10 @@ macro_rules! info_method {
                     );
                 )*
                 $(
-                    let (dyn_start, dyn_len) = $crate::mj_model_dyn_range!(model_ref, id, $ffi_len_dyn);
-                    let $attr_dyn = (dyn_start $(* $offset_mult)?, dyn_len $(* $offset_mult)?);
+                    let $attr_dyn = {
+                        let (dyn_start, dyn_len) = $crate::mj_model_dyn_range!(model_ref, id, $ffi_len_dyn);
+                        (dyn_start $(* $offset_mult)?, dyn_len $(* $offset_mult)?)
+                    };
                 )*
 
                 let model_signature = model_ffi.signature;

--- a/src/util.rs
+++ b/src/util.rs
@@ -37,13 +37,18 @@ pub(crate) fn write_ascii_to_buf(buf: &mut [c_char], value: &str) {
 ///
 /// # Examples
 /// ```ignore
-/// if let Some((graph_adr, graph_len)) = optional_sparse_addr_range(model.mesh_graphadr(), mesh_id, model.mesh_graph().len()) {
+/// if let Some((graph_adr, graph_len)) = optional_sparse_addr_range(
+///     model.mesh_graphadr(), mesh_id, model.mesh_graph().len()
+/// ) {
 ///     // copy mesh_graph[graph_adr..graph_adr + graph_len]
 /// }
 /// ```
+///
+/// # Panics
+/// Panics if `id >= addr_array.len()`.
 pub(crate) fn optional_sparse_addr_range<T>(addr_array: &[T], id: usize, data_len: usize) -> Option<(usize, usize)>
 where
-    T: Into<i64> + Copy + PartialEq,
+    T: Into<i64> + Copy,
 {
     let adr: i64 = addr_array[id].into();
     if adr < 0 {
@@ -62,6 +67,7 @@ where
 }
 
 
+/// Sets or clears a bit flag based on a boolean value.
 ///
 /// # Examples
 /// ```ignore
@@ -364,7 +370,13 @@ macro_rules! view_creator {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! info_method {
-    ($info_type:ident, $([$model:ident],)? $type_:ident, [$($attr:ident: $len:expr),*], [$($attr_ffi:ident: $len_ffi:ident $(* $multiplier:expr)?),*], [$($attr_dyn:ident: $ffi_len_dyn:ident $(* $offset_mult:expr)?),*]) => {
+    (
+        $info_type:ident, $([$model:ident],)?
+        $type_:ident,
+        [$($attr:ident: $len:expr),*],
+        [$($attr_ffi:ident: $len_ffi:ident $(* $multiplier:expr)?),*],
+        [$($attr_dyn:ident: $ffi_len_dyn:ident $(* $offset_mult:expr)?),*]
+    ) => {
         paste::paste! {
             #[doc = concat!(
                 "Returns a [`", stringify!([<Mj $type_:camel $info_type Info>]), "`] for the named ", stringify!($type_), ", ",
@@ -385,7 +397,10 @@ macro_rules! info_method {
                     let $attr = (id * $len, $len);
                 )*
                 $(
-                    let $attr_ffi = (id * model_ffi.$len_ffi as usize $( * $multiplier)*, model_ffi.$len_ffi as usize $( * $multiplier)*);
+                    let $attr_ffi = (
+                        id * model_ffi.$len_ffi as usize $( * $multiplier)*,
+                        model_ffi.$len_ffi as usize $( * $multiplier)*,
+                    );
                 )*
                 $(
                     let (dyn_start, dyn_len) = $crate::mj_model_dyn_range!(model_ref, id, $ffi_len_dyn);

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,36 +25,40 @@ pub(crate) fn write_ascii_to_buf(buf: &mut [c_char], value: &str) {
     dest[bytes.len()..].fill(0);
 }
 
-/// Returns the number of elements belonging to item `id` inside a packed data array,
-/// given an address array where each entry is either the item's start offset in the data
-/// array or `-1` (meaning the item has no data).
+/// Returns `Some((start, len))` for item `id` inside a packed data array,
+/// or `None` if the item has no data (address entry is negative).
 ///
-/// The length is determined by scanning `addr_array[id + 1..]` for the first entry that
-/// is `!= -1` (i.e., the next item that *does* have data). If no such entry exists the
-/// region extends to the end of the data array (`data_len`).
+/// Each entry in `addr_array` is either the item's start offset in the data array
+/// or a negative value (conventionally `-1`) meaning the item has no associated data.
 ///
-/// # Panics
-/// Panics if `addr_array[id]` is negative but not `-1` (malformed model data).
+/// The length is determined by scanning `addr_array[id + 1..]` for the first
+/// non-negative entry (the next item that *does* have data). If no such entry exists,
+/// the region extends to the end of the data array (`data_len`).
 ///
 /// # Examples
 /// ```ignore
-/// let len = optional_addr_len(model.mesh_graphadr(), mesh_id, model.mesh_graph().len());
+/// if let Some((graph_adr, graph_len)) = optional_sparse_addr_range(model.mesh_graphadr(), mesh_id, model.mesh_graph().len()) {
+///     // copy mesh_graph[graph_adr..graph_adr + graph_len]
+/// }
 /// ```
-#[cfg(feature = "viewer")]
-pub(crate) fn optional_addr_len(addr_array: &[i32], id: usize, data_len: usize) -> usize {
-    let adr = addr_array[id];
+pub(crate) fn optional_sparse_addr_range<T>(addr_array: &[T], id: usize, data_len: usize) -> Option<(usize, usize)>
+where
+    T: Into<i64> + Copy + PartialEq,
+{
+    let adr: i64 = addr_array[id].into();
     if adr < 0 {
-        return 0;
+        return None;
     }
     let adr = adr as usize;
-    addr_array
+    let len = addr_array
         .get(id + 1..)
         .unwrap_or(&[])
         .iter()
-        .find(|&&next| next != -1)
-        .map(|&next| next as usize)
+        .find(|&&next| next.into() != -1)
+        .map(|&next| next.into() as usize)
         .unwrap_or(data_len)
-        - adr
+        - adr;
+    Some((adr, len))
 }
 
 
@@ -77,112 +81,47 @@ macro_rules! set_flag {
     };
 }
 
-/// Creates a (start, length) tuple based on
-/// lookup variables that define the mapping in MuJoCo's mjModel struct.
-/// The tuple is used to create views to correct addresses in corresponding structs.
-/// Format: item id, map from item id to index inside the array of all items' values,
-///         number of items, maximum number of elements inside the array of all items' values
-#[macro_export]
-#[doc(hidden)]
-macro_rules! mj_view_indices {
-    ($id:expr, $addr_map:expr, $njnt:expr, $max_n:expr) => {
-        {
-            let start_addr = *$addr_map.add($id) as isize;
-            if start_addr == -1 {
-                (0, 0)
-            }
-            else
-            {
-                // Some addr maps (e.g. actuator_actadr) contain -1 for items with no
-                // allocated data (stateless actuators).  Skip over those sentinels when
-                // looking for the end boundary of the current range.
-                let mut next_idx = $id + 1;
-                let end_addr: usize = loop {
-                    if next_idx >= $njnt as usize {
-                        break $max_n as usize;
-                    }
-                    let next_addr = *$addr_map.add(next_idx) as isize;
-                    if next_addr != -1 {
-                        break next_addr as usize;
-                    }
-                    next_idx += 1;
-                };
-                let n = end_addr - start_addr as usize;
-                (start_addr as usize, n)
-            }
-        }
-    };
-}
 
 /// Returns the correct address mapping based on the X in nX (nq, nv, nu, ...).
 #[macro_export]
 #[doc(hidden)]
-macro_rules! mj_model_nx_to_mapping {
-    ($model_ffi:ident, nq) => {
-        $model_ffi.jnt_qposadr
-    };
-
-    ($model_ffi:ident, nv) => {
-        $model_ffi.jnt_dofadr
-    };
-
-    ($model_ffi:ident, nsensordata) => {
-        $model_ffi.sensor_adr
-    };
-    ($model_ffi:ident, ntupledata) => {
-        $model_ffi.tuple_adr
-    };
-    ($model_ffi:ident, ntexdata) => {
-        $model_ffi.tex_adr
-    };
-    ($model_ffi:ident, nnumericdata) => {
-        $model_ffi.numeric_adr
-    };
-    ($model_ffi:ident, nhfielddata) => {
-        $model_ffi.hfield_adr
-    };
-    ($model_ffi:ident, na) => {
-        $model_ffi.actuator_actadr
-    };
-    ($model_ffi:ident, nJten) => {
-        $model_ffi.ten_J_rowadr
-    };
-}
-
-
-/// Returns the correct number of items based on the X in nX (nq, nv, nu, ...).
-#[macro_export]
-#[doc(hidden)]
-macro_rules! mj_model_nx_to_nitem {
-    ($model_ffi:ident, nq) => {
-        $model_ffi.njnt
-    };
-
-    ($model_ffi:ident, nv) => {
-        $model_ffi.njnt
-    };
-
-    ($model_ffi:ident, nsensordata) => {
-        $model_ffi.nsensor
-    };
-    ($model_ffi:ident, ntupledata) => {
-        $model_ffi.ntuple
-    };
-    ($model_ffi:ident, ntexdata) => {
-        $model_ffi.ntex
-    };
-    ($model_ffi:ident, nnumericdata) => {
-        $model_ffi.nnumeric
-    };
-    ($model_ffi:ident, nhfielddata) => {
-        $model_ffi.nhfield
-    };
-    ($model_ffi:ident, na) => {
-        $model_ffi.nu
-    };
-    ($model_ffi:ident, nJten) => {
-        $model_ffi.ntendon
-    };
+macro_rules! mj_model_dyn_range {
+    ($model:expr, $id:expr, nq) => {{
+        let slice = $model.jnt_qposadr();
+        $crate::util::optional_sparse_addr_range(slice, $id, $model.nq() as usize).unwrap_or((0, 0))
+    }};
+    ($model:expr, $id:expr, nv) => {{
+        let slice = $model.jnt_dofadr();
+        $crate::util::optional_sparse_addr_range(slice, $id, $model.nv() as usize).unwrap_or((0, 0))
+    }};
+    ($model:expr, $id:expr, nsensordata) => {{
+        let slice = $model.sensor_adr();
+        $crate::util::optional_sparse_addr_range(slice, $id, $model.nsensordata() as usize).unwrap_or((0, 0))
+    }};
+    ($model:expr, $id:expr, ntupledata) => {{
+        let slice = $model.tuple_adr();
+        $crate::util::optional_sparse_addr_range(slice, $id, $model.ntupledata() as usize).unwrap_or((0, 0))
+    }};
+    ($model:expr, $id:expr, ntexdata) => {{
+        let slice = $model.tex_adr();
+        $crate::util::optional_sparse_addr_range(slice, $id, $model.ntexdata() as usize).unwrap_or((0, 0))
+    }};
+    ($model:expr, $id:expr, nnumericdata) => {{
+        let slice = $model.numeric_adr();
+        $crate::util::optional_sparse_addr_range(slice, $id, $model.nnumericdata() as usize).unwrap_or((0, 0))
+    }};
+    ($model:expr, $id:expr, nhfielddata) => {{
+        let slice = $model.hfield_adr();
+        $crate::util::optional_sparse_addr_range(slice, $id, $model.nhfielddata() as usize).unwrap_or((0, 0))
+    }};
+    ($model:expr, $id:expr, na) => {{
+        let slice = $model.actuator_actadr();
+        $crate::util::optional_sparse_addr_range(slice, $id, $model.na() as usize).unwrap_or((0, 0))
+    }};
+    ($model:expr, $id:expr, nJten) => {{
+        let slice = $model.ten_j_rowadr();
+        $crate::util::optional_sparse_addr_range(slice, $id, $model.n_jten() as usize).unwrap_or((0, 0))
+    }};
 }
 
 /// Provides a more direct view to a C array.
@@ -416,7 +355,7 @@ macro_rules! view_creator {
 /// - **Fixed stride**: `attr: N`: index range is `(id * N, N)`.
 /// - **FFI stride** (with optional multiplier): `attr: ffi_field (* k)`: stride taken from
 ///   `model.ffi_field`, optionally scaled by `k`.
-/// - **Dynamic range**: `attr: nXXX (* k)`: start and length resolved via [`mj_view_indices!`],
+/// - **Dynamic range**: `attr: nXXX (* k)`: start and length resolved via [`mj_model_dyn_range!`],
 ///   where `nXXX` is the major-dimension field (e.g. `nhfielddata`, `ntexdata`).
 ///   The optional `* k` is a stride multiplier: each logical unit occupies `k` flat elements,
 ///   so both the start offset and the length are scaled by `k`. Use this when the target array
@@ -425,7 +364,7 @@ macro_rules! view_creator {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! info_method {
-    ($info_type:ident, $ffi:expr, $type_:ident, [$($attr:ident: $len:expr),*], [$($attr_ffi:ident: $len_ffi:ident $(* $multiplier:expr)?),*], [$($attr_dyn:ident: $ffi_len_dyn:ident $(* $offset_mult:expr)?),*]) => {
+    ($info_type:ident, $([$model:ident],)? $type_:ident, [$($attr:ident: $len:expr),*], [$($attr_ffi:ident: $len_ffi:ident $(* $multiplier:expr)?),*], [$($attr_dyn:ident: $ffi_len_dyn:ident $(* $offset_mult:expr)?),*]) => {
         paste::paste! {
             #[doc = concat!(
                 "Returns a [`", stringify!([<Mj $type_:camel $info_type Info>]), "`] for the named ", stringify!($type_), ", ",
@@ -437,31 +376,23 @@ macro_rules! info_method {
             )]
             #[allow(non_snake_case)]
             pub fn $type_(&self, name: &str) -> Option<[<Mj $type_:camel $info_type Info>]> {
-                let c_name = CString::new(name).unwrap();
-                let ffi = self.$ffi;
-                let id = unsafe { mj_name2id(ffi, MjtObj::[<mjOBJ_ $type_:upper>] as i32, c_name.as_ptr()) };
-                if id == -1 {
-                    return None;
-                }
+                let model_ref = self$(.$model())?;
+                let id = model_ref.name_to_id(MjtObj::[<mjOBJ_ $type_:upper>], name)?;
+                let model_ffi = model_ref.ffi();
 
                 let id = id as usize;
                 $(
                     let $attr = (id * $len, $len);
                 )*
                 $(
-                    let $attr_ffi = (id * ffi.$len_ffi as usize $( * $multiplier)*, ffi.$len_ffi as usize $( * $multiplier)*);
+                    let $attr_ffi = (id * model_ffi.$len_ffi as usize $( * $multiplier)*, model_ffi.$len_ffi as usize $( * $multiplier)*);
                 )*
                 $(
-                    let (dyn_start, dyn_len) = unsafe { mj_view_indices!(
-                        id,
-                        mj_model_nx_to_mapping!(ffi, $ffi_len_dyn),
-                        mj_model_nx_to_nitem!(ffi, $ffi_len_dyn),
-                        ffi.$ffi_len_dyn
-                    ) };
+                    let (dyn_start, dyn_len) = $crate::mj_model_dyn_range!(model_ref, id, $ffi_len_dyn);
                     let $attr_dyn = (dyn_start $(* $offset_mult)?, dyn_len $(* $offset_mult)?);
                 )*
 
-                let model_signature = ffi.signature;
+                let model_signature = model_ffi.signature;
                 Some([<Mj $type_:camel $info_type Info>] { name: name.to_string(), id, model_signature, $($attr,)* $($attr_ffi,)* $($attr_dyn),* })
             }
         }

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -23,8 +23,8 @@ use winit::window::Fullscreen;
 use bitflags::bitflags;
 
 use crate::wrappers::mj_rendering::{MjrContext, MjrRectangle, MjtFont, MjtGridPos};
-use crate::vis_common::{sync_geoms, flip_image_vertically, write_png};
 use crate::util::{optional_sparse_addr_range, LockUnpoison, ThreeWayMerge};
+use crate::vis_common::{sync_geoms, flip_image_vertically, write_png};
 use crate::wrappers::mj_auxiliary::{MjVisual, MjStatistic};
 use crate::winit_gl_base::{RenderBaseGlState, RenderBase};
 use crate::wrappers::mj_primitive::{MjtNum, MjtSize};
@@ -155,10 +155,8 @@ impl Display for MjViewerError {
             Self::GlInitFailed(e) => write!(f, "GL initialization failed: {e}"),
             Self::SceneError(e) => write!(f, "scene error: {e}"),
             Self::ContextError(e) => write!(f, "rendering context error: {e}"),
-            Self::SignatureMismatch =>
-                write!(f, "model signature mismatch: call sync_model / sync_data first"),
-            Self::IndexOutOfBounds { id, len } =>
-                write!(f, "asset id {id} is out of range [0, {len})"),
+            Self::SignatureMismatch => write!(f, "model signature mismatch: call sync_model / sync_data first"),
+            Self::IndexOutOfBounds { id, len } => write!(f, "asset id {id} is out of range [0, {len})"),
         }
     }
 }
@@ -393,6 +391,13 @@ impl ViewerSharedState {
         self.last_stat_sync_time
     }
 
+    fn check_signature(&self, model: &MjModel) -> Result<(), MjViewerError> {
+        if model.signature() != self.data_passive.model().signature() {
+            return Err(MjViewerError::SignatureMismatch);
+        }
+        Ok(())
+    }
+
     /// Copies the texture with `texture_id` from `model` into the viewer's internal passive model
     /// and schedules a GPU re-upload for the next [`MjViewer::render`] call.
     ///
@@ -403,9 +408,7 @@ impl ViewerSharedState {
     /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
     /// - [`MjViewerError::IndexOutOfBounds`] if `texture_id >= model.ntex()`.
     pub fn update_texture_from(&mut self, model: &MjModel, texture_id: usize) -> Result<(), MjViewerError> {
-        if model.signature() != self.data_passive.model().signature() {
-            return Err(MjViewerError::SignatureMismatch);
-        }
+        self.check_signature(model)?;
         let ntex = model.ntex() as usize;
         if texture_id >= ntex {
             return Err(MjViewerError::IndexOutOfBounds { id: texture_id, len: ntex });
@@ -430,9 +433,7 @@ impl ViewerSharedState {
     /// # Errors
     /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
     pub fn update_textures_from(&mut self, model: &MjModel) -> Result<(), MjViewerError> {
-        if model.signature() != self.data_passive.model().signature() {
-            return Err(MjViewerError::SignatureMismatch);
-        }
+        self.check_signature(model)?;
         // SAFETY: Signature verified above, so tex_data layouts match exactly.
         unsafe { self.data_passive.model_mut() }
             .tex_data_mut()
@@ -458,9 +459,7 @@ impl ViewerSharedState {
     /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
     /// - [`MjViewerError::IndexOutOfBounds`] if `mesh_id >= model.nmesh()`.
     pub fn update_mesh_from(&mut self, model: &MjModel, mesh_id: usize) -> Result<(), MjViewerError> {
-        if model.signature() != self.data_passive.model().signature() {
-            return Err(MjViewerError::SignatureMismatch);
-        }
+        self.check_signature(model)?;
         let nmesh = model.nmesh() as usize;
         if mesh_id >= nmesh {
             return Err(MjViewerError::IndexOutOfBounds { id: mesh_id, len: nmesh });
@@ -515,9 +514,7 @@ impl ViewerSharedState {
     /// # Errors
     /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
     pub fn update_meshes_from(&mut self, model: &MjModel) -> Result<(), MjViewerError> {
-        if model.signature() != self.data_passive.model().signature() {
-            return Err(MjViewerError::SignatureMismatch);
-        }
+        self.check_signature(model)?;
         // SAFETY: Signature verified above, ensuring all mesh array layouts match exactly.
         let passive = unsafe { self.data_passive.model_mut() };
         passive.mesh_vert_mut().copy_from_slice(model.mesh_vert());
@@ -543,9 +540,7 @@ impl ViewerSharedState {
     /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
     /// - [`MjViewerError::IndexOutOfBounds`] if `hfield_id >= model.nhfield()`.
     pub fn update_hfield_from(&mut self, model: &MjModel, hfield_id: usize) -> Result<(), MjViewerError> {
-        if model.signature() != self.data_passive.model().signature() {
-            return Err(MjViewerError::SignatureMismatch);
-        }
+        self.check_signature(model)?;
         let nhfield = model.nhfield() as usize;
         if hfield_id >= nhfield {
             return Err(MjViewerError::IndexOutOfBounds { id: hfield_id, len: nhfield });
@@ -569,9 +564,7 @@ impl ViewerSharedState {
     /// # Errors
     /// - [`MjViewerError::SignatureMismatch`] if `model`'s signature does not match the viewer's passive model.
     pub fn update_hfields_from(&mut self, model: &MjModel) -> Result<(), MjViewerError> {
-        if model.signature() != self.data_passive.model().signature() {
-            return Err(MjViewerError::SignatureMismatch);
-        }
+        self.check_signature(model)?;
         // SAFETY: Signature verified above, so hfield_data layouts match exactly.
         unsafe { self.data_passive.model_mut() }
             .hfield_data_mut()
@@ -1259,13 +1252,13 @@ impl MjViewer {
             // Process any pending GPU asset re-uploads. The GL context is current here
             // (ensured by render()). Each set is taken (leaving an empty set) and iterated.
             for id in std::mem::take(texture_reupload_pending) {
-                self.context.upload_texture(data_passive.model(), id).unwrap();
+                self.context.upload_texture(data_passive.model(), id)?;
             }
             for id in std::mem::take(mesh_reupload_pending) {
-                self.context.upload_mesh(data_passive.model(), id).unwrap();
+                self.context.upload_mesh(data_passive.model(), id)?;
             }
             for id in std::mem::take(hfield_reupload_pending) {
-                self.context.upload_hfield(data_passive.model(), id).unwrap();
+                self.context.upload_hfield(data_passive.model(), id)?;
             }
 
             // Update and render the scene from the MjData state

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -24,7 +24,7 @@ use bitflags::bitflags;
 
 use crate::wrappers::mj_rendering::{MjrContext, MjrRectangle, MjtFont, MjtGridPos};
 use crate::vis_common::{sync_geoms, flip_image_vertically, write_png};
-use crate::util::{optional_addr_len, LockUnpoison, ThreeWayMerge};
+use crate::util::{optional_sparse_addr_range, LockUnpoison, ThreeWayMerge};
 use crate::wrappers::mj_auxiliary::{MjVisual, MjStatistic};
 use crate::winit_gl_base::{RenderBaseGlState, RenderBase};
 use crate::wrappers::mj_primitive::{MjtNum, MjtSize};
@@ -473,8 +473,7 @@ impl ViewerSharedState {
         let texcoord_num = model.mesh_texcoordnum()[mesh_id] as usize;
         let face_adr = model.mesh_faceadr()[mesh_id] as usize;
         let face_num = model.mesh_facenum()[mesh_id] as usize;
-        let graph_adr = model.mesh_graphadr()[mesh_id];
-        let mesh_graph_len = optional_addr_len(model.mesh_graphadr(), mesh_id, model.mesh_graph().len());
+        let graph_range = optional_sparse_addr_range(model.mesh_graphadr(), mesh_id, model.mesh_graph().len());
         // SAFETY: Signature and bounds verified above; all offsets and counts are taken
         // from the mesh's own metadata in a model with matching layout.
         let passive = unsafe { self.data_passive.model_mut() };
@@ -494,7 +493,7 @@ impl ViewerSharedState {
                 .copy_from_slice(&model.mesh_facenormal()[face_adr..face_adr + face_num]);
             passive.mesh_facetexcoord_mut()[face_adr..face_adr + face_num]
                 .copy_from_slice(&model.mesh_facetexcoord()[face_adr..face_adr + face_num]);
-            if let Some(graph_adr) = (graph_adr >= 0).then_some(graph_adr as usize) {
+            if let Some((graph_adr, mesh_graph_len)) = graph_range {
                 passive.mesh_graph_mut()[graph_adr..graph_adr + mesh_graph_len]
                     .copy_from_slice(&model.mesh_graph()[graph_adr..graph_adr + mesh_graph_len]);
             }

--- a/src/wrappers/mj_data.rs
+++ b/src/wrappers/mj_data.rs
@@ -1,5 +1,4 @@
 //! MjData related.
-use crate::{mj_view_indices, mj_model_nx_to_mapping, mj_model_nx_to_nitem};
 use crate::{view_creator, info_method, info_with_view, array_slice_dyn};
 use crate::wrappers::mj_auxiliary::{MjVisual, MjStatistic};
 use crate::wrappers::mj_option::MjOption;
@@ -156,17 +155,17 @@ impl<M: Deref<Target = MjModel>> MjData<M> {
         }
     }
 
-    info_method! { Data, model.ffi(), body, [
+    info_method! { Data, [model], body, [
         xfrc_applied: 6, xpos: 3, xquat: 4, xmat: 9, xipos: 3, ximat: 9, subtree_com: 3, cinert: 10,
         crb: 10, cvel: 6, subtree_linvel: 3, subtree_angmom: 3, cacc: 6, cfrc_int: 6, cfrc_ext: 6,
         awake: 1
     ], [], []}
-    info_method! { Data, model.ffi(), camera, [xpos: 3, xmat: 9], [], []}
-    info_method! { Data, model.ffi(), geom, [xpos: 3, xmat: 9], [], []}
-    info_method! { Data, model.ffi(), site, [xpos: 3, xmat: 9], [], []}
-    info_method! { Data, model.ffi(), light, [xpos: 3, xdir: 3], [], []}
+    info_method! { Data, [model], camera, [xpos: 3, xmat: 9], [], []}
+    info_method! { Data, [model], geom, [xpos: 3, xmat: 9], [], []}
+    info_method! { Data, [model], site, [xpos: 3, xmat: 9], [], []}
+    info_method! { Data, [model], light, [xpos: 3, xdir: 3], [], []}
 
-    info_method! { Data, model.ffi(), actuator,
+    info_method! { Data, [model], actuator,
         [ctrl: 1, length: 1, velocity: 1, force: 1],
         [],
         [act: na]
@@ -178,53 +177,51 @@ impl<M: Deref<Target = MjModel>> MjData<M> {
     /// # Panics
     /// When the `name` contains '\0' characters, a panic occurs.
     pub fn joint(&self, name: &str) -> Option<MjJointDataInfo> {
-        let c_name = CString::new(name).unwrap();
-        let id = unsafe { mj_name2id(self.model.ffi(), MjtObj::mjOBJ_JOINT as i32, c_name.as_ptr())};
-        if id == -1 {  // not found
-            return None;
-        }
-        let model_ffi = self.model.ffi();
-        let id = id as usize;
-        unsafe {
-            let nq_range = mj_view_indices!(id, mj_model_nx_to_mapping!(model_ffi, nq), mj_model_nx_to_nitem!(model_ffi, nq), model_ffi.nq);
-            let nv_range = mj_view_indices!(id, mj_model_nx_to_mapping!(model_ffi, nv), mj_model_nx_to_nitem!(model_ffi, nv), model_ffi.nv);
+        let model = self.model();
+        let id = model.name_to_id(MjtObj::mjOBJ_JOINT, name)?;
+        let nq_range = {
+            let slice = model.jnt_qposadr();
+            crate::util::optional_sparse_addr_range(slice, id, model.nq() as usize).unwrap_or((0, 0))
+        };
+        let nv_range = {
+            let slice = model.jnt_dofadr();
+            crate::util::optional_sparse_addr_range(slice, id, model.nv() as usize).unwrap_or((0, 0))
+        };
 
-            // $id:expr, $addr_map:expr, $njnt:expr, $max_n:expr
-            let qpos = nq_range;
-            let qvel = nv_range;
-            let qacc_warmstart = nv_range;
-            let qfrc_applied = nv_range;
-            let qacc = nv_range;
-            let xanchor = (id * 3, 3);
-            let xaxis = (id * 3, 3);
-            #[allow(non_snake_case)]
-            let qLDiagInv = nv_range;
-            let qfrc_bias = nv_range;
-            let qfrc_passive = nv_range;
-            let qfrc_actuator = nv_range;
-            let qfrc_smooth = nv_range;
-            let qacc_smooth = nv_range;
-            let qfrc_constraint = nv_range;
-            let qfrc_inverse = nv_range;
+        let qpos = nq_range;
+        let qvel = nv_range;
+        let qacc_warmstart = nv_range;
+        let qfrc_applied = nv_range;
+        let qacc = nv_range;
+        let xanchor = (id * 3, 3);
+        let xaxis = (id * 3, 3);
+        #[allow(non_snake_case)]
+        let qLDiagInv = nv_range;
+        let qfrc_bias = nv_range;
+        let qfrc_passive = nv_range;
+        let qfrc_actuator = nv_range;
+        let qfrc_smooth = nv_range;
+        let qacc_smooth = nv_range;
+        let qfrc_constraint = nv_range;
+        let qfrc_inverse = nv_range;
 
-            let qfrc_spring = nv_range;
-            let qfrc_damper = nv_range;
-            let qfrc_gravcomp = nv_range;
-            let qfrc_fluid = nv_range;
+        let qfrc_spring = nv_range;
+        let qfrc_damper = nv_range;
+        let qfrc_gravcomp = nv_range;
+        let qfrc_fluid = nv_range;
 
-            let model_signature = self.model.signature();
-            Some(MjJointDataInfo {name: name.to_string(), id: id as usize, model_signature,
-                qpos, qvel, qacc_warmstart, qfrc_applied, qacc, xanchor, xaxis, qLDiagInv, qfrc_bias,
-                qfrc_spring, qfrc_damper, qfrc_gravcomp, qfrc_fluid, qfrc_passive,
-                qfrc_actuator, qfrc_smooth, qacc_smooth, qfrc_constraint, qfrc_inverse
-            })
-        }
+        let model_signature = self.model.signature();
+        Some(MjJointDataInfo {name: name.to_string(), id: id as usize, model_signature,
+            qpos, qvel, qacc_warmstart, qfrc_applied, qacc, xanchor, xaxis, qLDiagInv, qfrc_bias,
+            qfrc_spring, qfrc_damper, qfrc_gravcomp, qfrc_fluid, qfrc_passive,
+            qfrc_actuator, qfrc_smooth, qacc_smooth, qfrc_constraint, qfrc_inverse
+        })
     }
 
-    info_method! { Data, model.ffi(), sensor, [], [], [data: nsensordata] }
+    info_method! { Data, [model], sensor, [], [], [data: nsensordata] }
 
 
-    info_method! { Data, model.ffi(), tendon,
+    info_method! { Data, [model], tendon,
         [wrapadr: 1, wrapnum: 1, efcadr: 1, length: 1, velocity: 1],
         [],
         [J: nJten]

--- a/src/wrappers/mj_model.rs
+++ b/src/wrappers/mj_model.rs
@@ -1,7 +1,6 @@
 //! MjModel related.
 use crate::{
     view_creator, info_method, info_with_view,
-    mj_view_indices, mj_model_nx_to_mapping, mj_model_nx_to_nitem,
     array_slice_dyn, getter_setter
 };
 use crate::util::{assert_mujoco_version, ERROR_BUF_LEN};
@@ -344,7 +343,7 @@ impl MjModel {
         }
     }
 
-    info_method! { Model, ffi(), actuator,
+    info_method! { Model, actuator,
         [trntype: 1, dyntype: 1, gaintype: 1, biastype: 1, trnid: 2, actadr: 1, actnum: 1,
         group: 1, history: 2, historyadr: 1, delay: 1, ctrllimited: 1, forcelimited: 1, actlimited: 1, dynprm: mjNDYN as usize, gainprm: mjNGAIN as usize, biasprm: mjNBIAS as usize,
         actearly: 1, ctrlrange: 2, forcerange: 2, actrange: 2, damping: 1,
@@ -354,7 +353,7 @@ impl MjModel {
         []
     }
 
-    info_method! { Model, ffi(), body,
+    info_method! { Model, body,
         [parentid: 1, rootid: 1, weldid: 1, mocapid: 1, jntnum: 1, jntadr: 1,
         dofnum: 1, dofadr: 1, treeid: 1, geomnum: 1, geomadr: 1, simple: 1,
         sameframe: 1, pos: 3, quat: 4, ipos: 3, iquat: 4, mass: 1, subtreemass: 1,
@@ -364,7 +363,7 @@ impl MjModel {
         []
     }
 
-    info_method! { Model, ffi(), camera,
+    info_method! { Model, camera,
         [mode: 1, bodyid: 1, targetbodyid: 1,
         pos: 3, quat: 4, poscom0: 3,
         pos0: 3, mat0: 9, projection: 1, fovy: 1,
@@ -373,7 +372,7 @@ impl MjModel {
         []
     }
     
-    info_method! { Model, ffi(), joint,
+    info_method! { Model, joint,
         [r#type: 1, qposadr: 1, dofadr: 1, group: 1,
         limited: 1, actfrclimited: 1, actgravcomp: 1, solref: mjNREF as usize, solimp: mjNIMP as usize,
         pos: 3, axis: 3, stiffness: 1, stiffnesspoly: mjNPOLY as usize,
@@ -385,7 +384,7 @@ impl MjModel {
     }
 
 
-    info_method! { Model, ffi(), equality,
+    info_method! { Model, equality,
         [r#type: 1, obj1id: 1,
         obj2id: 1, active0: 1,
         solref: mjNREF as usize, solimp: mjNIMP as usize,
@@ -394,13 +393,13 @@ impl MjModel {
         []
     }
 
-    info_method! { Model, ffi(), exclude,
+    info_method! { Model, exclude,
         [signature: 1],
         [],
         []
     }
 
-    info_method! { Model, ffi(), geom,
+    info_method! { Model, geom,
         [r#type: 1, contype: 1, conaffinity: 1, condim: 1, bodyid: 1, dataid: 1, matid: 1,
         group: 1, priority: 1, plugin: 1, sameframe: 1, solmix: 1, solref: mjNREF as usize, solimp: mjNIMP as usize, size: 3,
         aabb: 6, rbound: 1, pos: 3, quat: 4, friction: 3, margin: 1, gap: 1, fluid: mjNFLUID as usize, rgba: 4],
@@ -408,7 +407,7 @@ impl MjModel {
         []
     }
 
-    info_method! { Model, ffi(), hfield,
+    info_method! { Model, hfield,
         [size: 4,
         nrow: 1,
         ncol: 1,
@@ -418,7 +417,7 @@ impl MjModel {
         [data: nhfielddata]
     }
 
-    info_method! { Model, ffi(), light,
+    info_method! { Model, light,
         [mode: 1, bodyid: 1, targetbodyid: 1, r#type: 1, texid: 1, castshadow: 1,
         bulbradius: 1, intensity: 1, range: 1,
         active: 1, pos: 3, dir: 3, poscom0: 3, pos0: 3,
@@ -428,7 +427,7 @@ impl MjModel {
         []
     }
 
-    info_method! { Model, ffi(), material,
+    info_method! { Model, material,
         [texid: MjtTextureRole::mjNTEXROLE as usize, texuniform: 1,
         texrepeat: 2, emission: 1,
         specular: 1, shininess: 1,
@@ -437,7 +436,7 @@ impl MjModel {
         []
     }
 
-    info_method! { Model, ffi(), mesh,
+    info_method! { Model, mesh,
         [vertadr: 1, vertnum: 1,
         texcoordadr: 1, faceadr: 1,
         facenum: 1, graphadr: 1,
@@ -449,14 +448,14 @@ impl MjModel {
         []
     }
 
-    info_method! { Model, ffi(), numeric,
+    info_method! { Model, numeric,
         [adr: 1,
         size: 1],
         [],
         [data: nnumericdata]
     }
 
-    info_method! { Model, ffi(), pair,
+    info_method! { Model, pair,
         [dim: 1, geom1: 1, geom2: 1,
         signature: 1, solref: mjNREF as usize, solimp: mjNIMP as usize,
         margin: 1, gap: 1, friction: 5, solreffriction: mjNREF as usize],
@@ -464,7 +463,7 @@ impl MjModel {
         []
     }
 
-    info_method! { Model, ffi(), sensor,
+    info_method! { Model, sensor,
         [r#type: 1, datatype: 1, needstage: 1,
         objtype: 1, objid: 1, reftype: 1,
         refid: 1, intprm: mjNSENS as usize, dim: 1, adr: 1,
@@ -473,7 +472,7 @@ impl MjModel {
         []
     }
 
-    info_method! { Model, ffi(), site,
+    info_method! { Model, site,
         [r#type: 1, bodyid: 1, matid: 1,
         group: 1, sameframe: 1, size: 3,
         pos: 3, quat: 4, rgba: 4],
@@ -481,7 +480,7 @@ impl MjModel {
         []
     }
 
-    info_method! { Model, ffi(), skin,
+    info_method! { Model, skin,
         [matid: 1, group: 1, rgba: 4, inflate: 1,
         vertadr: 1, vertnum: 1, texcoordadr: 1,
         faceadr: 1, facenum: 1, boneadr: 1,
@@ -490,7 +489,7 @@ impl MjModel {
         []
     }
 
-    info_method! { Model, ffi(), tendon,
+    info_method! { Model, tendon,
         [adr: 1, num: 1, matid: 1, actuatorid: 1, group: 1, treenum: 1, treeid: 2,
         limited: 1, actfrclimited: 1, width: 1,
         solref_lim: mjNREF as usize, solimp_lim: mjNIMP as usize, solref_fri: mjNREF as usize, solimp_fri: mjNIMP as usize, range: 2, actfrcrange: 2, margin: 1,
@@ -500,7 +499,7 @@ impl MjModel {
         [J_colind: nJten]
     }
 
-    info_method! { Model, ffi(), texture,
+    info_method! { Model, texture,
         [r#type: 1, colorspace: 1, height: 1,
         width: 1, nchannel: 1,
         adr: 1, pathadr: 1],
@@ -508,7 +507,7 @@ impl MjModel {
         [data: ntexdata]
     }
 
-    info_method! { Model, ffi(), tuple,
+    info_method! { Model, tuple,
         [adr: 1,
         size: 1],
         [],
@@ -517,7 +516,7 @@ impl MjModel {
         objprm: ntupledata]
     }
 
-    info_method! { Model, ffi(), key,
+    info_method! { Model, key,
         [time: 1],
         [qpos: nq, qvel: nv,
         act: na, mpos: nmocap*3,

--- a/src/wrappers/mj_model.rs
+++ b/src/wrappers/mj_model.rs
@@ -793,7 +793,8 @@ impl MjModel {
 
     /// Fallible version of [`MjModel::max_contacts`].
     /// # Errors
-    /// Returns [`MjModelError::IndexOutOfBounds`] when either `geom1` or `geom2` are equal or greater than [`MjModel::ngeom`].
+    /// Returns [`MjModelError::IndexOutOfBounds`] when either `geom1` or `geom2` are equal or
+    /// greater than [`MjModel::ngeom`].
     pub fn try_max_contacts(&self, geom1: usize, geom2: usize, has_margin: Option<bool>) -> Result<u32, MjModelError> {
         let ngeom = self.ngeom() as usize;
 

--- a/src/wrappers/mj_rendering.rs
+++ b/src/wrappers/mj_rendering.rs
@@ -284,10 +284,10 @@ impl MjrContext {
     }
 
     /// Common implementation of GPU upload methods. Specific item upload is made
-    /// by giving the corresponding `mjr_uploadX` to `upload_fn`.   
+    /// by giving the corresponding `mjr_uploadX` to `upload_fn`.
     fn upload_x(
         &self, model: &MjModel, item_id: usize, n_items: usize,
-        upload_fn: unsafe extern "C" fn (m: *const mjModel, con: *const mjrContext, hfieldid: ::std::ffi::c_int)
+        upload_fn: unsafe extern "C" fn (m: *const mjModel, con: *const mjrContext, id: ::std::ffi::c_int)
     ) -> Result<(), MjrContextError>
     {
         if item_id >= n_items {


### PR DESCRIPTION
Reduce duplication of code, which stems from nested macros that should of be a function in the first place. As a side-effect, this improves safety as infos/views rely on unchecked C-FFI calls less than before. Furthermore, this PR addresses some coding style violations of the entire repository.