### PR TITLE
Refactor Model Editing macros to generate less direct duplicated code

### DIFF
--- a/.github/skills/miri/SKILL.md
+++ b/.github/skills/miri/SKILL.md
@@ -35,7 +35,7 @@ Run the codebase under Miri's experimental FFI native-lib support to detect unde
    export LD_LIBRARY_PATH=$(realpath build/lib64/) && \
    export MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-native-lib=$(realpath build/lib64/libmujoco.so.X.Y.Z) -Zmiri-permissive-provenance -Zmiri-symbolic-alignment-check" && \
    cd .. && \
-   cargo +nightly miri run --example miri_test
+   cargo +nightly miri run --example miri_test --features renderer
    ```
 
 3. **Verify results**:

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 .. |mj_data| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData`
 .. |mj_model| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel`
 .. |mj_spec| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec`
+.. |mjs_body| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsBody`
 .. |mj_geomview| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjGeomDataView`
 .. |mj_geomviewmut| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjGeomDataViewMut`
 .. |mjv_scene| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_visualization::<struct>MjvScene`
@@ -160,6 +161,15 @@ runtime.
   mutated each frame and immediately re-uploaded before rendering to PNG frames.
 
 .. rubric:: Bug fixes
+
+- Fixed a model-editing potential undefined behavior in |mjs_body|, which occurred
+  when yielded references of body's items were not destroyed before the next entry
+  to the iterator. This was problematic if individual references of yielded items
+  were stored and later used --- technically a undefined behavior due to reuse of the |mjs_body|
+  inside the iterator. The |mjs_body| parent is now stored as a raw FFI pointer to prevent such
+  aliasing.
+
+
 .. rubric:: Other changes
 
 

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -547,32 +547,44 @@ impl MjSpec {
 /// Mutable iterator over items in [`MjSpec`].
 #[derive(Debug)]
 pub struct MjsSpecItemIterMut<'a, T> {
-    root: &'a mut MjSpec,
+    /// Pointer to the wrapped mjSpec pointer.
+    /// This is the FFI type wrapped inside [`MjSpec`].
+    ffi_ptr: *mut mjSpec,
+    /// Last obtained element in the iterator.
+    /// This CAN be null, and this iterator it uses the null to detect
+    /// end of iteration. 
     last: *mut mjsElement,
     /// Used for generic implementation of iterator's methods.
-    item_type: PhantomData<T>
+    item_type: PhantomData<&'a mut T>
 }
 
 /// Immutable iterator over items in [`MjSpec`].
 #[derive(Debug, Clone)]
 pub struct MjsSpecItemIter<'a, T> {
-    root: &'a MjSpec,
+    /// Pointer to the wrapped mjSpec pointer.
+    /// This is the FFI type wrapped inside [`MjSpec`].
+    ffi_ptr: *const mjSpec,
+    /// Last obtained element in the iterator.
+    /// This CAN be null, and this iterator it uses the null to detect
+    /// end of iteration. 
     last: *mut mjsElement,
     /// Used for generic implementation of iterator's methods.
-    item_type: PhantomData<T>
+    item_type: PhantomData<&'a T>
 }
 
 impl<'a, T: SpecObject> MjsSpecItemIterMut<'a, T> {
     fn new(root: &'a mut MjSpec) -> Self {
         let last = unsafe { mjs_firstElement(root.0.as_ptr(), T::OBJ_TYPE) };
-        Self { root, last, item_type: PhantomData }
+        Self { ffi_ptr: root.0.as_ptr(), last, item_type: PhantomData }
     }
 }
 
 impl<'a, T: SpecObject> MjsSpecItemIter<'a, T> {
     fn new(root: &'a MjSpec) -> Self {
+        // SAFETY: mjs_firstElement does not mutate mjsSpec, thus as_ptr is valid to be case to *mut
+        // from the const reference to its wrapper.
         let last = unsafe { mjs_firstElement(root.0.as_ptr(), T::OBJ_TYPE) };
-        Self { root, last, item_type: PhantomData }
+        Self { ffi_ptr: root.0.as_ptr(), last, item_type: PhantomData }
     }
 }
 
@@ -587,7 +599,7 @@ impl<'a, T: SpecObject + 'a> Iterator for MjsSpecItemIterMut<'a, T> {
             let out = T::from_element_as_ptr_mut(self.last).as_mut();
             // Use as_ptr() instead of ffi_mut() to avoid creating &mut mjSpec,
             // which would alias with previously yielded &mut items.
-            self.last = mjs_nextElement(self.root.0.as_ptr(), self.last);
+            self.last = mjs_nextElement(self.ffi_ptr, self.last);
             out
         }
     }
@@ -602,7 +614,9 @@ impl<'a, T: SpecObject + 'a> Iterator for MjsSpecItemIter<'a, T> {
         }
         unsafe {
             let out = T::from_element_as_ptr_mut(self.last).as_ref();
-            self.last = mjs_nextElement(self.root.0.as_ptr(), self.last);
+            // SAFETY: mjs_nextElement does not mutate mjsSpec, thus as_ptr is valid to be case to *mut
+            // from the const reference to its wrapper.
+            self.last = mjs_nextElement(self.ffi_ptr as *mut _, self.last);
             out
         }
     }
