### PR TITLE
Pre-release fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-The changelog is available [here](https://mujoco-rs.readthedocs.io/en/5.0.x/changelog.html).
+The changelog is available [here](https://mujoco-rs.readthedocs.io/en/v5.0.x/changelog.html).

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -208,6 +208,11 @@ runtime.
   were stored and later used --- technically a undefined behavior due to reuse of the ``MjsBody``
   inside the iterator. The ``MjsBody`` parent is now stored as a raw FFI pointer to prevent such
   aliasing.
+- Fixed an out-of-bounds read reachable from safe code in
+  :docs-rs:`~~mujoco_rs::wrappers::mj_visualization::<type>MjvCamera::<method>frame`: a fixed
+  camera whose ``fixedcamid`` was outside the model's camera range caused MuJoCo's
+  ``mjv_cameraFrame`` to read ``cam_xpos`` / ``cam_xmat`` out of bounds. ``frame`` now validates the
+  id against the model and panics on an out-of-range fixed camera id instead.
 
 
 .. rubric:: Other changes

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -35,6 +35,32 @@ MuJoCo-rs 5.0.0 links against MuJoCo **3.9.0**. Download the matching release
 and update your library path. See :ref:`installation` for details.
 
 
+``SpecItem::element_pointer`` pointer type changed (potentially breaking)
+--------------------------------------------------------------------------
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<tymethod>element_pointer`
+now returns ``*const mjsElement`` (was ``*mut mjsElement``) and is no longer ``unsafe``. This only
+affects code that called the model-editing trait methods directly (e.g. to drive MuJoCo's C
+model-editing API). When a mutable pointer is required, use
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>element_mut_pointer`
+(also no longer ``unsafe``). Any ``unsafe`` block wrapping these calls is now redundant and can be
+removed.
+
+**Before (4.x):**
+
+.. code-block:: rust
+
+    let ptr: *mut mjsElement = unsafe { item.element_pointer() };
+
+**After (5.0.0):**
+
+.. code-block:: rust
+
+    // read-only C calls take an immutable pointer:
+    let ptr: *const mjsElement = item.element_pointer();
+    // when a mutable pointer is required:
+    let ptr: *mut mjsElement = item.element_mut_pointer();
+
+
 Deprecated implementation of removing model-editing elements
 --------------------------------------------------------------
 Due to the :docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>delete`

--- a/src/wrappers/mj_visualization.rs
+++ b/src/wrappers/mj_visualization.rs
@@ -242,7 +242,21 @@ impl MjvCamera {
     }
 
     /// Get the camera coordinate frame (pos, forward, up, right).
+    ///
+    /// # Panics
+    /// Panics if this is a fixed camera (`MjtCamera::mjCAMERA_FIXED`) whose `fixedcamid` is out of range.
     pub fn frame<M: Deref<Target = MjModel>>(&self, data: &MjData<M>) -> ([MjtNum; 3], [MjtNum; 3], [MjtNum; 3], [MjtNum; 3]) {
+        // Only the fixed-camera branch of mjv_cameraFrame dereferences the per-camera arrays; the
+        // free/tracking branches derive the frame from azimuth/elevation and need no validation.
+        if self.type_ == MjtCamera::mjCAMERA_FIXED as i32 {
+            let ncam = data.model().ncam();
+            assert!(
+                self.fixedcamid >= 0 && (self.fixedcamid as i64) < ncam,
+                "fixed camera id {} is out of range for a model with {} cameras",
+                self.fixedcamid, ncam
+            );
+        }
+
         let mut headpos = [0.0; 3];
         let mut forward = [0.0; 3];
         let mut up = [0.0; 3];
@@ -984,6 +998,18 @@ mod tests {
         let label = "Hello World";
         geom.set_label(label).unwrap();
         assert_eq!(geom.label(), label);
+    }
+
+    /// A fixed camera whose id is out of range for the model must panic in `frame` instead of
+    /// triggering an out-of-bounds read in MuJoCo's `mjv_cameraFrame` (which indexes
+    /// `cam_xpos`/`cam_xmat` by `fixedcamid` without bounds checks).
+    #[test]
+    #[should_panic(expected = "out of range")]
+    fn test_camera_frame_fixed_id_out_of_range_panics() {
+        let model = load_model();          // EXAMPLE_MODEL defines no <camera>, so ncam == 0
+        let data = model.make_data();
+        let camera = MjvCamera::new_fixed(0);  // fixedcamid = 0, but ncam = 0 -> out of range
+        let _ = camera.frame(&data);
     }
 
     #[test]


### PR DESCRIPTION
Fixes:
- possible out-of-bounds access on `MjvCamera::frame` when the camera ID was out-of-bounds;
- documentation missing changelog and migration guide entries.