### PR TITLE
Model editing: set actuator types

### DIFF
--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -192,10 +192,18 @@ runtime.
   and :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>frame_mut`.
 
 - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator` now exposes the full family of
-  actuator-configuration helpers mirroring MuJoCo's ``mjs_setToX`` C API: ``set_to_motor``,
+  actuator-configuration helpers covering MuJoCo's ``mjs_setToX`` C API: ``set_to_motor``,
   ``set_to_positon``, ``set_to_int_velocity``, ``set_to_velocity``, ``set_to_damper``,
   ``set_to_cylinder``, ``set_to_muscle``, ``set_to_adhesion``, and ``set_to_dc_motor``. Helpers
-  that MuJoCo can reject return ``Result<(), MjEditError>``; those that cannot fail return ``()``.
+  whose C function takes nullable parameters take a dedicated ``Default``-able config struct
+  (``PositionConfig``, ``IntVelocityConfig``, ``DcMotorConfig``) in which the nullable parameters
+  are ``Option`` fields, so callers specify only the fields they need via struct-update syntax and
+  unset optionals default to ``None``. For example:
+  ``actuator.set_to_dc_motor(DcMotorConfig { motorconst: Some([1.0, 1.0]), resistance: 1.0, ..Default::default() })?``.
+  Helpers whose parameters are all mandatory keep simple positional arguments (e.g.
+  ``set_to_velocity(kv)``, ``set_to_cylinder(timeconst, bias, area, diameter)``,
+  ``set_to_muscle(...)``). Helpers that MuJoCo can reject return ``Result<(), MjEditError>``; those
+  that cannot fail return ``()``.
 
 .. rubric:: New examples
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -191,6 +191,12 @@ runtime.
 - Added the missing frame-finding methods to |mj_spec|: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>frame`
   and :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>frame_mut`.
 
+- :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator` now exposes the full family of
+  actuator-configuration helpers mirroring MuJoCo's ``mjs_setToX`` C API: ``set_to_motor``,
+  ``set_to_positon``, ``set_to_int_velocity``, ``set_to_velocity``, ``set_to_damper``,
+  ``set_to_cylinder``, ``set_to_muscle``, ``set_to_adhesion``, and ``set_to_dc_motor``. Helpers
+  that MuJoCo can reject return ``Result<(), MjEditError>``; those that cannot fail return ``()``.
+
 .. rubric:: New examples
 
 - :gh-example:`Asset re-upload <visualization/viewer/asset_reupload.rs>` --- demonstrates animated heightfield,

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -193,7 +193,7 @@ runtime.
 
 - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator` now exposes the full family of
   actuator-configuration helpers covering MuJoCo's ``mjs_setToX`` C API: ``set_to_motor``,
-  ``set_to_positon``, ``set_to_int_velocity``, ``set_to_velocity``, ``set_to_damper``,
+  ``set_to_position``, ``set_to_int_velocity``, ``set_to_velocity``, ``set_to_damper``,
   ``set_to_cylinder``, ``set_to_muscle``, ``set_to_adhesion``, and ``set_to_dc_motor``. Helpers
   whose C function takes nullable parameters take a dedicated ``Default``-able config struct
   (``PositionConfig``, ``IntVelocityConfig``, ``DcMotorConfig``) in which the nullable parameters
@@ -203,8 +203,9 @@ runtime.
   ``actuator.set_to_dc_motor(DcMotorConfig::default().with_motorconst([1.0, 1.0]).with_resistance(1.0))?``.
   Helpers whose parameters are all mandatory keep simple positional arguments (e.g.
   ``set_to_velocity(kv)``, ``set_to_cylinder(timeconst, bias, area, diameter)``,
-  ``set_to_muscle(...)``). Helpers that MuJoCo can reject return ``Result<(), MjEditError>``; those
-  that cannot fail return ``()``.
+  ``set_to_muscle(...)``). Helpers that MuJoCo can reject return ``Result<(), MjEditError>`` (e.g.
+  ``set_to_damper``, ``set_to_muscle``, ``set_to_dc_motor``); those that cannot fail
+  (``set_to_motor``, ``set_to_velocity``, ``set_to_cylinder``) return ``()``.
 
 .. rubric:: New examples
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -197,9 +197,10 @@ runtime.
   ``set_to_cylinder``, ``set_to_muscle``, ``set_to_adhesion``, and ``set_to_dc_motor``. Helpers
   whose C function takes nullable parameters take a dedicated ``Default``-able config struct
   (``PositionConfig``, ``IntVelocityConfig``, ``DcMotorConfig``) in which the nullable parameters