@@ -1758,36 +1772,21 @@ impl MjsBody {
 /// Mutable iterator over items in [`MjsBody`].
 #[derive(Debug)]
 pub struct MjsBodyItemIterMut<'a, T> {
-    root: &'a mut MjsBody,
+    /// NonNull pointer to the FFI type [`mjsBody`].
+    /// [`MjsBody`] is its alias, thus storing it plainly
+    /// would technically be UB as Rust can't see across
+    /// boundary to verify . 
+    ffi_ptr: *mut MjsBody,
     last: *mut mjsElement,
     recurse: bool,
     /// Used for generic implementation of iterator's methods.
-    item_type: PhantomData<T>
-}
-
-/// Immutable iterator over items in [`MjsBody`].
-#[derive(Debug, Clone)]
-pub struct MjsBodyItemIter<'a, T> {
-    root: &'a MjsBody,
-    last: *mut mjsElement,
-    recurse: bool,
-    /// Used for generic implementation of iterator's methods.
-    item_type: PhantomData<T>
+    item_type: PhantomData<&'a T>
 }
 
 impl<'a, T: SpecObject> MjsBodyItemIterMut<'a, T> {
     fn new(root: &'a mut MjsBody, recurse: bool) -> Self {
         let last = unsafe { mjs_firstChild(root, T::OBJ_TYPE, recurse.into()) };
-        Self { root, last, recurse, item_type: PhantomData }
-    }
-}
-
-impl<'a, T: SpecObject> MjsBodyItemIter<'a, T> {
-    fn new(root: &'a MjsBody, recurse: bool) -> Self {
-        // SAFETY: mjs_firstChild requires a *mut pointer but does not mutate
-        // the body. The const-to-mut cast is sound because no mutation occurs.
-        let last = unsafe { mjs_firstChild(root as *const _ as *mut _, T::OBJ_TYPE, recurse.into()) };
-        Self { root, last, recurse, item_type: PhantomData }
+        Self { ffi_ptr: root, last, recurse, item_type: PhantomData }
     }
 }
 
@@ -1798,11 +1797,40 @@ impl<'a, T: SpecObject + 'a> Iterator for MjsBodyItemIterMut<'a, T> {
         if self.last.is_null() {
             return None;
         }
+
         unsafe {
             let out = T::from_element_as_ptr_mut(self.last).as_mut();
-            self.last = mjs_nextChild(self.root, self.last, self.recurse.into());
+            self.last = mjs_nextChild(self.ffi_ptr, self.last, self.recurse.into());
             out
         }
+    }
+}
+
+impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsBodyItemIterMut<'a, T> {}
+
+/// Immutable iterator over items in [`MjsBody`].
+#[derive(Debug, Clone)]
+pub struct MjsBodyItemIter<'a, T> {
+    ffi_ptr: *const MjsBody,
+    last: *const mjsElement,
+    recurse: bool,
+    /// Used for generic implementation of iterator's methods.
+    item_type: PhantomData<&'a T>
+}
+
+
+impl<'a, T: SpecObject> MjsBodyItemIter<'a, T> {
+    fn new(root: &'a MjsBody, recurse: bool) -> Self {
+        // SAFETY: mjs_firstChild requires a *mut pointer but does not mutate
+        // the body. The const-to-mut cast is sound because no mutation occurs.
+        let last = unsafe {
+            mjs_firstChild(
+                root as *const _ as *mut _,
+                T::OBJ_TYPE,
+                recurse.into()
+            )
+        };
+        Self { ffi_ptr: root, last, recurse, item_type: PhantomData }
     }
 }
 
@@ -1814,16 +1842,15 @@ impl<'a, T: SpecObject + 'a> Iterator for MjsBodyItemIter<'a, T> {
             return None;
         }
         unsafe {
-            let out = T::from_element_as_ptr_mut(self.last).as_ref();
+            let out = T::from_element_as_ptr_mut(self.last as *mut _).as_ref();
             // SAFETY: mjs_nextChild requires *mut but does not mutate. Cast is sound.
-            self.last = mjs_nextChild(self.root as *const _ as *mut _, self.last, self.recurse.into());
+            self.last = mjs_nextChild(self.ffi_ptr as *mut _, self.last as *mut _, self.recurse.into());
             out
         }
     }
 }
 
 // Once self.last is null, next() always returns None.
-impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsBodyItemIterMut<'a, T> {}
 impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsBodyItemIter<'a, T> {}
 
 /// Iterator methods.

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -562,26 +562,21 @@ pub struct MjsSpecItemIter<'a, T> {
     item_type: PhantomData<T>
 }
 
