### PR TITLE
Refactor the model-editing delete mechanism (resolve its undefined behavior)

### DIFF
--- a/.github/rules/coding-conventions.md
+++ b/.github/rules/coding-conventions.md
@@ -13,6 +13,9 @@
   (e.g. RST-style double backticks in Rust doc comments) in **new, uncommitted changes**. Existing
   committed code on `develop` or `main` should be left as-is unless it contains actually invalid
   or broken syntax.
+- **Do not make unnecessary edits to already compiling code.** If the requested task is satisfied
+  and the code compiles, avoid extra refactors, renames, or cleanup-only changes that are not
+  required for correctness.
 
 ## Feature flags
 - Read `Cargo.toml` to discover available features and their default state.

--- a/.github/rules/important-context.md
+++ b/.github/rules/important-context.md
@@ -10,6 +10,7 @@
 | Code generation | Check if `../mujoco-rs-utils` exists and run with `--help` |
 | Running tests | Use the `/test` workflow |
 | Running examples | Use the `/run-example` workflow |
+| Running Miri | Use the `/miri` workflow; apply a minimal temporary direct patch to the user-selected example if needed |
 | Feature flags | Read `Cargo.toml` `[features]` section |
 | Documentation URLs | See `project-overview.md` |
 

--- a/.github/rules/rule-compliance.md
+++ b/.github/rules/rule-compliance.md
@@ -11,3 +11,6 @@ Rules for the main agent to stay compliant with this project's conventions throu
 
 3. **Pre-compaction TODO.** When context compaction appears imminent (e.g., the conversation is very
    long), add a TODO reminder to re-read the rules immediately after compaction occurs.
+
+4. **Minimal-change enforcement.** Do not introduce non-essential edits when existing code already
+   compiles and the requested task is complete. Keep changes scoped to required correctness work.

--- a/.github/skills/miri/SKILL.md
+++ b/.github/skills/miri/SKILL.md
@@ -26,22 +26,40 @@ Run the codebase under Miri's experimental FFI native-lib support to detect unde
    cmake --build build --parallel --target mujoco
    ```
 
-2. **Setup environment and Run**:
-   Run the codebase under Miri using the built library. Replace `<EXAMPLE_NAME>` as needed:
+2. **Select the example and prepare a temporary minimal patch**:
+   Pick the example requested by the user and patch it directly with the smallest possible temporary change so Miri can run.
+
+   Use this pattern:
+   - Do **not** add long-lived `#[cfg(miri)]` / `#[cfg(not(miri))]` scaffolding.
+   - Apply only the minimal temporary edits needed (for example, initialize `setup_miri_bump_allocator`, simplify/shorten runtime loop, avoid viewer/GL-only paths).
+   - Keep edits tightly scoped to the selected example and preserve behavior as much as possible.
+
+3. **Setup environment and run the selected example**:
+   Run under Miri using the built library. Replace `<EXAMPLE_NAME>` and `X.Y.Z`:
    ```bash
    # Set paths and Miri flags (using build/lib64/ or build/lib/ depending on your system)
-   # Replace X.Y.Z with the MuJoCo version from Cargo.toml (e.g. +mj-3.6.0 -> 3.6.0)
+   # Replace X.Y.Z with the MuJoCo version from Cargo.toml (e.g. +mj-3.9.0 -> 3.9.0)
    export MUJOCO_DYNAMIC_LINK_DIR=$(realpath build/lib64/) && \
    export LD_LIBRARY_PATH=$(realpath build/lib64/) && \
-   export MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-native-lib=$(realpath build/lib64/libmujoco.so.X.Y.Z) -Zmiri-permissive-provenance -Zmiri-symbolic-alignment-check" && \
+   export MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-native-lib=$(realpath build/lib64/libmujoco.so.X.Y.Z) -Zmiri-permissive-provenance -Zmiri-symbolic-alignment-check -Zmiri-deterministic-concurrency -Zmiri-backtrace=full -Zmiri-report-progress -Zmiri-tree-borrows -Zmiri-track-alloc-accesses" && \
    cd .. && \
-   cargo +nightly miri run --example miri_test --features renderer
+   cargo +nightly miri run --example <EXAMPLE_NAME> --features <REQUIRED_FEATURES>
    ```
