### PR TITLE
Add missing documentation and fix references

### DIFF
--- a/.github/rules/subagent-policy.md
+++ b/.github/rules/subagent-policy.md
@@ -25,41 +25,23 @@ conventions:
    background subagents (mode `"background"`), immediately use `ask_user` to ask what to work on
    while waiting for the subagents to finish. Do not sit idle.
 
-6. **Limit parallel high-cost agents.** Do not launch more than 3 parallel agents using premium
-   models (e.g. Claude Opus 4.6) to avoid rate-limit errors. For cheaper models (Haiku, Sonnet),
-   higher parallelism is acceptable.
-
-7. **Choose agent model by task complexity.** Match the model to the work:
-   - **Claude Haiku 4.5** (`claude-haiku-4.5`): Simple, mechanical tasks -- file searches, running
-     commands, pattern replacements, build/test execution, prerequisite validation.
-   - **Claude Sonnet 4.6** (`claude-sonnet-4.6`): Moderate tasks -- code review, adding doc comments,
-     applying well-defined patterns across files, targeted refactors, verification of specific claims.
-   - **Claude Opus 4.6** (`claude-opus-4.6`): Complex tasks -- architectural audits, multi-file
-     reasoning, API design decisions, nuanced correctness verification, novel implementation.
-   When in doubt, prefer Sonnet 4.6 as the default. Use Haiku only when the task is truly trivial.
-   Use Opus only when the task requires deep reasoning or broad synthesis.
-
-8. **Prefer system tools over agents when sufficient.** If a task can be accomplished with built-in
+6. **Prefer system tools over agents when sufficient.** If a task can be accomplished with built-in
    tools (grep, glob, view, bash, edit, etc.) in comparable time, use those directly instead of
    spawning a subagent. Reserve agents for tasks that require multi-step reasoning, synthesis across
    many files, or parallel workloads that benefit from independent context windows.
 