-item_spec_iterator! {
-    Body, Geom, Joint, Site, Camera, Light, Frame, Actuator, Sensor, Flex, Pair, Equality, Exclude, Tendon,
-    Numeric, Text, Tuple, Key, Mesh, Hfield, Skin, Texture, Material, Plugin
-}
-
-impl<'a, T: MjsElementCast> MjsSpecItemIterMut<'a, T> {
+impl<'a, T: SpecObject> MjsSpecItemIterMut<'a, T> {
     fn new(root: &'a mut MjSpec) -> Self {
         let last = unsafe { mjs_firstElement(root.0.as_ptr(), T::OBJ_TYPE) };
         Self { root, last, item_type: PhantomData }
     }
 }
 
-impl<'a, T: MjsElementCast> MjsSpecItemIter<'a, T> {
+impl<'a, T: SpecObject> MjsSpecItemIter<'a, T> {
     fn new(root: &'a MjSpec) -> Self {
         let last = unsafe { mjs_firstElement(root.0.as_ptr(), T::OBJ_TYPE) };
         Self { root, last, item_type: PhantomData }
     }
 }
 
-impl<'a, T: MjsElementCast + 'a> Iterator for MjsSpecItemIterMut<'a, T> {
+impl<'a, T: SpecObject + 'a> Iterator for MjsSpecItemIterMut<'a, T> {
     type Item = &'a mut T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -589,7 +584,7 @@ impl<'a, T: MjsElementCast + 'a> Iterator for MjsSpecItemIterMut<'a, T> {
             return None;
         }
         unsafe {
-            let out = T::cast_from_element(self.last).as_mut();
+            let out = T::from_element_as_ptr_mut(self.last).as_mut();
             // Use as_ptr() instead of ffi_mut() to avoid creating &mut mjSpec,
             // which would alias with previously yielded &mut items.
             self.last = mjs_nextElement(self.root.0.as_ptr(), self.last);
@@ -598,7 +593,7 @@ impl<'a, T: MjsElementCast + 'a> Iterator for MjsSpecItemIterMut<'a, T> {
     }
 }
 
-impl<'a, T: MjsElementCast + 'a> Iterator for MjsSpecItemIter<'a, T> {
+impl<'a, T: SpecObject + 'a> Iterator for MjsSpecItemIter<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -606,7 +601,7 @@ impl<'a, T: MjsElementCast + 'a> Iterator for MjsSpecItemIter<'a, T> {
             return None;
         }
         unsafe {
-            let out = T::cast_from_element(self.last).as_ref();
+            let out = T::from_element_as_ptr_mut(self.last).as_ref();
             self.last = mjs_nextElement(self.root.0.as_ptr(), self.last);
             out
         }
@@ -614,8 +609,8 @@ impl<'a, T: MjsElementCast + 'a> Iterator for MjsSpecItemIter<'a, T> {
 }
 
 // Once self.last is null, next() always returns None.