+   - Do not pipe the Miri command through `tail`, `head`, or `grep` while streaming; those can buffer and delay visible output.
 
-3. **Verify results**:
-   Check for any "Undefined Behavior" reports in the output. A clean run ending with "Comprehensive test completed successfully!" indicates success.
+   For targeted deep-dive tracing, extend `MIRIFLAGS` with:
+   - `-Zmiri-track-alloc-id=...`
+   - `-Zmiri-track-pointer-tag=...`
+
+4. **Verify results and clean up**:
+   - Check for any `error: Undefined Behavior` reports.
+   - The warning about "sharing memory with a native function called via FFI" is expected when calling `setup_miri_bump_allocator`.
+   - Treat the example edits as temporary: always revert them after investigation.
+   - Do not commit persistent Miri-only wiring in user-facing examples.
 
 > [!NOTE]
 > - **Global Allocator**: When `MUJOCO_MIRI_SUPPORT` is enabled, the MuJoCo build uses linker-level wrapping (`--wrap`) to intercept all internal C++ `operator new`/`delete` calls and redirect them to a specialized Miri bump allocator.
+> - **Verbose output**: The default flags intentionally increase log volume (`backtrace=full`, `report-progress`, alloc access tracking) to maximize diagnosability.
 > - **Provenance**: `-Zmiri-permissive-provenance` is essential because MuJoCo (a C library) manages its own memory, which Rust then accesses.
+> - **Strict provenance**: `-Zmiri-strict-provenance` is not compatible with native FFI calls; do not use it for MuJoCo-backed runs.
 > - **Target Limitation**: Miri with native libs can only run on `bin` targets or `examples`. It cannot currently run the standard Rust test harness on `lib` targets due to compiler limitations.