-9. **Write high-quality subagent prompts.** Include specific file paths and line numbers (not just
+7. **Write high-quality subagent prompts.** Include specific file paths and line numbers (not just
    general descriptions), embed the exact commands to run, and state the expected output format.
    Vague prompts produce vague results; precise prompts produce precise results.
 
-10. **Challenge every finding from both sides (audit / verification work).** Whenever subagents
-    are used for audits, code review, or documentation verification, each finding must be argued
-    from two opposing positions:
-    - **For the fix**: cite the exact evidence (line numbers, function names, type definitions)
-      that makes the doc or code wrong.
-    - **Against the fix**: argue why the finding could be ignored, considered acceptable, or
-      is a false positive (e.g. the behaviour is by design, the wording is conventional, the
-      affected path is unreachable in practice).
+8. **Challenge every finding from both sides (audit / verification work).** Whenever subagents
+   are used for audits, code review, or documentation verification, each finding must be argued
+   from two opposing positions:
+   - **For the fix**: cite the exact evidence (line numbers, function names, type definitions)
+     that makes the doc or code wrong.
+   - **Against the fix**: argue why the finding could be ignored, considered acceptable, or
+     is a false positive (e.g. the behaviour is by design, the wording is conventional, the
+     affected path is unreachable in practice).
 
-11. **Subagent language** Always speak and receive messages from agents in Chinese.
-    The main agent remains in English or whatever language spoken to by the user.
-
-12. **Keep four audit agents running.** For per-file audit batches that require many independent
-    checks, run up to 4 subagents in parallel in background mode. Whenever one finishes, start the
-    next queued file immediately so 4 agents remain active until the queue is exhausted.
+9. **Subagent language** Always speak and receive messages from agents in Chinese.
+   The main agent remains in English or whatever language spoken to by the user.

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -188,7 +188,8 @@ runtime.
   - :docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>id`
     for retrieving optional element IDs.
 
-- Added the missing frame-finding method to |mj_spec|: :docs-rs:`~mujoco-rs::wrappers::mj_editing::<struct>MjSpec::<method>frame`.
+- Added the missing frame-finding methods to |mj_spec|: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>frame`
+  and :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>frame_mut`.
 
 .. rubric:: New examples
 
@@ -928,16 +929,16 @@ The six new enums (all ``#[non_exhaustive]``) have the following variants:
   types (the fields existed in MuJoCo 3.3.7 but were not previously accessible
   via per-object view types).
 - ``MjsMaterial``:
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsMaterial::<method>set_texture` /
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsMaterial::<method>with_texture`
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsMaterial::<method>set_texture` /
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsMaterial::<method>with_texture`
   set a texture name by
   :docs-rs:`~mujoco_rs::wrappers::mj_model::<type>MjtTextureRole`, correctly targeting the
   pre-sized slot the MuJoCo renderer reads (e.g. ``mjTEXROLE_RGB``).
   The existing ``set_textures`` / ``append_textures`` methods are retained but
   should generally be avoided for role-indexed vectors.
 - ``MjsTexture``:
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTexture::<method>set_cubefile` /
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTexture::<method>with_cubefile`
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTexture::<method>set_cubefile` /
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTexture::<method>with_cubefile`
   set a cube-map face file by
   :docs-rs:`~mujoco_rs::wrappers::mj_model::<enum>MjtCubeFace`.
   The existing ``set_cubefiles`` / ``append_cubefiles`` methods are retained.

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -47,7 +47,7 @@ update of MuJoCo alone can increase the major version.
 
 *(Potentially breaking) Changed raw pointer types of trait methods*
 
-- Changed raw pointer types of trait methods. For example, ``unsafe element_pointer(&self)``
+- Changed raw pointer types of trait methods. For example, ``element_pointer(&self)``
   now returns ``*const mjsElement``. This is a change that should not affect most users,
   unless they explicitly opted in to using the C model-editing API of MuJoCo directly, or
   implemented/depended on the old trait method signature in advanced extension code.
@@ -499,13 +499,13 @@ gained new variants. See `Error handling`_ below for the full method list.
   ``destination: &mut MjData<N>`` where ``N: Deref<Target = MjModel>``. Previously
   the source and destination had to share the same ``M``.
 
-- :docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>set_name`
+- :docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>set_name`
   now returns ``Result<(), MjEditError>`` instead of ``()``. Append ``?`` to call
   sites.
-  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>with_name`
+  :docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>with_name`
   still returns ``&mut Self`` but now panics on duplicate names.
 
-- :docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecItem` is now a sealed
+- :docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem` is now a sealed
   trait. External implementations are no longer permitted.
 
 - ``MjsOrientation::switch_quat`` no longer has a type parameter. Replace

--- a/docs/guide/source/index.rst
+++ b/docs/guide/source/index.rst
@@ -41,7 +41,7 @@ The main features on top of MuJoCo include:
 - :ref:`visualization`:
 
   - :ref:`mj_renderer`: offscreen rendering to array or file (enabled by the ``renderer`` feature).
-  - :ref:`mj_rust_viewer`: onscreen visualization (enabled by the ``viewer`` and ``viewer-ui`` features).
+  - :ref:`mj_rust_viewer`: onscreen visualization (enabled by the ``viewer`` feature, or ``viewer-ui`` for an added UI).
 
     .. image:: ../../img_common/viewer_spot.png
         :width: 50%

--- a/docs/guide/source/installation.rst
+++ b/docs/guide/source/installation.rst
@@ -30,6 +30,11 @@ MuJoCo-rs can be added to your project like so:
 
     cargo add mujoco-rs --features "viewer-ui renderer-winit-fallback"
 
+.. note::
+
+    On Windows and macOS the ``renderer-winit-fallback`` feature is **required** whenever the
+    ``renderer`` feature is enabled (the build fails otherwise). It is optional on Linux.
+
 See :ref:`opt-cargo-features` for information about available Cargo features.
 Visualization and rendering features are opt-in to keep compilation fast for headless use cases.
 

--- a/docs/guide/source/installation.rst
+++ b/docs/guide/source/installation.rst
@@ -201,7 +201,8 @@ we provide a modified MuJoCo repository with static linking support.
 While MuJoCo-rs already provides a :ref:`rust_native_viewer`, we understand that some projects wish
 to use the original C++ based 3D viewer (also named Simulate).
 To enable this, the modified MuJoCo repository also includes changes that support
-a safe interface between Rust and the C++ Simulate code.
+a safe interface between Rust and the C++ Simulate code. The C++ viewer is exposed through
+the ``cpp-viewer`` Cargo feature, which requires this static-linking setup.
 
 To build statically linkable libraries, perform the following steps:
 

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -24,6 +24,17 @@ For a full list of changes, see the :ref:`changelog`.
 Migrating to 5.0.0
 ======================
 
+Version 5.0.0 updates MuJoCo to 3.9.0, redesigns model-editing element deletion,
+and migrates several rendering APIs to the |mjr_context| error type.
+
+
+MuJoCo upgrade
+-----------------------
+
+MuJoCo-rs 5.0.0 links against MuJoCo **3.9.0**. Download the matching release
+and update your library path. See :ref:`installation` for details.
+
+
 Deprecated implementation of removing model-editing elements
 --------------------------------------------------------------
 Due to the :docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>delete`
@@ -530,12 +541,12 @@ Use ``try_add_default`` for a fallible alternative.
 Model-editing API changes
 ----------------------------
 
-:docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>set_name`
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>set_name`
 now returns ``Result<(), MjEditError>`` instead of ``()``.
-:docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>with_name`
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>with_name`
 still returns ``&mut Self`` but now panics on duplicate names.
 
-:docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecItem` is now a sealed
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem` is now a sealed
 trait. External implementations are no longer permitted -- remove any
 ``impl SpecItem for MyType`` blocks from downstream code.
 

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -97,7 +97,7 @@ We can now add our ball's body, geom and joint like so:
     These allow method chaining.
     Alternatively, methods that have the ``set_`` prefix can be used. Field setters
     (e.g. ``set_pos``, ``set_size``) return nothing, while ``set_name`` and ``set_default``
-    return a ``Result`` (they fail on, for example, a duplicate name).
+    return a ``Result`` (``set_name`` fails on a duplicate name, ``set_default`` on an unknown class).
     Setter (``set_``) methods are available for many common fields, including strings and
     several vector/buffer fields. For nested or structured data, use getters that end with
     the ``_mut`` suffix.
@@ -240,8 +240,8 @@ A new class is created by providing its ``class_name`` and optionally a ``parent
 Elements can then reference the class via their ``childclass`` or ``class`` (``dclass``) attribute
 in the model XML.
 In Rust code, class assignment is typically done with
-:docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>set_default` or
-:docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>with_default`.
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>set_default` or
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>with_default`.
 Some item-specific wrappers (for example frames) also expose explicit ``childclass`` setters.
 
 

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -95,7 +95,9 @@ We can now add our ball's body, geom and joint like so:
 
     In the above block, we used methods that have the ``with_`` prefix.
     These allow method chaining.
-    Alternatively, methods that have the ``set_`` prefix can be used, which don't return anything.
+    Alternatively, methods that have the ``set_`` prefix can be used. Field setters
+    (e.g. ``set_pos``, ``set_size``) return nothing, while ``set_name`` and ``set_default``
+    return a ``Result`` (they fail on, for example, a duplicate name).
     Setter (``set_``) methods are available for many common fields, including strings and
     several vector/buffer fields. For nested or structured data, use getters that end with
     the ``_mut`` suffix.
@@ -176,6 +178,38 @@ The compiled |mj_model| can also be swapped into a running simulation using
 as described in the :ref:`basic_sim` chapter.
 
 
+Deleting elements
+======================
+Elements can be removed from a specification with
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>delete_element`,
+which takes the element's raw pointer obtained from
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>element_mut_pointer`:
+
+.. code-block:: rust
+
+    use mujoco_rs::prelude::*;
+
+    fn main() {
+        let mut spec = MjSpec::new();
+        let body = spec.world_body_mut().add_body().with_name("ball");
+
+        let body_ptr = body.element_mut_pointer();
+        // SAFETY: `body_ptr` refers to a live element of `spec` that has not been deleted.
+        unsafe { spec.delete_element(body_ptr).expect("failed to delete the body") };
+    }
+
+Because ``delete_element`` takes ``&mut MjSpec``, the borrow checker already invalidates any
+references obtained earlier (such as ``body`` above) --- you cannot use a reference into the
+spec across the call. The method is ``unsafe`` only because the raw element pointer itself
+cannot be validated: in particular, the caller must not pass a pointer to an element that has
+already been deleted, which would make MuJoCo operate on freed memory.
+
+.. note::
+
+    The older ``SpecItem::delete`` method is **deprecated since 5.0.0** and is unsound
+    (it relies on undefined behavior). Use ``delete_element`` instead.
+
+
 .. _model_editing_defaults:
 
 Class inheritance (defaults)
@@ -249,6 +283,24 @@ The only difference is an additional boolean parameter, which enables recursive 
         println!("{}", body.name());
     }
     // ...