-  are ``Option`` fields, so callers specify only the fields they need via struct-update syntax and
-  unset optionals default to ``None``. For example:
-  ``actuator.set_to_dc_motor(DcMotorConfig { motorconst: Some([1.0, 1.0]), resistance: 1.0, ..Default::default() })?``.
+  are ``Option`` fields. Each config can be built either with struct-update syntax or with
+  chainable ``with_*`` builder methods (which take the inner value and wrap optionals in ``Some``),
+  so callers specify only the fields they need and unset optionals default to ``None``. For example:
+  ``actuator.set_to_dc_motor(DcMotorConfig::default().with_motorconst([1.0, 1.0]).with_resistance(1.0))?``.
   Helpers whose parameters are all mandatory keep simple positional arguments (e.g.
   ``set_to_velocity(kv)``, ``set_to_cylinder(timeconst, bias, area, diameter)``,
   ``set_to_muscle(...)``). Helpers that MuJoCo can reject return ``Result<(), MjEditError>``; those

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -8,6 +8,7 @@ Model editing
 .. |mj_model| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel`
 .. |mj_spec| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec`
 .. |mjs_body| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsBody`
+.. |mjs_actuator| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator`
 
 The most general way to create an |mj_model| instance is by loading an XML file
 via :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>from_xml`.
@@ -34,6 +35,17 @@ After creation, we can use |mj_spec| to add items to the model, such as joints, 
 
 After procedurally creating a specification with |mj_spec|, the latter
 can either be compiled for direct use in the simulation or saved to an XML file.
+
+
+Examples
+================
+Complete, runnable examples on model editing are available in the repository's examples:
+
+- :gh-example:`Basic model editing <model_editing/model_editing.rs>`
+- :gh-example:`Terrain generation <model_editing/terrain_generation.rs>`
+- :gh-example:`Procedural tree <model_editing/procedural_tree.rs>`
+- :gh-example:`Multi-legged creatures <model_editing/multi_legged_creatures.rs>`
+
 
 Basic editing
 ======================
@@ -303,12 +315,47 @@ After compilation, an element's numeric id in the resulting |mj_model| can be re
 (``None`` when the element has no id yet).
 
 
-Examples
-================
-Additional examples on model editing are
-available in the repository's examples:
+.. _model_editing_actuators:
 
-- :gh-example:`Basic model editing <model_editing/model_editing.rs>`
-- :gh-example:`Terrain generation <model_editing/terrain_generation.rs>`
-- :gh-example:`Procedural tree <model_editing/procedural_tree.rs>`
-- :gh-example:`Multi-legged creatures <model_editing/multi_legged_creatures.rs>`
+Configuring actuators
+======================
+An actuator added with :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>add_actuator`
+can be configured into one of MuJoCo's predefined actuator types with the ``set_to_*`` family of
+methods on |mjs_actuator| (motor, position, integrated velocity, velocity, damper, cylinder,
+muscle, adhesion, and DC motor), mirroring MuJoCo's ``mjs_setToX`` C API.
+
+A method whose parameters are all mandatory takes them positionally (for example
+``set_to_velocity(kv)`` or ``set_to_cylinder(timeconst, bias, area, diameter)``). A method whose
+underlying C function accepts *nullable* parameters instead takes a dedicated ``Default``-able
+config struct --- :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>PositionConfig`,
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>IntVelocityConfig`, and
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>DcMotorConfig` --- in which those nullable
+parameters are ``Option`` fields. A config is built either with struct-update syntax or with the
+chainable ``with_*`` builder methods (which take the inner value and wrap it in ``Some``), so only
+the relevant fields need to be set; everything else stays at its MuJoCo default:
+
+.. code-block:: rust
+
+    use mujoco_rs::prelude::*;
+    use mujoco_rs::wrappers::mj_editing::DcMotorConfig;
+
+    fn main() {
+        let mut spec = MjSpec::new();
+        let body = spec.world_body_mut().add_body();
+        body.add_geom().with_size([0.01, 0.0, 0.0]);
+        body.add_joint().with_name("hinge");
+
+        let actuator = spec.add_actuator().with_trntype(MjtTrn::mjTRN_JOINT);
+        actuator.set_target("hinge");
+
+        // Configure as a DC motor using the chainable builder. Struct-update syntax works too:
+        //   DcMotorConfig { motorconst: Some([1.0, 1.0]), resistance: 1.0, ..Default::default() }
+        actuator.set_to_dc_motor(
+            DcMotorConfig::default().with_motorconst([1.0, 1.0]).with_resistance(1.0)
+        ).expect("invalid DC motor parameters");
+    }
+
+Methods that MuJoCo can reject (for example a negative gain, or mutually exclusive parameters)
+return ``Result<(), MjEditError>``, and the only error variant they ever produce is
+:docs-rs:`~~mujoco_rs::error::<enum>MjEditError::<variant>InvalidParameter`; the parameterless or
+always-valid ones (``set_to_motor``, ``set_to_velocity``, ``set_to_cylinder``) return ``()``.

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -331,8 +331,8 @@ config struct --- :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>PositionCo
 :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>IntVelocityConfig`, and
 :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>DcMotorConfig` --- in which those nullable
 parameters are ``Option`` fields. A config is built either with struct-update syntax or with the
-chainable ``with_*`` builder methods (which take the inner value and wrap it in ``Some``), so only
-the relevant fields need to be set; everything else stays at its MuJoCo default:
+chainable ``with_*`` builder methods (which take the inner value and wrap optional fields in
+``Some``), so only the relevant fields need to be set; everything else stays at its MuJoCo default:
 
 .. code-block:: rust
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -309,6 +309,10 @@ pub enum MjEditError {
         /// Pass a buffer of at least `required_size + 1` bytes to retry.
         required_size: usize,
     },
+    /// Returned when the parameters to the given method/function are invalid.
+    /// This is currently only returned within [`MjsActuator`](crate::wrappers::mj_editing::MjsActuator)'s
+    /// `set_to_x` methods, where `x` is the actuator type.
+    InvalidParameter(String),
 }
 
 impl fmt::Display for MjEditError {
@@ -328,6 +332,7 @@ impl fmt::Display for MjEditError {
                 "XML output buffer too small; retry with at least {} bytes",
                 required_size + 1
             ),
+            Self::InvalidParameter(msg) => write!(f, "{msg}"),
         }
     }
 }

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -1042,6 +1042,42 @@ impl MjsActuator {
     }
 }
 
+
+impl MjsActuator {
+    /// Configure the actuator to be a motor.
+    pub fn set_to_motor(&mut self) {
+        // RETURN: always returns "". 
+        unsafe { mjs_setToMotor(self) };
+    }
+
+    /// Configure the actuator to be positional-target motor (with a proportional regulator).
+    /// # Errors
+    /// Returns [`MjEditError::InvalidParameter`] when the parameters aren't
+    /// within the allowed range.
+    pub fn set_to_positon(
+        &mut self, kp: f64, inheritrange: f64,
+        kv: Option<f64>, dampratio: Option<f64>, timeconst: Option<f64>
+    ) -> Result<(), MjEditError>
+    {
+        // RETURN: always returns "". 
+        let c_err_msg = unsafe { mjs_setToPosition(
+            self, kp,
+            kv.map_or(ptr::null_mut(), |mut x| &mut x),
+            dampratio.map_or(ptr::null_mut(), |mut x| &mut x),
+            timeconst.map_or(ptr::null_mut(), |mut x| &mut x),
+            inheritrange
+        ) };
+
+        // SAFETY: MuJoCo's error messages are always NULL terminated.
+        let err_msg = unsafe { CStr::from_ptr(c_err_msg).to_string_lossy() };
+        if err_msg.len() > 0 {
+            return Err(MjEditError::InvalidParameter(err_msg.to_string()));
+        }
+
+        Ok(())
+    }
+}
+
 /***************************
 ** Sensor specification
 ***************************/

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -1059,6 +1059,69 @@ fn actuator_set_result(c_err_msg: *const c_char) -> Result<(), MjEditError> {
     }
 }
 
+/* Actuator configuration structs.
+** Each `set_to_*` method takes its own config struct. Build with struct-update syntax so only the
+** relevant fields are specified, e.g. `PositionConfig { kp: 10.0, kv: Some(2.0), ..Default::default() }`.
+** Optional fields default to `None`, leaving the corresponding actuator parameter at its MuJoCo
+** default. */
+
+/// Configuration for [`MjsActuator::set_to_positon`].
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct PositionConfig {
+    /// Proportional (position) gain.
+    pub kp: f64,
+    /// Automatic range-inheritance factor (0 disables it).
+    pub inheritrange: f64,
+    /// Velocity feedback gain. Mutually exclusive with `dampratio`.
+    pub kv: Option<f64>,
+    /// Damping ratio. Mutually exclusive with `kv`.
+    pub dampratio: Option<f64>,
+    /// First-order activation-filter time constant.
+    pub timeconst: Option<f64>,
+}
+
+/// Configuration for [`MjsActuator::set_to_int_velocity`]. Same parameters as [`PositionConfig`].
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct IntVelocityConfig {
+    /// Proportional gain.
+    pub kp: f64,
+    /// Automatic range-inheritance factor (0 disables it).
+    pub inheritrange: f64,
+    /// Velocity feedback gain. Mutually exclusive with `dampratio`.
+    pub kv: Option<f64>,
+    /// Damping ratio. Mutually exclusive with `kv`.
+    pub dampratio: Option<f64>,
+    /// First-order activation-filter time constant.
+    pub timeconst: Option<f64>,
+}
+
+/// Configuration for [`MjsActuator::set_to_dc_motor`].
+///
+/// Each optional field defaults to `None`, disabling the corresponding feature.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct DcMotorConfig {
+    /// Electrical resistance.
+    pub resistance: f64,
+    /// Input mode selector.
+    pub input_mode: i32,
+    /// Torque and back-EMF constants `[Kt, Ke]`.
+    pub motorconst: Option<[f64; 2]>,
+    /// Nominal ratings `[voltage, stall_torque, no_load_speed]`.
+    pub nominal: Option<[f64; 3]>,
+    /// Saturation `[tau_max, i_max, di_dt_max]`.
+    pub saturation: Option<[f64; 3]>,
+    /// Inductance `[L, te]`.
+    pub inductance: Option<[f64; 2]>,
+    /// Cogging `[amplitude, periodicity, phase]`.
+    pub cogging: Option<[f64; 3]>,
+    /// Controller `[kp, ki, kd, slewmax, Imax, v_max]`.
+    pub controller: Option<[f64; 6]>,
+    /// Thermal `[R_th, C, tau_th, alpha, T0, T_ambient]`.
+    pub thermal: Option<[f64; 6]>,
+    /// LuGre friction `[stiffness, damping, coulomb, static, stribeck]`.
+    pub lugre: Option<[f64; 5]>,
+}
+
 impl MjsActuator {
     /// Configure the actuator to be a motor.
     pub fn set_to_motor(&mut self) {
@@ -1067,17 +1130,12 @@ impl MjsActuator {
     }
 
     /// Configure the actuator to be a positional-target motor (with a proportional regulator).
-    /// `kv` and `dampratio` are mutually exclusive damping specifications, and `timeconst`
-    /// optionally adds a first-order activation filter.
     /// # Errors
-    /// Returns [`MjEditError::InvalidParameter`] when the parameters aren't within the allowed
-    /// range, e.g. `kv` and `dampratio` are both given, a value that must be non-negative is
-    /// negative, or `inheritrange` is given together with a control range.
-    pub fn set_to_positon(
-        &mut self, kp: f64, inheritrange: f64,
-        mut kv: Option<f64>, mut dampratio: Option<f64>, mut timeconst: Option<f64>
-    ) -> Result<(), MjEditError>
-    {
+    /// Returns [`MjEditError::InvalidParameter`] when the configuration is rejected, e.g. `kv` and
+    /// `dampratio` are both set, a value that must be non-negative is negative, or `inheritrange`
+    /// is set together with a control range.
+    pub fn set_to_positon(&mut self, config: PositionConfig) -> Result<(), MjEditError> {
+        let PositionConfig { kp, inheritrange, mut kv, mut dampratio, mut timeconst } = config;
         let c_err_msg = unsafe { mjs_setToPosition(
             self, kp,
             kv.as_mut().map_or(ptr::null_mut(), |x| x),
@@ -1088,17 +1146,14 @@ impl MjsActuator {
         actuator_set_result(c_err_msg)
     }
 
-    /// Configure the actuator to be an integrated-velocity servo. This behaves like
+    /// Configure the actuator to be an integrated-velocity servo. Behaves like
     /// [`MjsActuator::set_to_positon`], but integrates the control signal into an activation
-    /// variable. See that method for the meaning of the parameters.
+    /// variable.
     /// # Errors
-    /// Returns [`MjEditError::InvalidParameter`] when `inheritrange` is given together with an
+    /// Returns [`MjEditError::InvalidParameter`] when `inheritrange` is set together with an
     /// activation range.
-    pub fn set_to_int_velocity(
-        &mut self, kp: f64, inheritrange: f64,
-        mut kv: Option<f64>, mut dampratio: Option<f64>, mut timeconst: Option<f64>
-    ) -> Result<(), MjEditError>
-    {
+    pub fn set_to_int_velocity(&mut self, config: IntVelocityConfig) -> Result<(), MjEditError> {
+        let IntVelocityConfig { kp, inheritrange, mut kv, mut dampratio, mut timeconst } = config;
         let c_err_msg = unsafe { mjs_setToIntVelocity(
             self, kp,
             kv.as_mut().map_or(ptr::null_mut(), |x| x),
@@ -1121,13 +1176,13 @@ impl MjsActuator {
     /// Returns [`MjEditError::InvalidParameter`] when `kv` is negative or the control range is
     /// negative.
     pub fn set_to_damper(&mut self, kv: f64) -> Result<(), MjEditError> {
-        let c_err_msg = unsafe { mjs_setToDamper(self, kv) };
-        actuator_set_result(c_err_msg)
+        actuator_set_result(unsafe { mjs_setToDamper(self, kv) })
     }
 
     /// Configure the actuator to be a hydraulic or pneumatic cylinder. `timeconst` is the
     /// activation filter time constant, `bias` is added to the force, and the effective area is
-    /// `area`; if `diameter` is non-negative, the area is computed from it instead.
+    /// `area`; if `diameter` is non-negative the area is computed from it instead (pass a negative
+    /// `diameter` to use `area` directly).
     pub fn set_to_cylinder(&mut self, timeconst: f64, bias: f64, area: f64, diameter: f64) {
         // mjs_setToCylinder cannot fail; it always returns an empty string.
         unsafe { mjs_setToCylinder(self, timeconst, bias, area, diameter) };
@@ -1157,32 +1212,20 @@ impl MjsActuator {
     /// Returns [`MjEditError::InvalidParameter`] when `gain` is negative or the control range is
     /// negative.
     pub fn set_to_adhesion(&mut self, gain: f64) -> Result<(), MjEditError> {
-        let c_err_msg = unsafe { mjs_setToAdhesion(self, gain) };
-        actuator_set_result(c_err_msg)
+        actuator_set_result(unsafe { mjs_setToAdhesion(self, gain) })
     }
 
-    /// Configure the actuator to be a DC motor. `resistance` and `input_mode` are required; all
-    /// array parameters are optional and a `None` value disables the corresponding feature
-    /// (`motorconst`: `[Kt, Ke]`; `nominal`: `[voltage, stall_torque, no_load_speed]`;
-    /// `saturation`: `[tau_max, i_max, di_dt_max]`; `inductance`: `[L, te]`;
-    /// `cogging`: `[amplitude, periodicity, phase]`;
-    /// `controller`: `[kp, ki, kd, slewmax, Imax, v_max]`;
-    /// `thermal`: `[R_th, C, tau_th, alpha, T0, T_ambient]`;
-    /// `lugre`: `[stiffness, damping, coulomb, static, stribeck]`).
+    /// Configure the actuator to be a DC motor.
     /// # Errors
-    /// Returns [`MjEditError::InvalidParameter`] when the derived motor constant or resistance is
-    /// not positive, or when an inductance, thermal resistance, or thermal capacitance value is
-    /// out of its allowed range.
-    #[allow(clippy::too_many_arguments)]
-    pub fn set_to_dc_motor(
-        &mut self,
-        mut motorconst: Option<[f64; 2]>, resistance: f64,
-        mut nominal: Option<[f64; 3]>, mut saturation: Option<[f64; 3]>,
-        mut inductance: Option<[f64; 2]>, mut cogging: Option<[f64; 3]>,
-        mut controller: Option<[f64; 6]>, mut thermal: Option<[f64; 6]>,
-        mut lugre: Option<[f64; 5]>, input_mode: i32
-    ) -> Result<(), MjEditError>
-    {
+    /// Returns [`MjEditError::InvalidParameter`] when MuJoCo cannot derive a positive motor
+    /// constant or resistance, or when an inductance, thermal resistance, or thermal capacitance
+    /// value is out of its allowed range.
+    pub fn set_to_dc_motor(&mut self, config: DcMotorConfig) -> Result<(), MjEditError> {
+        let DcMotorConfig {
+            resistance, input_mode,
+            mut motorconst, mut nominal, mut saturation, mut inductance,
+            mut cogging, mut controller, mut thermal, mut lugre
+        } = config;
         let c_err_msg = unsafe { mjs_setToDCMotor(
             self,
             motorconst.as_mut().map_or(ptr::null_mut(), |x| x),
@@ -2350,28 +2393,32 @@ mod tests {
         assert!(actuator.set_to_adhesion(-1.0).is_err());
         assert!(actuator.set_to_adhesion(1.0).is_ok());
 
-        /* cylinder: filter dynamics, always succeeds */
+        /* cylinder: filter dynamics, always succeeds (negative diameter keeps the area) */
         actuator.set_to_cylinder(0.1, 0.0, 1.0, -1.0);
         assert_eq!(actuator.dyntype(), MjtDyn::mjDYN_FILTER);
 
-        /* muscle: negative tausmooth is rejected, otherwise muscle gain/bias/dyn */
+        /* muscle: negative tausmooth is rejected; negative entries keep MuJoCo's defaults */
         assert!(actuator.set_to_muscle([-1.0, -1.0], -1.0, [-1.0, -1.0], -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0).is_err());
-        assert!(actuator.set_to_muscle([-1.0, -1.0], 0.0, [-1.0, -1.0], -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0).is_ok());
+        actuator.set_to_muscle([-1.0, -1.0], 0.0, [-1.0, -1.0], -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0).unwrap();
         assert_eq!(actuator.gaintype(), MjtGain::mjGAIN_MUSCLE);
         assert_eq!(actuator.biastype(), MjtBias::mjBIAS_MUSCLE);
         assert_eq!(actuator.dyntype(), MjtDyn::mjDYN_MUSCLE);
 
         /* position: kv and dampratio are mutually exclusive */
-        assert!(actuator.set_to_positon(1.0, 0.0, Some(1.0), Some(1.0), None).is_err());
-        assert!(actuator.set_to_positon(1.0, 0.0, Some(1.0), None, None).is_ok());
+        assert!(actuator.set_to_positon(
+            PositionConfig { kp: 1.0, kv: Some(1.0), dampratio: Some(1.0), ..Default::default() }
+        ).is_err());
+        actuator.set_to_positon(PositionConfig { kp: 1.0, kv: Some(1.0), ..Default::default() }).unwrap();
 
         /* integrated velocity: integrator dynamics */
-        assert!(actuator.set_to_int_velocity(1.0, 0.0, None, None, None).is_ok());
+        actuator.set_to_int_velocity(IntVelocityConfig { kp: 1.0, ..Default::default() }).unwrap();
         assert_eq!(actuator.dyntype(), MjtDyn::mjDYN_INTEGRATOR);
 
-        /* dc motor: a positive motor constant and resistance are required */
-        assert!(actuator.set_to_dc_motor(None, 0.0, None, None, None, None, None, None, None, 0).is_err());
-        assert!(actuator.set_to_dc_motor(Some([1.0, 1.0]), 1.0, None, None, None, None, None, None, None, 0).is_ok());
+        /* dc motor: without a motor constant MuJoCo cannot derive K > 0, so it is rejected */
+        assert!(actuator.set_to_dc_motor(DcMotorConfig::default()).is_err());
+        actuator.set_to_dc_motor(
+            DcMotorConfig { motorconst: Some([1.0, 1.0]), resistance: 1.0, ..Default::default() }
+        ).unwrap();
         assert_eq!(actuator.gaintype(), MjtGain::mjGAIN_DCMOTOR);
         assert_eq!(actuator.biastype(), MjtBias::mjBIAS_DCMOTOR);
         assert_eq!(actuator.dyntype(), MjtDyn::mjDYN_DCMOTOR);

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -1067,7 +1067,7 @@ fn actuator_set_result(c_err_msg: *const c_char) -> Result<(), MjEditError> {
 ** leaving the corresponding actuator parameter at its MuJoCo default; the `with_*` setters take
 ** the inner value directly and wrap it in `Some`. */
 
-/// Configuration for [`MjsActuator::set_to_positon`].
+/// Configuration for [`MjsActuator::set_to_position`].
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct PositionConfig {
     /// Proportional (position) gain.
@@ -1177,7 +1177,7 @@ impl MjsActuator {
     /// Returns [`MjEditError::InvalidParameter`] when the configuration is rejected, e.g. `kv` and
     /// `dampratio` are both set, a value that must be non-negative is negative, or `inheritrange`
     /// is set together with a control range.
-    pub fn set_to_positon(&mut self, config: PositionConfig) -> Result<(), MjEditError> {
+    pub fn set_to_position(&mut self, config: PositionConfig) -> Result<(), MjEditError> {
         let PositionConfig { kp, inheritrange, mut kv, mut dampratio, mut timeconst } = config;
         let c_err_msg = unsafe { mjs_setToPosition(
             self, kp,
@@ -1190,7 +1190,7 @@ impl MjsActuator {
     }
 
     /// Configure the actuator to be an integrated-velocity servo. Behaves like
-    /// [`MjsActuator::set_to_positon`], but integrates the control signal into an activation
+    /// [`MjsActuator::set_to_position`], but integrates the control signal into an activation
     /// variable.
     /// # Errors
     /// Returns [`MjEditError::InvalidParameter`] when `inheritrange` is set together with an
@@ -2448,10 +2448,10 @@ mod tests {
         assert_eq!(actuator.dyntype(), MjtDyn::mjDYN_MUSCLE);
 
         /* position (builder API): kv and dampratio are mutually exclusive */
-        assert!(actuator.set_to_positon(
+        assert!(actuator.set_to_position(
             PositionConfig::default().with_kp(1.0).with_kv(1.0).with_dampratio(1.0)
         ).is_err());
-        actuator.set_to_positon(PositionConfig::default().with_kp(1.0).with_kv(1.0)).unwrap();
+        actuator.set_to_position(PositionConfig::default().with_kp(1.0).with_kv(1.0)).unwrap();
 
         /* integrated velocity: integrator dynamics */
         actuator.set_to_int_velocity(IntVelocityConfig::default().with_kp(1.0)).unwrap();

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -1043,38 +1043,160 @@ impl MjsActuator {
 }
 
 
+/// Converts the error string returned by MuJoCo's `mjs_setToX` actuator
+/// configuration functions into a [`Result`].
+///
+/// Those functions return an empty string on success and a non-empty,
+/// NUL-terminated message describing the rejected parameter on failure.
+fn actuator_set_result(c_err_msg: *const c_char) -> Result<(), MjEditError> {
+    // SAFETY: MuJoCo's error messages are always NUL terminated.
+    let err_msg = unsafe { CStr::from_ptr(c_err_msg) }.to_string_lossy();
+    if err_msg.is_empty() {
+        Ok(())
+    }
+    else {
+        Err(MjEditError::InvalidParameter(err_msg.into_owned()))
+    }
+}
+
 impl MjsActuator {
     /// Configure the actuator to be a motor.
     pub fn set_to_motor(&mut self) {
-        // RETURN: always returns "". 
+        // mjs_setToMotor cannot fail; it always returns an empty string.
         unsafe { mjs_setToMotor(self) };
     }
 
-    /// Configure the actuator to be positional-target motor (with a proportional regulator).
+    /// Configure the actuator to be a positional-target motor (with a proportional regulator).
+    /// `kv` and `dampratio` are mutually exclusive damping specifications, and `timeconst`
+    /// optionally adds a first-order activation filter.
     /// # Errors
-    /// Returns [`MjEditError::InvalidParameter`] when the parameters aren't
-    /// within the allowed range.
+    /// Returns [`MjEditError::InvalidParameter`] when the parameters aren't within the allowed
+    /// range, e.g. `kv` and `dampratio` are both given, a value that must be non-negative is
+    /// negative, or `inheritrange` is given together with a control range.
     pub fn set_to_positon(
         &mut self, kp: f64, inheritrange: f64,
-        kv: Option<f64>, dampratio: Option<f64>, timeconst: Option<f64>
+        mut kv: Option<f64>, mut dampratio: Option<f64>, mut timeconst: Option<f64>
     ) -> Result<(), MjEditError>
     {
-        // RETURN: always returns "". 
         let c_err_msg = unsafe { mjs_setToPosition(
             self, kp,
-            kv.map_or(ptr::null_mut(), |mut x| &mut x),
-            dampratio.map_or(ptr::null_mut(), |mut x| &mut x),
-            timeconst.map_or(ptr::null_mut(), |mut x| &mut x),
+            kv.as_mut().map_or(ptr::null_mut(), |x| x),
+            dampratio.as_mut().map_or(ptr::null_mut(), |x| x),
+            timeconst.as_mut().map_or(ptr::null_mut(), |x| x),
             inheritrange
         ) };
+        actuator_set_result(c_err_msg)
+    }
 
-        // SAFETY: MuJoCo's error messages are always NULL terminated.
-        let err_msg = unsafe { CStr::from_ptr(c_err_msg).to_string_lossy() };
-        if err_msg.len() > 0 {
-            return Err(MjEditError::InvalidParameter(err_msg.to_string()));
-        }
+    /// Configure the actuator to be an integrated-velocity servo. This behaves like
+    /// [`MjsActuator::set_to_positon`], but integrates the control signal into an activation
+    /// variable. See that method for the meaning of the parameters.
+    /// # Errors
+    /// Returns [`MjEditError::InvalidParameter`] when `inheritrange` is given together with an
+    /// activation range.
+    pub fn set_to_int_velocity(
+        &mut self, kp: f64, inheritrange: f64,
+        mut kv: Option<f64>, mut dampratio: Option<f64>, mut timeconst: Option<f64>
+    ) -> Result<(), MjEditError>
+    {
+        let c_err_msg = unsafe { mjs_setToIntVelocity(
+            self, kp,
+            kv.as_mut().map_or(ptr::null_mut(), |x| x),
+            dampratio.as_mut().map_or(ptr::null_mut(), |x| x),
+            timeconst.as_mut().map_or(ptr::null_mut(), |x| x),
+            inheritrange
+        ) };
+        actuator_set_result(c_err_msg)
+    }
 
-        Ok(())
+    /// Configure the actuator to be a velocity servo with velocity feedback gain `kv`.
+    pub fn set_to_velocity(&mut self, kv: f64) {
+        // mjs_setToVelocity cannot fail; it always returns an empty string.
+        unsafe { mjs_setToVelocity(self, kv) };
+    }
+
+    /// Configure the actuator to be a damper with damping coefficient `kv`. The applied force is
+    /// proportional to velocity and modulated by the (non-negative) control input.
+    /// # Errors
+    /// Returns [`MjEditError::InvalidParameter`] when `kv` is negative or the control range is
+    /// negative.
+    pub fn set_to_damper(&mut self, kv: f64) -> Result<(), MjEditError> {
+        let c_err_msg = unsafe { mjs_setToDamper(self, kv) };
+        actuator_set_result(c_err_msg)
+    }
+
+    /// Configure the actuator to be a hydraulic or pneumatic cylinder. `timeconst` is the
+    /// activation filter time constant, `bias` is added to the force, and the effective area is
+    /// `area`; if `diameter` is non-negative, the area is computed from it instead.
+    pub fn set_to_cylinder(&mut self, timeconst: f64, bias: f64, area: f64, diameter: f64) {
+        // mjs_setToCylinder cannot fail; it always returns an empty string.
+        unsafe { mjs_setToCylinder(self, timeconst, bias, area, diameter) };
+    }
+
+    /// Configure the actuator to be a muscle. `timeconst` holds the activation and deactivation
+    /// time constants, `range` the operating-length range, and the remaining scalars the muscle
+    /// force-length-velocity parameters. A negative value for any array entry or scalar (except
+    /// `tausmooth`) leaves the corresponding muscle default in place.
+    /// # Errors
+    /// Returns [`MjEditError::InvalidParameter`] when `tausmooth` is negative.
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_to_muscle(
+        &mut self, mut timeconst: [f64; 2], tausmooth: f64, mut range: [f64; 2],
+        force: f64, scale: f64, lmin: f64, lmax: f64, vmax: f64, fpmax: f64, fvmax: f64
+    ) -> Result<(), MjEditError>
+    {
+        let c_err_msg = unsafe { mjs_setToMuscle(
+            self, &mut timeconst, tausmooth, &mut range,
+            force, scale, lmin, lmax, vmax, fpmax, fvmax
+        ) };
+        actuator_set_result(c_err_msg)
+    }
+
+    /// Configure the actuator to be an active-adhesion actuator with the given `gain`.
+    /// # Errors
+    /// Returns [`MjEditError::InvalidParameter`] when `gain` is negative or the control range is
+    /// negative.
+    pub fn set_to_adhesion(&mut self, gain: f64) -> Result<(), MjEditError> {
+        let c_err_msg = unsafe { mjs_setToAdhesion(self, gain) };
+        actuator_set_result(c_err_msg)
+    }
+
+    /// Configure the actuator to be a DC motor. `resistance` and `input_mode` are required; all
+    /// array parameters are optional and a `None` value disables the corresponding feature
+    /// (`motorconst`: `[Kt, Ke]`; `nominal`: `[voltage, stall_torque, no_load_speed]`;
+    /// `saturation`: `[tau_max, i_max, di_dt_max]`; `inductance`: `[L, te]`;
+    /// `cogging`: `[amplitude, periodicity, phase]`;
+    /// `controller`: `[kp, ki, kd, slewmax, Imax, v_max]`;
+    /// `thermal`: `[R_th, C, tau_th, alpha, T0, T_ambient]`;
+    /// `lugre`: `[stiffness, damping, coulomb, static, stribeck]`).
+    /// # Errors
+    /// Returns [`MjEditError::InvalidParameter`] when the derived motor constant or resistance is
+    /// not positive, or when an inductance, thermal resistance, or thermal capacitance value is
+    /// out of its allowed range.
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_to_dc_motor(
+        &mut self,
+        mut motorconst: Option<[f64; 2]>, resistance: f64,
+        mut nominal: Option<[f64; 3]>, mut saturation: Option<[f64; 3]>,
+        mut inductance: Option<[f64; 2]>, mut cogging: Option<[f64; 3]>,
+        mut controller: Option<[f64; 6]>, mut thermal: Option<[f64; 6]>,
+        mut lugre: Option<[f64; 5]>, input_mode: i32
+    ) -> Result<(), MjEditError>
+    {
+        let c_err_msg = unsafe { mjs_setToDCMotor(
+            self,
+            motorconst.as_mut().map_or(ptr::null_mut(), |x| x),
+            resistance,
+            nominal.as_mut().map_or(ptr::null_mut(), |x| x),
+            saturation.as_mut().map_or(ptr::null_mut(), |x| x),
+            inductance.as_mut().map_or(ptr::null_mut(), |x| x),
+            cogging.as_mut().map_or(ptr::null_mut(), |x| x),
+            controller.as_mut().map_or(ptr::null_mut(), |x| x),
+            thermal.as_mut().map_or(ptr::null_mut(), |x| x),
+            lugre.as_mut().map_or(ptr::null_mut(), |x| x),
+            input_mode
+        ) };
+        actuator_set_result(c_err_msg)
     }
 }
 
@@ -2191,6 +2313,73 @@ mod tests {
         
         assert!(actuator.set_default(DEFAULT_NAME).is_ok());
 
+        spec.compile().unwrap();
+    }
+
+    #[test]
+    fn test_actuator_set_to() {
+        let mut spec = MjSpec::new();
+        let body = spec.world_body_mut().add_body();
+        body.add_geom().with_size([0.01, 0.0, 0.0]);
+        body.add_joint().with_name("hinge").with_type(MjtJoint::mjJNT_HINGE);
+
+        let actuator = spec.add_actuator().with_trntype(MjtTrn::mjTRN_JOINT);
+        actuator.set_target("hinge");
+
+        /* motor */
+        actuator.set_to_motor();
+        assert_eq!(actuator.gaintype(), MjtGain::mjGAIN_FIXED);
+        assert_eq!(actuator.biastype(), MjtBias::mjBIAS_NONE);
+        assert_eq!(actuator.dyntype(), MjtDyn::mjDYN_NONE);
+        assert_eq!(actuator.gainprm()[0], 1.0);
+
+        /* velocity servo */
+        actuator.set_to_velocity(2.0);
+        assert_eq!(actuator.gaintype(), MjtGain::mjGAIN_FIXED);
+        assert_eq!(actuator.biastype(), MjtBias::mjBIAS_AFFINE);
+        assert_eq!(actuator.gainprm()[0], 2.0);
+        assert_eq!(actuator.biasprm()[2], -2.0);
+
+        /* damper: negative feedback gain is rejected, otherwise affine gain */
+        assert!(actuator.set_to_damper(-1.0).is_err());
+        assert!(actuator.set_to_damper(5.0).is_ok());
+        assert_eq!(actuator.gaintype(), MjtGain::mjGAIN_AFFINE);
+        assert_eq!(actuator.gainprm()[2], -5.0);
+
+        /* adhesion: negative gain is rejected */
+        assert!(actuator.set_to_adhesion(-1.0).is_err());
+        assert!(actuator.set_to_adhesion(1.0).is_ok());
+
+        /* cylinder: filter dynamics, always succeeds */
+        actuator.set_to_cylinder(0.1, 0.0, 1.0, -1.0);
+        assert_eq!(actuator.dyntype(), MjtDyn::mjDYN_FILTER);
+
+        /* muscle: negative tausmooth is rejected, otherwise muscle gain/bias/dyn */
+        assert!(actuator.set_to_muscle([-1.0, -1.0], -1.0, [-1.0, -1.0], -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0).is_err());
+        assert!(actuator.set_to_muscle([-1.0, -1.0], 0.0, [-1.0, -1.0], -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0).is_ok());
+        assert_eq!(actuator.gaintype(), MjtGain::mjGAIN_MUSCLE);
+        assert_eq!(actuator.biastype(), MjtBias::mjBIAS_MUSCLE);
+        assert_eq!(actuator.dyntype(), MjtDyn::mjDYN_MUSCLE);
+
+        /* position: kv and dampratio are mutually exclusive */
+        assert!(actuator.set_to_positon(1.0, 0.0, Some(1.0), Some(1.0), None).is_err());
+        assert!(actuator.set_to_positon(1.0, 0.0, Some(1.0), None, None).is_ok());
+
+        /* integrated velocity: integrator dynamics */
+        assert!(actuator.set_to_int_velocity(1.0, 0.0, None, None, None).is_ok());
+        assert_eq!(actuator.dyntype(), MjtDyn::mjDYN_INTEGRATOR);
+
+        /* dc motor: a positive motor constant and resistance are required */
+        assert!(actuator.set_to_dc_motor(None, 0.0, None, None, None, None, None, None, None, 0).is_err());
+        assert!(actuator.set_to_dc_motor(Some([1.0, 1.0]), 1.0, None, None, None, None, None, None, None, 0).is_ok());
+        assert_eq!(actuator.gaintype(), MjtGain::mjGAIN_DCMOTOR);
+        assert_eq!(actuator.biastype(), MjtBias::mjBIAS_DCMOTOR);
+        assert_eq!(actuator.dyntype(), MjtDyn::mjDYN_DCMOTOR);
+
+        /* reset to a plain motor and confirm the spec still compiles */
+        actuator.set_to_motor();
+        actuator.set_actearly(false);
+        actuator.set_ctrllimited(MjtLimited::mjLIMITED_FALSE);
         spec.compile().unwrap();
     }
 

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -1060,10 +1060,12 @@ fn actuator_set_result(c_err_msg: *const c_char) -> Result<(), MjEditError> {
 }
 
 /* Actuator configuration structs.
-** Each `set_to_*` method takes its own config struct. Build with struct-update syntax so only the
-** relevant fields are specified, e.g. `PositionConfig { kp: 10.0, kv: Some(2.0), ..Default::default() }`.
-** Optional fields default to `None`, leaving the corresponding actuator parameter at its MuJoCo
-** default. */
+** Each `set_to_*` method taking optional (nullable in C) parameters has its own config struct.
+** Build either with struct-update syntax or with the chainable `with_*` builder methods, e.g.
+** `PositionConfig { kp: 10.0, kv: Some(2.0), ..Default::default() }` or
+** `PositionConfig::default().with_kp(10.0).with_kv(2.0)`. Optional fields default to `None`,
+** leaving the corresponding actuator parameter at its MuJoCo default; the `with_*` setters take
+** the inner value directly and wrap it in `Some`. */
 
 /// Configuration for [`MjsActuator::set_to_positon`].
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -1080,6 +1082,18 @@ pub struct PositionConfig {
     pub timeconst: Option<f64>,
 }
 
+impl PositionConfig {
+    getter_setter! {
+        with, [
+            kp: f64;            "the proportional (position) gain.";
+            inheritrange: f64;  "the automatic range-inheritance factor.";
+            kv: f64;            "the velocity feedback gain (mutually exclusive with dampratio).";
+            dampratio: f64;     "the damping ratio (mutually exclusive with kv).";
+            timeconst: f64;     "the first-order activation-filter time constant.";
+        ]
+    }
+}
+
 /// Configuration for [`MjsActuator::set_to_int_velocity`]. Same parameters as [`PositionConfig`].
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct IntVelocityConfig {
@@ -1093,6 +1107,18 @@ pub struct IntVelocityConfig {
     pub dampratio: Option<f64>,
     /// First-order activation-filter time constant.
     pub timeconst: Option<f64>,
+}
+
+impl IntVelocityConfig {
+    getter_setter! {
+        with, [
+            kp: f64;            "the proportional gain.";
+            inheritrange: f64;  "the automatic range-inheritance factor.";
+            kv: f64;            "the velocity feedback gain (mutually exclusive with dampratio).";
+            dampratio: f64;     "the damping ratio (mutually exclusive with kv).";
+            timeconst: f64;     "the first-order activation-filter time constant.";
+        ]
+    }
 }
 
 /// Configuration for [`MjsActuator::set_to_dc_motor`].
@@ -1120,6 +1146,23 @@ pub struct DcMotorConfig {
     pub thermal: Option<[f64; 6]>,
     /// LuGre friction `[stiffness, damping, coulomb, static, stribeck]`.
     pub lugre: Option<[f64; 5]>,
+}
+
+impl DcMotorConfig {
+    getter_setter! {
+        with, [
+            resistance: f64;       "the electrical resistance.";
+            input_mode: i32;       "the input mode selector.";
+            motorconst: [f64; 2];  "the torque and back-EMF constants [Kt, Ke].";
+            nominal: [f64; 3];     "the nominal ratings [voltage, stall_torque, no_load_speed].";
+            saturation: [f64; 3];  "the saturation [tau_max, i_max, di_dt_max].";
+            inductance: [f64; 2];  "the inductance [L, te].";
+            cogging: [f64; 3];     "the cogging [amplitude, periodicity, phase].";
+            controller: [f64; 6];  "the controller [kp, ki, kd, slewmax, Imax, v_max].";
+            thermal: [f64; 6];     "the thermal [R_th, C, tau_th, alpha, T0, T_ambient].";
+            lugre: [f64; 5];       "the LuGre friction [stiffness, damping, coulomb, static, stribeck].";
+        ]
+    }
 }
 
 impl MjsActuator {
@@ -2404,20 +2447,20 @@ mod tests {
         assert_eq!(actuator.biastype(), MjtBias::mjBIAS_MUSCLE);
         assert_eq!(actuator.dyntype(), MjtDyn::mjDYN_MUSCLE);
 
-        /* position: kv and dampratio are mutually exclusive */
+        /* position (builder API): kv and dampratio are mutually exclusive */
         assert!(actuator.set_to_positon(
-            PositionConfig { kp: 1.0, kv: Some(1.0), dampratio: Some(1.0), ..Default::default() }
+            PositionConfig::default().with_kp(1.0).with_kv(1.0).with_dampratio(1.0)
         ).is_err());
-        actuator.set_to_positon(PositionConfig { kp: 1.0, kv: Some(1.0), ..Default::default() }).unwrap();
+        actuator.set_to_positon(PositionConfig::default().with_kp(1.0).with_kv(1.0)).unwrap();
 
         /* integrated velocity: integrator dynamics */
-        actuator.set_to_int_velocity(IntVelocityConfig { kp: 1.0, ..Default::default() }).unwrap();
+        actuator.set_to_int_velocity(IntVelocityConfig::default().with_kp(1.0)).unwrap();
         assert_eq!(actuator.dyntype(), MjtDyn::mjDYN_INTEGRATOR);
 
-        /* dc motor: without a motor constant MuJoCo cannot derive K > 0, so it is rejected */
+        /* dc motor (builder API): without a motor constant MuJoCo cannot derive K > 0 */
         assert!(actuator.set_to_dc_motor(DcMotorConfig::default()).is_err());
         actuator.set_to_dc_motor(
-            DcMotorConfig { motorconst: Some([1.0, 1.0]), resistance: 1.0, ..Default::default() }
+            DcMotorConfig::default().with_motorconst([1.0, 1.0]).with_resistance(1.0)
         ).unwrap();
         assert_eq!(actuator.gaintype(), MjtGain::mjGAIN_DCMOTOR);
         assert_eq!(actuator.biastype(), MjtBias::mjBIAS_DCMOTOR);


### PR DESCRIPTION
Implements the ability to set acuator types via the `set_to_x`, methods available on the `MjsActuator`.