--- a/docs/guide/source/_extensions/docs-rs.py
+++ b/docs/guide/source/_extensions/docs-rs.py
@@ -68,7 +68,7 @@ def link_docs_rs(name, rawtext, text: str, lineno, inliner, options={}, content=
         for i, (mapped, type_) in enumerate(map_specifier(parts)):
             parts[i] = mapped
 
-        if type_ in {"method", "variant", "structfield"}:  # last iteration result
+        if type_ in {"method", "variant", "structfield", "tymethod"}:  # last iteration result
             parts[-2] += ".html"
             html_ref = parts.pop()
         elif type_:

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -27,6 +27,7 @@ update of MuJoCo alone can increase the major version.
 
 .. Template titles
   .. rubric:: Breaking changes
+  .. rubric:: Deprecations
   .. rubric:: Error handling
   .. rubric:: New features and improvements
   .. rubric:: Bug fixes
@@ -92,6 +93,14 @@ update of MuJoCo alone can increase the major version.
   to compile. Replace it with
   :docs-rs:`~mujoco_rs::error::<enum>MjModelError::<variant>IndexOutOfBounds`
   (see migration guide).
+
+.. rubric:: Deprecations
+
+- Deprecated :docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>delete`
+  due to it relying on **undefined behavior**.
+  Users are expected to use
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>delete_element`
+  instead.
 
 .. rubric:: Error handling
 
@@ -195,8 +204,8 @@ runtime.
 - Fixed a model-editing potential undefined behavior in |mjs_body|, which occurred
   when yielded references of body's items were not destroyed before the next entry
   to the iterator. This was problematic if individual references of yielded items
-  were stored and later used --- technically a undefined behavior due to reuse of the |mjs_body|
-  inside the iterator. The |mjs_body| parent is now stored as a raw FFI pointer to prevent such
+  were stored and later used --- technically a undefined behavior due to reuse of the ``MjsBody``
+  inside the iterator. The ``MjsBody`` parent is now stored as a raw FFI pointer to prevent such
   aliasing.
 
 
@@ -210,6 +219,9 @@ runtime.
   ``MjtBool`` migration.
 - Added missing ``mjt*`` type aliases for recently surfaced MuJoCo enums: ``MjtMeshBuiltin``, ``MjtCTimer``.
 - Added auxiliary exposed aliases: ``MjPreContact``, ``MjfCollision``, ``MjpResourceProvider``.
+- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<tymethod>element_pointer`
+  and :docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>element_mut_pointer`
+  are no longer marked ``unsafe``.
 
 
 4.0.1 (MuJoCo 3.8.0)

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -24,6 +24,34 @@ For a full list of changes, see the :ref:`changelog`.
 Migrating to 5.0.0
 ======================
 
+Deprecated implementation of removing model-editing elements
+--------------------------------------------------------------
+Due to the :docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>delete`
+method relying on undefined behavior, the said method is now deprecated.
+It's replacement --- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>delete_element` ---
+now forces the user to drop all existing references of |mj_spec| and its
+subsequent elements (geoms, joints, etc.), providing some inconvenience
+compared to the previous implementation but with a benefit of being safe.
+Consequently, the new method is also no longer marked ``unsafe``.
+
+**Before (4.x)**:
+
+.. code-block:: rust
+
+  let mut spec = MjSpec::new();
+  let body = spec.world_body_mut().add_body();  // &mut MjsBody
+  unsafe { body.delete().unwrap() } ;
+
+**After**:
+
+.. code-block:: rust
+
+  let mut spec = MjSpec::new();
+  let body = spec.world_body_mut().add_body();  // &mut MjsBody
+  let body_ptr = body.element_mut_pointer();    // *mut MjsBody (alias to FFI type *mut mjsBody)
+  spec.delete_element(body_ptr).unwrap();       // 'body' can no longer be used 
+
+
 ``MjrContext::upload_texture`` parameter type changed
 -----------------------------------------------------
 

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -31,8 +31,7 @@ method relying on undefined behavior, the said method is now deprecated.
 It's replacement --- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>delete_element` ---
 now forces the user to drop all existing references of |mj_spec| and its
 subsequent elements (geoms, joints, etc.), providing some inconvenience
-compared to the previous implementation but with a benefit of being safe.
-Consequently, the new method is also no longer marked ``unsafe``.
+compared to the previous implementation.
 
 **Before (4.x)**:
 
@@ -42,14 +41,14 @@ Consequently, the new method is also no longer marked ``unsafe``.
   let body = spec.world_body_mut().add_body();  // &mut MjsBody
   unsafe { body.delete().unwrap() } ;
 
-**After**:
+**After (5.0.0)**:
 
 .. code-block:: rust
 
   let mut spec = MjSpec::new();
   let body = spec.world_body_mut().add_body();  // &mut MjsBody
-  let body_ptr = body.element_mut_pointer();    // *mut MjsBody (alias to FFI type *mut mjsBody)
-  spec.delete_element(body_ptr).unwrap();       // 'body' can no longer be used 
+  let body_ptr = body.element_mut_pointer();
+  unsafe { spec.delete_element(body_ptr).unwrap() }
 
 
 ``MjrContext::upload_texture`` parameter type changed

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -348,10 +348,12 @@ impl MjSpec {
     /// Returns [`MjEditError::DeleteFailed`] if MuJoCo cannot delete the element.
     ///
     /// # Safety
-    /// `element` must be a valid pointer to an element owned by this spec.
-    /// Any Rust references derived from that element before a successful call
-    /// must not be used afterward.
-    pub fn delete_element(&mut self, element: *mut mjsElement) -> Result<(), MjEditError> {
+    /// The caller must ensure:
+    /// - `element` is a valid pointer to an mjsElement
+    /// - `element` is owned by this spec
+    /// - `element` has not been previously deleted
+    /// - no Rust references derived from `element` exist
+    pub unsafe fn delete_element(&mut self, element: *mut mjsElement) -> Result<(), MjEditError> {
         if element.is_null() {
             return Err(MjEditError::DeleteFailed("null element pointer".to_owned()));
         }
@@ -2043,7 +2045,7 @@ mod tests {
         /* Test normal body deletion */
         let body_element = {
             let body = spec.body_mut(NEW_MODEL_NAME).expect("failed to obtain the body");
-            unsafe { body.element_mut_pointer() }
+            body.element_mut_pointer()
         };
         assert!(unsafe { spec.delete_element(body_element) }.is_ok(), "failed to delete model");
         assert!(spec.body(NEW_MODEL_NAME).is_none(), "body was not removed from spec");
@@ -2051,7 +2053,7 @@ mod tests {
         /* Test world body deletion */
         let world_element = {
             let world = spec.world_body_mut();
-            unsafe { world.element_mut_pointer() }
+            world.element_mut_pointer()
         };
         assert!(unsafe { spec.delete_element(world_element) }.is_err(), "the world model should not be deletable");
 
@@ -2070,7 +2072,7 @@ mod tests {
         /* Test normal body deletion */
         let joint_element = {
             let joint = spec.joint_mut(NEW_NAME).expect("failed to obtain the body");
-            unsafe { joint.element_mut_pointer() }
+            joint.element_mut_pointer()
         };
         assert!(unsafe { spec.delete_element(joint_element) }.is_ok(), "failed to delete model");
         assert!(spec.joint(NEW_NAME).is_none(), "body was not removed fom spec");
@@ -2089,7 +2091,7 @@ mod tests {
         /* Test normal hfield deletion */
         let hfield_element = {
             let hfield = spec.hfield_mut(NEW_NAME).expect("failed to obtain the hfield");
-            unsafe { hfield.element_mut_pointer() }
+            hfield.element_mut_pointer()
         };
         assert!(unsafe { spec.delete_element(hfield_element) }.is_ok(), "failed to delete hfield");
         assert!(spec.hfield(NEW_NAME).is_none(), "hfield was not removed from spec");

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -342,6 +342,53 @@ impl MjSpec {
         unsafe { self.0.as_mut() }
     }
 
+    /// Delete an element from this specification.
+    ///
+    /// # Errors
+    /// Returns [`MjEditError::DeleteFailed`] if MuJoCo cannot delete the element.
+    ///
+    /// # Safety
+    /// `element` must be a valid pointer to an element owned by this spec.
+    /// Any Rust references derived from that element before a successful call
+    /// must not be used afterward.
+    pub unsafe fn delete_element(&mut self, element: *mut mjsElement) -> Result<(), MjEditError> {
+        if element.is_null() {
+            return Err(MjEditError::DeleteFailed("null element pointer".to_owned()));
+        }
+
+        let spec = unsafe { self.ffi_mut() };
+        let owner = unsafe { mjs_getSpec(element) };
+        if owner != spec {
+            return Err(MjEditError::DeleteFailed("element does not belong to this spec".to_owned()));
+        }
+
+        if unsafe { (*element).elemtype } == MjtObj::mjOBJ_DEFAULT {
+            return Err(MjEditError::UnsupportedOperation);
+        }
+        if unsafe { (*element).elemtype } == MjtObj::mjOBJ_BODY {
+            let name = unsafe { read_mjs_string(mjs_getName(element)) };
+            if name == "world" {
+                return Err(MjEditError::UnsupportedOperation);
+            }
+        }
+
+        let result = unsafe { mjs_delete(spec, element) };
+        match result {
+            0 => Ok(()),
+            _ => {
+                let error_msg = unsafe {
+                    let ptr = mjs_getError(spec);
+                    if ptr.is_null() {
+                        "Unknown error".to_owned()
+                    } else {
+                        CStr::from_ptr(ptr).to_string_lossy().into_owned()
+                    }
+                };
+                Err(MjEditError::DeleteFailed(error_msg))
+            }
+        }
+    }
+
     /// Compile [`MjSpec`] to [`MjModel`].
     /// A spec can be edited and compiled multiple times,
     /// returning a new mjModel instance that takes the edits into account.
@@ -1677,19 +1724,19 @@ mjs_struct!(Body [SpecObject] {
     // Override the delete method to prevent deletion of world.
     /// Delete this body from its parent spec.
     ///
-    /// This method must be called **at most once** per body. After a successful deletion
-    /// the underlying C body and all of its children (joints, geoms, sites, etc.) are freed
-    /// by MuJoCo; any further use of `self` or of references to child elements obtained
-    /// before this call is **use-after-free** undefined behavior. If the call returns `Err`,
-    /// nothing is freed and the body remains valid.
+    /// # Deprecated
+    /// This API is deprecated and will be removed in a future release.
+    /// Use [`MjSpec::delete_element`](crate::wrappers::MjSpec::delete_element) instead.
+    ///
+    /// This method is inherently unsound: deleting a body mutates owner/ancestor graph
+    /// structures outside the borrowed `&mut self` region.
     ///
     /// # Errors
     /// - Returns [`MjEditError::UnsupportedOperation`] if this is the world body.
     /// - Returns [`MjEditError::DeleteFailed`] if MuJoCo's internal deletion fails.
     ///
     /// # Safety
-    /// The caller must guarantee that no references to this body or any of its children
-    /// remain live after a successful return, as the underlying C memory will have been freed.
+    /// This legacy method is not soundly callable; it exists only for backward compatibility.
     unsafe fn delete(&mut self) -> Result<(), MjEditError> {
         if self.name() == "world" {
             return Err(MjEditError::UnsupportedOperation);
@@ -1994,13 +2041,19 @@ mod tests {
         body.set_name(NEW_MODEL_NAME).unwrap();
 
         /* Test normal body deletion */
-        let body = spec.body_mut(NEW_MODEL_NAME).expect("failed to obtain the body");
-        assert!(unsafe { body.delete() }.is_ok(), "failed to delete model");
+        let body_element = {
+            let body = spec.body_mut(NEW_MODEL_NAME).expect("failed to obtain the body");
+            unsafe { body.element_mut_pointer() }
+        };
+        assert!(unsafe { spec.delete_element(body_element) }.is_ok(), "failed to delete model");
         assert!(spec.body(NEW_MODEL_NAME).is_none(), "body was not removed from spec");
 
         /* Test world body deletion */
-        let world = spec.world_body_mut();
-        assert!(unsafe { world.delete() }.is_err(), "the world model should not be deletable");
+        let world_element = {
+            let world = spec.world_body_mut();
+            unsafe { world.element_mut_pointer() }
+        };
+        assert!(unsafe { spec.delete_element(world_element) }.is_err(), "the world model should not be deletable");
 
         spec.compile().unwrap();
     }
@@ -2015,8 +2068,11 @@ mod tests {
         joint.set_name(NEW_NAME).unwrap();
 
         /* Test normal body deletion */
-        let joint = spec.joint_mut(NEW_NAME).expect("failed to obtain the body");
-        assert!(unsafe { joint.delete() }.is_ok(), "failed to delete model");
+        let joint_element = {
+            let joint = spec.joint_mut(NEW_NAME).expect("failed to obtain the body");
+            unsafe { joint.element_mut_pointer() }
+        };
+        assert!(unsafe { spec.delete_element(joint_element) }.is_ok(), "failed to delete model");
         assert!(spec.joint(NEW_NAME).is_none(), "body was not removed fom spec");
 
         spec.compile().unwrap();
@@ -2031,8 +2087,11 @@ mod tests {
         hfield.set_name(NEW_NAME).unwrap();
 
         /* Test normal hfield deletion */
-        let hfield = spec.hfield_mut(NEW_NAME).expect("failed to obtain the hfield");
-        assert!(unsafe { hfield.delete() }.is_ok(), "failed to delete hfield");
+        let hfield_element = {
+            let hfield = spec.hfield_mut(NEW_NAME).expect("failed to obtain the hfield");
+            unsafe { hfield.element_mut_pointer() }
+        };
+        assert!(unsafe { spec.delete_element(hfield_element) }.is_ok(), "failed to delete hfield");
         assert!(spec.hfield(NEW_NAME).is_none(), "hfield was not removed from spec");
 
         spec.compile().unwrap();

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -351,7 +351,7 @@ impl MjSpec {
     /// `element` must be a valid pointer to an element owned by this spec.
     /// Any Rust references derived from that element before a successful call
     /// must not be used afterward.
-    pub unsafe fn delete_element(&mut self, element: *mut mjsElement) -> Result<(), MjEditError> {
+    pub fn delete_element(&mut self, element: *mut mjsElement) -> Result<(), MjEditError> {
         if element.is_null() {
             return Err(MjEditError::DeleteFailed("null element pointer".to_owned()));
         }

--- a/src/wrappers/mj_editing/default.rs
+++ b/src/wrappers/mj_editing/default.rs
@@ -45,7 +45,7 @@ impl MjsDefault {
 impl super::traits::sealed::Sealed for MjsDefault {}
 
 impl SpecItem for MjsDefault {
-    unsafe fn element_pointer(&self) -> *const mjsElement {
+    fn element_pointer(&self) -> *const mjsElement {
         self.element
     }
 

--- a/src/wrappers/mj_editing/default.rs
+++ b/src/wrappers/mj_editing/default.rs
@@ -77,6 +77,10 @@ impl SpecItem for MjsDefault {
 
     /// Defaults can't be deleted.
     ///
+    /// # Deprecated
+    /// This API is deprecated and will be removed in a future release.
+    /// Use [`MjSpec::delete_element`](super::MjSpec::delete_element) instead.
+    ///
     /// This override always returns [`MjEditError::UnsupportedOperation`] without performing
     /// any operation, so the post-deletion use-after-free restriction from [`SpecItem::delete`]
     /// does not apply -- `self` remains valid after an `Err` return.

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -24,16 +24,16 @@ pub trait SpecItem: Sized + sealed::Sealed {
     /// # Safety
     /// This borrows immutably, but returns a mutable pointer. This is done to overcome MJS's wrong
     /// use of mutable pointers in functions, such as [`mjs_getName`].
-    unsafe fn element_pointer(&self) -> *const mjsElement;
+    fn element_pointer(&self) -> *const mjsElement;
 
     /// Same as [`SpecItem::element_pointer`], but with a mutable borrow.
     ///
     /// # Safety
     /// See [`SpecItem::element_pointer`].
-    unsafe fn element_mut_pointer(&mut self) -> *mut mjsElement {
+    fn element_mut_pointer(&mut self) -> *mut mjsElement {
         // SAFETY: self.element is a valid non-null pointer to the C spec element
         // for the lifetime of the parent MjSpec (struct invariant).
-        unsafe { self.element_pointer() as *mut _ }
+        self.element_pointer() as *mut _
     }
 
     /// Returns the item's name.
@@ -94,7 +94,7 @@ pub trait SpecItem: Sized + sealed::Sealed {
     fn set_default(&mut self, class_name: &str) -> Result<(), MjEditError> {
         /* Workaround to pass the borrow checker (we use the existing borrow) */
         let cname = CString::new(class_name).unwrap();  // class_name is always valid UTF-8.
-        let element = unsafe { self.element_pointer() };
+        let element = self.element_pointer();
         let spec = unsafe { mjs_getSpec(element) };
         let default = unsafe { mjs_findDefault(spec, cname.as_ptr()) };
         if default.is_null() {
@@ -155,7 +155,7 @@ pub trait SpecItem: Sized + sealed::Sealed {
     unsafe fn __delete_default__(&mut self) -> Result<(), MjEditError> {
         // SAFETY: element_mut_pointer() is valid (struct invariant); mjs_getSpec
         // returns the owning spec, also valid.
-        let element = unsafe { self.element_mut_pointer() };
+        let element = self.element_mut_pointer();
         let spec = unsafe { mjs_getSpec(element) };
         let result = unsafe { mjs_delete(spec, element) };
         match result {

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -117,10 +117,16 @@ pub trait SpecItem: Sized + sealed::Sealed {
 
     /// Delete the item.
     ///
-    /// This method must be called **at most once** per item. After a successful deletion
-    /// the underlying C element is freed by MuJoCo; any further use of `self` -- including
-    /// calling `delete` again or reading any field -- is **use-after-free** undefined behavior.
-    /// If the call returns `Err`, no memory is freed and the item remains valid.
+    /// # Deprecated
+    /// This API is deprecated and will be removed in a future release.
+    /// Use [`MjSpec::delete_element`](super::MjSpec::delete_element) instead.
+    ///
+    /// This method is inherently unsound: deleting one element mutates owner/ancestor graph
+    /// structures outside the borrowed `&mut self` region, so aliasing assumptions of existing
+    /// Rust references can already be violated by the call itself.
+    ///
+    /// In other words, calling this method is **undefined behavior** and should be avoided.
+    /// Use [`MjSpec::delete_element`](super::MjSpec::delete_element) for deletion.
     ///
     /// # Errors
     /// - [`MjEditError::DeleteFailed`] if MuJoCo cannot delete the element.
@@ -128,11 +134,11 @@ pub trait SpecItem: Sized + sealed::Sealed {
     ///   (e.g. the world body or default classes).
     ///
     /// # Safety
-    /// The `&mut self` receiver prevents aliased mutable access at the call site, but the
-    /// Rust compiler cannot prevent the caller from retaining other references (shared or
-    /// mutable) that were obtained before this call. The caller must guarantee that no such
-    /// references remain live after a successful return, as the underlying C memory will
-    /// have been freed. Violating this invariant is **use-after-free** undefined behavior.
+    /// This legacy method is not soundly callable; it exists only for backward compatibility.
+    #[deprecated(
+        since = "5.0.0",
+        note = "unsound legacy API; use MjSpec::delete_element(element_mut_pointer())"
+    )]
     unsafe fn delete(&mut self) -> Result<(), MjEditError> {
         unsafe { self.__delete_default__() }
     }

--- a/src/wrappers/mj_editing/utility.rs
+++ b/src/wrappers/mj_editing/utility.rs
@@ -380,7 +380,7 @@ macro_rules! mjs_struct {
         impl crate::wrappers::mj_editing::traits::sealed::Sealed for [<Mjs $ffi_name>] {}
 
         impl SpecItem for [<Mjs $ffi_name>] {
-            unsafe fn element_pointer(&self) -> *const mjsElement {
+            fn element_pointer(&self) -> *const mjsElement {
                 self.element
             }
 


### PR DESCRIPTION
Model editing in MuJoCo-rs is primarily handled by a wrapper around `*mut mjSpec`, named `MjSpec`, which acts as an owned instance. For idiomatic purposes and duplication avoidance, the rest of the model-editing items are tracked rust references created from raw pointers, with lifetimes tied to their parent. This however creates problems related to possible undefined behaviors, which the original `SpecItem::delete` has (`SpecItem` is a trait that is implemented for all of Spec's items/children). The problem is, it modifies both the spec and the parent(s), of the item being deletes, outside of the parent's mutable borrow.

This PR addresses this by moving the deletion logic to `MjSpec` itself. Even if the item's parent is mutably borrowed, the borrow checker will see a new mutable borrow of the spec and invalidate all the children's borrows, preventing undefined behavior through mutation outside of the mutable borrow. This new method is `MjSpec::delete_element`.