+
+
+Finding elements
+================
+Existing elements can be looked up by name. |mj_spec| exposes a finder method (and a matching
+``_mut`` variant) per item type, for example
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>body` /
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>body_mut`,
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>geom`, and
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>frame`. Within a body,
+child bodies are found with
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsBody::<method>child` /
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsBody::<method>child_mut`.
+Every finder returns an ``Option`` that is ``None`` when no element with that name exists.
+
+After compilation, an element's numeric id in the resulting |mj_model| can be retrieved with
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>id`
+(``None`` when the element has no id yet).
 
 
 Examples

--- a/docs/guide/source/programming/simulation/views.rst
+++ b/docs/guide/source/programming/simulation/views.rst
@@ -16,8 +16,8 @@ attributes of :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData` and
 
 Views borrow data and cannot be preserved across simulation steps, as that would violate
 Rust's borrow checker rules. Re-looking up names each step would also be expensive.
-To overcome this, "info" structs exist, which cache the required information for fast view
-creation after each step.
+To overcome this, "info" structs exist, which cache the resolved index ranges and the model
+signature for fast view creation after each step.
 
 .. warning::
 
@@ -79,6 +79,10 @@ fields). ``PointerView`` implements the
 `Deref <https://doc.rust-lang.org/std/ops/trait.Deref.html>`_ trait and on deref
 acts like a slice. While some fields might be scalars, we still treat those as arrays
 for implementation simplicity reasons.