-impl<'a, T: MjsElementCast + 'a> std::iter::FusedIterator for MjsSpecItemIterMut<'a, T> {}
-impl<'a, T: MjsElementCast + 'a> std::iter::FusedIterator for MjsSpecItemIter<'a, T> {}
+impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsSpecItemIterMut<'a, T> {}
+impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsSpecItemIter<'a, T> {}
 
 /// Iterator methods.
 impl MjSpec {
@@ -653,7 +648,7 @@ impl Clone for MjSpec {
 /***************************
 ** Site specification
 ***************************/
-mjs_struct!(Site);
+mjs_struct!(Site [SpecObject]);
 impl MjsSite {
     getter_setter! {
         [&] with, get, [
@@ -683,7 +678,7 @@ impl MjsSite {
 /***************************
 ** Joint specification
 ***************************/
-mjs_struct!(Joint);
+mjs_struct!(Joint [SpecObject]);
 impl MjsJoint {
     getter_setter! {
         [&] with, get, [
@@ -738,7 +733,7 @@ impl MjsJoint {
 /***************************
 ** Geom specification
 ***************************/
-mjs_struct!(Geom);
+mjs_struct!(Geom [SpecObject]);
 impl MjsGeom {
     getter_setter! {
         [&] with, get, [
@@ -790,7 +785,7 @@ impl MjsGeom {
 /***************************
 ** Camera specification
 ***************************/
-mjs_struct!(Camera);
+mjs_struct!(Camera [SpecObject]);
 impl MjsCamera {
     getter_setter! {
         [&] with, get, [
@@ -825,7 +820,7 @@ impl MjsCamera {
 /***************************
 ** Light specification
 ***************************/
-mjs_struct!(Light);
+mjs_struct!(Light [SpecObject]);
 impl MjsLight {
     getter_setter! {
         [&] with, get, [
@@ -864,7 +859,7 @@ impl MjsLight {
 /***************************
 ** Frame specification
 ***************************/
-mjs_struct!(Frame);
+mjs_struct!(Frame [SpecObject]);
 impl MjsFrame {
     add_x_method_by_frame! { body, site, joint, geom, camera, light }
 
@@ -913,7 +908,7 @@ impl MjsFrame {
 /***************************
 ** Actuator specification
 ***************************/
-mjs_struct!(Actuator);
+mjs_struct!(Actuator [SpecObject]);
 impl MjsActuator {
     getter_setter! {
         [&] with, get, [
@@ -976,7 +971,7 @@ impl MjsActuator {
 /***************************
 ** Sensor specification
 ***************************/
-mjs_struct!(Sensor);
+mjs_struct!(Sensor [SpecObject]);
 impl MjsSensor {
     getter_setter! {
         [&] with, get, [
@@ -1016,7 +1011,7 @@ impl MjsSensor {
 /***************************
 ** Flex specification
 ***************************/
-mjs_struct!(Flex);
+mjs_struct!(Flex [SpecObject]);
 impl MjsFlex {
     getter_setter! {
         [&] with, get, [
@@ -1092,7 +1087,7 @@ impl MjsFlex {
 /***************************
 ** Pair specification
 ***************************/
-mjs_struct!(Pair);
+mjs_struct!(Pair [SpecObject]);
 impl MjsPair {
     getter_setter! {
         [&] with, get, [
@@ -1120,7 +1115,7 @@ impl MjsPair {
 /***************************
 ** Exclude specification
 ***************************/
-mjs_struct!(Exclude);
+mjs_struct!(Exclude [SpecObject]);
 impl MjsExclude {
     string_set_get_with! {[&]
         bodyname1; "name of body 1.";
@@ -1131,7 +1126,7 @@ impl MjsExclude {
 /***************************
 ** Equality specification
 ***************************/
-mjs_struct!(Equality);
+mjs_struct!(Equality [SpecObject]);
 impl MjsEquality {
     getter_setter! {
         [&] with, get, [
@@ -1159,7 +1154,7 @@ impl MjsEquality {
 /***************************
 ** Tendon specification
 ***************************/
-mjs_struct!(Tendon);
+mjs_struct!(Tendon [SpecObject]);
 impl MjsTendon {
     getter_setter! {
         [&] with, get, [
@@ -1346,7 +1341,7 @@ impl MjsWrap {
 /***************************
 ** Numeric specification
 ***************************/
-mjs_struct!(Numeric);
+mjs_struct!(Numeric [SpecObject]);
 impl MjsNumeric {
     getter_setter! {
         [&] with, get, set, [
@@ -1362,7 +1357,7 @@ impl MjsNumeric {
 /***************************
 ** Text specification
 ***************************/
-mjs_struct!(Text);
+mjs_struct!(Text [SpecObject]);
 impl MjsText {
     string_set_get_with! {[&]
         data; "text string.";
@@ -1372,7 +1367,7 @@ impl MjsText {
 /***************************
 ** Tuple specification
 ***************************/
-mjs_struct!(Tuple);
+mjs_struct!(Tuple [SpecObject]);
 impl MjsTuple {
     vec_set! {
         objtype: i32; "object types.";
@@ -1390,7 +1385,7 @@ impl MjsTuple {
 /***************************
 ** Key specification
 ***************************/
-mjs_struct!(Key);
+mjs_struct!(Key [SpecObject]);
 impl MjsKey {
     getter_setter! {
         [&] with, get, set, [
@@ -1411,7 +1406,7 @@ impl MjsKey {
 /***************************
 ** Plugin specification
 ***************************/
-mjs_struct!(Plugin);
+mjs_struct!(Plugin [SpecObject]);
 impl MjsPlugin {
     string_set_get_with! {[&]
         name; "instance name.";
@@ -1430,7 +1425,7 @@ impl MjsPlugin {
 /***************************
 ** Mesh specification
 ***************************/
-mjs_struct!(Mesh);
+mjs_struct!(Mesh [SpecObject]);
 impl MjsMesh {
     getter_setter! {
         [&] with, get, [
@@ -1479,7 +1474,7 @@ impl MjsMesh {
 /***************************
 ** Hfield specification
 ***************************/
-mjs_struct!(Hfield);
+mjs_struct!(Hfield [SpecObject]);
 impl MjsHfield {
     getter_setter! {
         [&] with, get, [
@@ -1507,7 +1502,7 @@ impl MjsHfield {
 /***************************
 ** Skin specification
 ***************************/
-mjs_struct!(Skin);
+mjs_struct!(Skin [SpecObject]);
 impl MjsSkin {
     getter_setter! {
         [&] with, get, [
@@ -1548,7 +1543,7 @@ impl MjsSkin {
 /***************************
 ** Texture specification
 ***************************/
-mjs_struct!(Texture);
+mjs_struct!(Texture [SpecObject]);
 
 /// # Note -- cube-map files
 ///
@@ -1610,7 +1605,7 @@ impl MjsTexture {
 /***************************
 ** Material specification
 ***************************/
-mjs_struct!(Material);
+mjs_struct!(Material [SpecObject]);
 
 /// # Note -- texture assignment
 ///
@@ -1652,7 +1647,7 @@ impl MjsMaterial {
 /***************************
 ** Body specification
 ***************************/
-mjs_struct!(Body {
+mjs_struct!(Body [SpecObject] {
     // Override the delete method to prevent deletion of world.
     /// Delete this body from its parent spec.
     ///
@@ -1780,14 +1775,14 @@ pub struct MjsBodyItemIter<'a, T> {
     item_type: PhantomData<T>
 }
 
-impl<'a, T: MjsElementCast> MjsBodyItemIterMut<'a, T> {
+impl<'a, T: SpecObject> MjsBodyItemIterMut<'a, T> {
     fn new(root: &'a mut MjsBody, recurse: bool) -> Self {
         let last = unsafe { mjs_firstChild(root, T::OBJ_TYPE, recurse.into()) };
         Self { root, last, recurse, item_type: PhantomData }
     }
 }
 
-impl<'a, T: MjsElementCast> MjsBodyItemIter<'a, T> {
+impl<'a, T: SpecObject> MjsBodyItemIter<'a, T> {
     fn new(root: &'a MjsBody, recurse: bool) -> Self {
         // SAFETY: mjs_firstChild requires a *mut pointer but does not mutate
         // the body. The const-to-mut cast is sound because no mutation occurs.
@@ -1796,7 +1791,7 @@ impl<'a, T: MjsElementCast> MjsBodyItemIter<'a, T> {
     }
 }
 
-impl<'a, T: MjsElementCast + 'a> Iterator for MjsBodyItemIterMut<'a, T> {
+impl<'a, T: SpecObject + 'a> Iterator for MjsBodyItemIterMut<'a, T> {
     type Item = &'a mut T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1804,14 +1799,14 @@ impl<'a, T: MjsElementCast + 'a> Iterator for MjsBodyItemIterMut<'a, T> {
             return None;
         }
         unsafe {
-            let out = T::cast_from_element(self.last).as_mut();
+            let out = T::from_element_as_ptr_mut(self.last).as_mut();
             self.last = mjs_nextChild(self.root, self.last, self.recurse.into());
             out
         }
     }
 }
 
-impl<'a, T: MjsElementCast + 'a> Iterator for MjsBodyItemIter<'a, T> {
+impl<'a, T: SpecObject + 'a> Iterator for MjsBodyItemIter<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1819,7 +1814,7 @@ impl<'a, T: MjsElementCast + 'a> Iterator for MjsBodyItemIter<'a, T> {
             return None;
         }
         unsafe {
-            let out = T::cast_from_element(self.last).as_ref();
+            let out = T::from_element_as_ptr_mut(self.last).as_ref();
             // SAFETY: mjs_nextChild requires *mut but does not mutate. Cast is sound.
             self.last = mjs_nextChild(self.root as *const _ as *mut _, self.last, self.recurse.into());
             out
@@ -1828,8 +1823,8 @@ impl<'a, T: MjsElementCast + 'a> Iterator for MjsBodyItemIter<'a, T> {
 }
 
 // Once self.last is null, next() always returns None.
-impl<'a, T: MjsElementCast + 'a> std::iter::FusedIterator for MjsBodyItemIterMut<'a, T> {}
-impl<'a, T: MjsElementCast + 'a> std::iter::FusedIterator for MjsBodyItemIter<'a, T> {}
+impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsBodyItemIterMut<'a, T> {}
+impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsBodyItemIter<'a, T> {}
 
 /// Iterator methods.
 impl MjsBody {

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -567,6 +567,56 @@ item_spec_iterator! {
     Numeric, Text, Tuple, Key, Mesh, Hfield, Skin, Texture, Material, Plugin
 }
 
+impl<'a, T: MjsElementCast> MjsSpecItemIterMut<'a, T> {
+    fn new(root: &'a mut MjSpec) -> Self {
+        let last = unsafe { mjs_firstElement(root.0.as_ptr(), T::OBJ_TYPE) };
+        Self { root, last, item_type: PhantomData }
+    }
+}
+
+impl<'a, T: MjsElementCast> MjsSpecItemIter<'a, T> {
+    fn new(root: &'a MjSpec) -> Self {
+        let last = unsafe { mjs_firstElement(root.0.as_ptr(), T::OBJ_TYPE) };
+        Self { root, last, item_type: PhantomData }
+    }
+}
+
+impl<'a, T: MjsElementCast + 'a> Iterator for MjsSpecItemIterMut<'a, T> {
+    type Item = &'a mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.last.is_null() {
+            return None;
+        }
+        unsafe {
+            let out = T::cast_from_element(self.last).as_mut();
+            // Use as_ptr() instead of ffi_mut() to avoid creating &mut mjSpec,
+            // which would alias with previously yielded &mut items.
+            self.last = mjs_nextElement(self.root.0.as_ptr(), self.last);
+            out
+        }
+    }
+}
+
+impl<'a, T: MjsElementCast + 'a> Iterator for MjsSpecItemIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.last.is_null() {
+            return None;
+        }
+        unsafe {
+            let out = T::cast_from_element(self.last).as_ref();
+            self.last = mjs_nextElement(self.root.0.as_ptr(), self.last);
+            out
+        }
+    }
+}
+
+// Once self.last is null, next() always returns None.
+impl<'a, T: MjsElementCast + 'a> std::iter::FusedIterator for MjsSpecItemIterMut<'a, T> {}
+impl<'a, T: MjsElementCast + 'a> std::iter::FusedIterator for MjsSpecItemIter<'a, T> {}
+
 /// Iterator methods.
 impl MjSpec {
     spec_get_iter! {
@@ -1730,9 +1780,56 @@ pub struct MjsBodyItemIter<'a, T> {
     item_type: PhantomData<T>
 }
 
-item_body_iterator! {
-    Body, Joint, Geom, Site, Camera, Light, Frame
+impl<'a, T: MjsElementCast> MjsBodyItemIterMut<'a, T> {
+    fn new(root: &'a mut MjsBody, recurse: bool) -> Self {
+        let last = unsafe { mjs_firstChild(root, T::OBJ_TYPE, recurse.into()) };
+        Self { root, last, recurse, item_type: PhantomData }
+    }
 }
+
+impl<'a, T: MjsElementCast> MjsBodyItemIter<'a, T> {
+    fn new(root: &'a MjsBody, recurse: bool) -> Self {
+        // SAFETY: mjs_firstChild requires a *mut pointer but does not mutate
+        // the body. The const-to-mut cast is sound because no mutation occurs.
+        let last = unsafe { mjs_firstChild(root as *const _ as *mut _, T::OBJ_TYPE, recurse.into()) };
+        Self { root, last, recurse, item_type: PhantomData }
+    }
+}
+
+impl<'a, T: MjsElementCast + 'a> Iterator for MjsBodyItemIterMut<'a, T> {
+    type Item = &'a mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.last.is_null() {
+            return None;
+        }
+        unsafe {
+            let out = T::cast_from_element(self.last).as_mut();
+            self.last = mjs_nextChild(self.root, self.last, self.recurse.into());
+            out
+        }
+    }
+}
+
+impl<'a, T: MjsElementCast + 'a> Iterator for MjsBodyItemIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.last.is_null() {
+            return None;
+        }
+        unsafe {
+            let out = T::cast_from_element(self.last).as_ref();
+            // SAFETY: mjs_nextChild requires *mut but does not mutate. Cast is sound.
+            self.last = mjs_nextChild(self.root as *const _ as *mut _, self.last, self.recurse.into());
+            out
+        }
+    }
+}
+
+// Once self.last is null, next() always returns None.
+impl<'a, T: MjsElementCast + 'a> std::iter::FusedIterator for MjsBodyItemIterMut<'a, T> {}
+impl<'a, T: MjsElementCast + 'a> std::iter::FusedIterator for MjsBodyItemIter<'a, T> {}
 
 /// Iterator methods.
 impl MjsBody {

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -7,23 +7,6 @@ use crate::mujoco_c::*;
 use super::default::MjsDefault;
 use super::utility::*;
 
-/// Provides the [`mjtObj`] discriminant and an element pointer cast for a spec item type.
-///
-/// Implemented for each type that can be traversed via `mjs_firstElement` / `mjs_nextElement`
-/// (spec-level iteration) or `mjs_firstChild` / `mjs_nextChild` (body-level iteration).
-/// Enables generic [`Iterator`] impls on [`super::MjsSpecItemIterMut`],
-/// [`super::MjsSpecItemIter`], [`super::MjsBodyItemIterMut`], and [`super::MjsBodyItemIter`].
-pub trait MjsElementCast: Sized {
-    /// The `mjtObj` discriminant passed to `mjs_firstElement` / `mjs_firstChild`.
-    const OBJ_TYPE: mjtObj;
-
-    /// Casts a raw `*mut mjsElement` to `*mut Self`.
-    ///
-    /// # Safety
-    /// `ptr` must point to a valid element of type `Self`.
-    unsafe fn cast_from_element(ptr: *mut mjsElement) -> *mut Self;
-}
-
 pub(crate) mod sealed {
     /// Prevents external implementations of [`SpecItem`](super::SpecItem).
     pub trait Sealed {}
@@ -174,4 +157,20 @@ pub trait SpecItem: Sized + sealed::Sealed {
             }
         }
     }
+}
+
+/// Represents a [`SpecItem`] that is a concrete object inside [`crate::wrappers::mj_model::MjModel`]
+/// after compilation of [`super::MjSpec`]. This includes all the [`SpecItem`]-s except [`MjsDefault`].
+/// 
+/// This trait is used internally by MuJoCo-rs to provide a generic casting interface from
+/// *mut mjsElement during iteration. 
+pub trait SpecObject: SpecItem {
+    /// The `mjtObj` discriminant passed to `mjs_firstElement` / `mjs_firstChild`.
+    const OBJ_TYPE: mjtObj;
+
+    /// Casts a raw `*mut mjsElement` to `*mut Self`.
+    ///
+    /// # Safety
+    /// `ptr` must point to a valid element of type `Self`.
+    unsafe fn from_element_as_ptr_mut(ptr: *mut mjsElement) -> *mut Self;
 }

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -7,6 +7,23 @@ use crate::mujoco_c::*;
 use super::default::MjsDefault;
 use super::utility::*;
 
+/// Provides the [`mjtObj`] discriminant and an element pointer cast for a spec item type.
+///
+/// Implemented for each type that can be traversed via `mjs_firstElement` / `mjs_nextElement`
+/// (spec-level iteration) or `mjs_firstChild` / `mjs_nextChild` (body-level iteration).
+/// Enables generic [`Iterator`] impls on [`super::MjsSpecItemIterMut`],
+/// [`super::MjsSpecItemIter`], [`super::MjsBodyItemIterMut`], and [`super::MjsBodyItemIter`].
+pub trait MjsElementCast: Sized {
+    /// The `mjtObj` discriminant passed to `mjs_firstElement` / `mjs_firstChild`.
+    const OBJ_TYPE: mjtObj;
+
+    /// Casts a raw `*mut mjsElement` to `*mut Self`.
+    ///
+    /// # Safety
+    /// `ptr` must point to a valid element of type `Self`.
+    unsafe fn cast_from_element(ptr: *mut mjsElement) -> *mut Self;
+}
+
 pub(crate) mod sealed {
     /// Prevents external implementations of [`SpecItem`](super::SpecItem).
     pub trait Sealed {}

--- a/src/wrappers/mj_editing/utility.rs
+++ b/src/wrappers/mj_editing/utility.rs
@@ -352,8 +352,10 @@ macro_rules! find_x_method_direct {
 
 /// Creates a wrapper around a mjs$ffi_name item. It also implements the methods: `ffi()`, `ffi_mut()`
 /// and traits: [`SpecItem`](super::traits::SpecItem), [`Sync`], [`Send`].
+/// 
+/// When `[SpecObject]` is given to the right of `ffi_name`, the SpecObject trait also gets implemented.
 macro_rules! mjs_struct {
-    ($ffi_name:ident $({ $($extra_trait_methods:tt)* })?) => {paste::paste!{
+    ($ffi_name:ident $([$SpecObject:ident])? $({ $($extra_trait_methods:tt)* })?) => {paste::paste!{
         #[doc = concat!(stringify!($ffi_name), " specification. This is an alias to the FFI type [`", stringify!([<mjs $ffi_name>]), "`].")]
         pub type [<Mjs $ffi_name>] = [<mjs $ffi_name>];
 
@@ -387,6 +389,18 @@ macro_rules! mjs_struct {
             )*)?
         }
 
+
+        $(
+            impl $SpecObject for [<Mjs $ffi_name>] {
+                const OBJ_TYPE: MjtObj = MjtObj::[<mjOBJ_ $ffi_name:upper>];
+                unsafe fn from_element_as_ptr_mut(element: *mut mjsElement) -> *mut Self {
+                    // SAFETY: *const conversion to *mut is valid, because mjs_as returns mut originally,
+                    // thus the data itself is *mut.
+                    unsafe { [<mjs_as $ffi_name:camel>](element) }
+                }
+            }
+        )?
+
         // SAFETY: Mjs* types are raw pointer wrappers. All shared-reference access goes
         // through &self methods that do not mutate state. All mutation requires &mut self,
         // which guarantees no concurrent aliasing. The pointer is valid for the lifetime
@@ -395,7 +409,6 @@ macro_rules! mjs_struct {
         unsafe impl Send for [<Mjs $ffi_name>] {}
     }};
 }
-
 
 /// Implements the userdata method.
 macro_rules! userdata_method {
@@ -629,22 +642,6 @@ macro_rules! vec_vec_append {
         )*
     }};
 }
-
-/// Implements [`MjsElementCast`] for each type that can be iterated in [`super::MjSpec`].
-macro_rules! item_spec_iterator {
-    ($($iter_over: ident),*) => {paste::paste!{
-        $(
-            impl MjsElementCast for [<Mjs $iter_over>] {
-                const OBJ_TYPE: MjtObj = MjtObj::[<mjOBJ_ $iter_over:upper>];
-
-                unsafe fn cast_from_element(ptr: *mut mjsElement) -> *mut Self {
-                    unsafe { [<mjs_as $iter_over>](ptr) }
-                }
-            }
-        )*
-    }};
-}
-
 
 /// Generates methods for obtaining iterators to `$iter_over` spec items.
 macro_rules! spec_get_iter {

--- a/src/wrappers/mj_editing/utility.rs
+++ b/src/wrappers/mj_editing/utility.rs
@@ -630,61 +630,17 @@ macro_rules! vec_vec_append {
     }};
 }
 
-/// Implements iterators for individual items in [MjSpec](super::MjSpec).
+/// Implements [`MjsElementCast`] for each type that can be iterated in [`super::MjSpec`].
 macro_rules! item_spec_iterator {
     ($($iter_over: ident),*) => {paste::paste!{
         $(
-            impl<'a> MjsSpecItemIterMut<'a, [<Mjs $iter_over>]> {
-                fn new(root: &'a mut MjSpec) -> Self {
-                    let last = unsafe { mjs_firstElement(root.0.as_ptr(), MjtObj::[<mjOBJ_ $iter_over:upper>]) };
-                    Self { root, last, item_type: PhantomData }
+            impl MjsElementCast for [<Mjs $iter_over>] {
+                const OBJ_TYPE: MjtObj = MjtObj::[<mjOBJ_ $iter_over:upper>];
+
+                unsafe fn cast_from_element(ptr: *mut mjsElement) -> *mut Self {
+                    unsafe { [<mjs_as $iter_over>](ptr) }
                 }
             }
-
-            impl<'a> MjsSpecItemIter<'a, [<Mjs $iter_over>]> {
-                fn new(root: &'a MjSpec) -> Self {
-                    let last = unsafe { mjs_firstElement(root.0.as_ptr(), MjtObj::[<mjOBJ_ $iter_over:upper>]) };
-                    Self { root, last, item_type: PhantomData }
-                }
-            }
-
-            impl<'a> Iterator for MjsSpecItemIterMut<'a, [<Mjs $iter_over>]> {
-                type Item = &'a mut [<Mjs $iter_over>];
-
-                fn next(&mut self) -> Option<Self::Item> {
-                    if self.last.is_null() {
-                        return None;
-                    }
-
-                    unsafe {
-                        let out = [<mjs_as $iter_over>](self.last).as_mut();
-                        // Use as_ptr() instead of ffi_mut() to avoid creating &mut mjSpec,
-                        // which would alias with previously yielded &mut items.
-                        self.last = mjs_nextElement(self.root.0.as_ptr(), self.last);
-                        out
-                    }
-                }
-            }
-
-            impl<'a> Iterator for MjsSpecItemIter<'a, [<Mjs $iter_over>]> {
-                type Item = &'a [<Mjs $iter_over>];
-
-                fn next(&mut self) -> Option<Self::Item> {
-                    if self.last.is_null() {
-                        return None;
-                    }
-
-                    unsafe {
-                        let out = [<mjs_as $iter_over>](self.last).as_ref();
-                        self.last = mjs_nextElement(self.root.0.as_ptr(), self.last);
-                        out
-                    }
-                }
-            }
-
-            // Once self.last is null, next() always returns None.
-            impl<'a> std::iter::FusedIterator for MjsSpecItemIterMut<'a, [<Mjs $iter_over>]> {}
-            impl<'a> std::iter::FusedIterator for MjsSpecItemIter<'a, [<Mjs $iter_over>]> {}
         )*
     }};
 }
@@ -707,66 +663,6 @@ macro_rules! spec_get_iter {
     }};
 }
 
-
-/// Implements iterators for individual items in [MjsBody](super::MjsBody).
-macro_rules! item_body_iterator {
-    ($($iter_over: ident),*) => {paste::paste!{
-        $(
-            impl<'a> MjsBodyItemIterMut<'a, [<Mjs $iter_over>]> {
-                fn new(root: &'a mut MjsBody, recurse: bool) -> Self {
-                    let last = unsafe { mjs_firstChild(root, MjtObj::[<mjOBJ_ $iter_over:upper>], recurse.into()) };
-                    Self { root, last, recurse, item_type: PhantomData }
-                }
-            }
-
-            impl<'a> MjsBodyItemIter<'a, [<Mjs $iter_over>]> {
-                fn new(root: &'a MjsBody, recurse: bool) -> Self {
-                    // SAFETY: mjs_firstChild requires a *mut pointer but does not mutate
-                    // the body. The const-to-mut cast is sound because no mutation occurs.
-                    let last = unsafe { mjs_firstChild(root as *const _ as *mut _, MjtObj::[<mjOBJ_ $iter_over:upper>], recurse.into()) };
-                    Self { root, last, recurse, item_type: PhantomData }
-                }
-            }
-
-            impl<'a> Iterator for MjsBodyItemIterMut<'a, [<Mjs $iter_over>]> {
-                type Item = &'a mut [<Mjs $iter_over>];
-
-                fn next(&mut self) -> Option<Self::Item> {
-                    if self.last.is_null() {
-                        return None;
-                    }
-
-                    unsafe {
-                        let out = [<mjs_as $iter_over>](self.last).as_mut();
-                        self.last = mjs_nextChild(self.root, self.last, self.recurse.into());
-                        out
-                    }
-                }
-            }
-
-            impl<'a> Iterator for MjsBodyItemIter<'a, [<Mjs $iter_over>]> {
-                type Item = &'a [<Mjs $iter_over>];
-
-                fn next(&mut self) -> Option<Self::Item> {
-                    if self.last.is_null() {
-                        return None;
-                    }
-
-                    unsafe {
-                        let out = [<mjs_as $iter_over>](self.last).as_ref();
-                        // SAFETY: mjs_nextChild requires *mut but does not mutate. Cast is sound.
-                        self.last = mjs_nextChild(self.root as *const _ as *mut _, self.last, self.recurse.into());
-                        out
-                    }
-                }
-            }
-
-            // Once self.last is null, next() always returns None.
-            impl<'a> std::iter::FusedIterator for MjsBodyItemIterMut<'a, [<Mjs $iter_over>]> {}
-            impl<'a> std::iter::FusedIterator for MjsBodyItemIter<'a, [<Mjs $iter_over>]> {}
-        )*
-    }};
-}
 
 /// Generates methods for obtaining iterators to `$iter_over` body items.
 /// The $self_lf represents the iterated item's borrow and $parent_lf the lifetime of its parent.


### PR DESCRIPTION
Refactor Model Editing macros to generate less direct duplicated code. This was done by creating a common trait (`SpecObject`) for spec items that are actual things after compilation and creating a generic implementation for existing traits, which are generic for `SpecObject`.

Previously, common items were just recreated via a macro for each type.