+
+The same ``view`` / ``view_mut`` pattern applies to every named element type --- bodies,
+geoms, sites, actuators, sensors, and so on --- each looked up through its corresponding
+finder (e.g. ``MjData::body`` or ``MjData::geom``) and info struct.
 
 
 Writing

--- a/docs/guide/source/programming/visualization/drawing.rst
+++ b/docs/guide/source/programming/visualization/drawing.rst
@@ -12,13 +12,14 @@ onto an existing 3D scene.
 
 .. note::
 
-    Custom visualization requires the ``viewer`` (or ``viewer-ui``) or the ``renderer`` Cargo feature to be enabled.
+    Custom visualization requires the ``viewer`` (or ``viewer-ui``), ``renderer``, or ``cpp-viewer`` Cargo feature to be enabled.
 
 In MuJoCo-rs, drawing is done through |mjv_scene|.
-There are two things that expose a scene for drawing custom visual-only geoms:
+There are three things that expose a scene for drawing custom visual-only geoms:
 
 - :ref:`mj_rust_viewer` (:docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>user_scene_mut`).
 - :ref:`mj_renderer` (:docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>user_scene_mut`).
+- :ref:`mj_cpp_viewer` (:docs-rs:`~~mujoco_rs::cpp_viewer::<struct>MjViewerCpp::<method>user_scn_mut`).
 
 
 Drawing to a scene

--- a/docs/guide/source/programming/visualization/visualization.rst
+++ b/docs/guide/source/programming/visualization/visualization.rst
@@ -4,10 +4,11 @@
 Visualization
 ========================
 It's useful to visualize what the simulation is doing.
-MuJoCo-rs provides two main ways of visualization (requires enabling the corresponding Cargo features):
+MuJoCo-rs provides three main ways of visualization (requires enabling the corresponding Cargo features):
 
 - :ref:`mj_rust_viewer` for onscreen visualization (window) --- ``viewer`` feature (or ``viewer-ui`` to enable with UI)
 - :ref:`mj_renderer` for offscreen rendering (array or a file) --- ``renderer`` feature
+- :ref:`mj_cpp_viewer` for onscreen visualization using MuJoCo's official C++ viewer --- ``cpp-viewer`` feature
 
 
 .. toctree::

--- a/docs/guide/source/webassembly.rst
+++ b/docs/guide/source/webassembly.rst
@@ -35,6 +35,14 @@ you need:
 
        git submodule update --init --recursive
 
+.. note::
+
+    Emscripten's tools (``emcc``, ``emcmake``, ...) must be on your ``PATH`` before building.
+    After installing emsdk, activate it in each shell session with
+    ``source /path/to/emsdk/emsdk_env.sh`` (see the
+    `emsdk documentation <https://emscripten.org/docs/getting_started/downloads.html>`_).
+    Without this step the ``emcmake`` commands below fail with "command not found".
+
 
 .. _wasm_building:
 


### PR DESCRIPTION
Adds missing documentation sections, clarifies feature flags and fixes incorrect usage of the `docs-rs` Sphinx extension.