### PR TITLE
Fix ray mutability of `MjData::ray` and `MjData::ray_mesh`

### DIFF
--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -128,6 +128,16 @@ update of MuJoCo alone can increase the major version.
   (see Bug fixes). The signature is otherwise unchanged; existing calls only need an ``unsafe``
   block.
 
+*MjData::ray / ray_mesh now take* ``&mut self``
+
+- :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>ray`,
+  :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>ray_mesh`, and
+  :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>try_ray_mesh` now take
+  ``&mut self`` (previously ``&self``). Their bounding-volume traversal mutates ``data.bvh_active``
+  (see Bug fixes), so callers holding a shared ``&MjData`` need an exclusive borrow instead.
+  ``ray_flex`` / ``ray_hfield`` are unaffected and remain ``&self``; ``multi_ray`` already took
+  ``&mut self``.
+
 .. rubric:: Deprecations
 
 - Deprecated :docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>delete`
@@ -309,6 +319,15 @@ runtime.
   shared error buffer), so the calls raced on the one arena -- undefined behavior. The handles
   (and ``MjsDefault``) are now ``!Send + !Sync``, so such a mutation can no longer cross a
   thread boundary; the owning |mj_spec| stays ``Send + Sync``.
+- Closed an unsoundness reachable from safe code in
+  :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>ray` and
+  :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>ray_mesh`, which took ``&self``
+  although their bounding-volume traversal (``mju_rayTree``) writes ``data.bvh_active`` when the
+  model's ``bvactive`` visualization flag is set. The MuJoCo C functions declare ``const mjData*``
+  yet mutate through it, so the ``&self`` signature let safe code drive shared-state mutation: with
+  ``MjData<M>: Sync`` two threads could race on ``bvh_active``, and a ``&[bool]`` borrowed from the
+  safe ``bvh_active`` accessor could be mutated while still live. ``ray``, ``ray_mesh``, and
+  ``try_ray_mesh`` now take ``&mut self``. See the Breaking changes section and the migration guide.
 
 
 .. rubric:: Other changes

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -286,6 +286,32 @@ existing call sites only need an ``unsafe`` block.
     unsafe { data.reset_debug(7) };
 
 
+``MjData::ray`` / ``ray_mesh`` now take ``&mut self``
+-----------------------------------------------------
+
+``ray``, ``ray_mesh``, and ``try_ray_mesh`` now take ``&mut self`` (previously ``&self``). Their
+bounding-volume traversal (``mju_rayTree``) writes ``data.bvh_active`` when the model's ``bvactive``
+visualization flag is set, even though the underlying MuJoCo C functions are declared
+``const mjData*``. The ``&self`` signature therefore let safe code drive shared ``MjData`` mutation
+(a data race under ``MjData<M>: Sync``, or mutation of a live ``&[bool]`` obtained from the
+``bvh_active`` accessor). Callers that held a shared ``&MjData`` now need an exclusive borrow.
+``ray_flex`` and ``ray_hfield`` are unaffected; ``multi_ray`` already took ``&mut self``.
+
+**Before (4.x):**
+
+.. code-block:: rust
+
+    let data = model.make_data();
+    let (geomid, dist) = data.ray(&pnt, &vec, None, false, None, None);
+
+**After:**
+
+.. code-block:: rust
+
+    let mut data = model.make_data();
+    let (geomid, dist) = data.ray(&pnt, &vec, None, false, None, None);
+
+
 .. _migrate_4_0_0:
 
 Migrating to 4.0.0

--- a/src/wrappers/mj_data.rs
+++ b/src/wrappers/mj_data.rs
@@ -1175,7 +1175,7 @@ impl<M: Deref<Target = MjModel>> MjData<M> {
     /// If `normal_out` is `Some`, it will be filled with the surface normal at the intersection.
     /// `geomgroup` and `flg_static` are as in mjvOption; pass `None` for `geomgroup` to skip group exclusion.
     pub fn ray(
-        &self, pnt: &[MjtNum; 3], vec: &[MjtNum; 3],
+        &mut self, pnt: &[MjtNum; 3], vec: &[MjtNum; 3],
         geomgroup: Option<&[MjtByte; mjNGROUP as usize]>, flg_static: MjtBool, bodyexclude: Option<usize>,
         normal_out: Option<&mut [MjtNum; 3]>
     ) -> (Option<usize>, MjtNum) {
@@ -1294,7 +1294,7 @@ impl<M: Deref<Target = MjModel>> MjData<M> {
     ///
     /// Use [`MjData::try_ray_mesh`] for a fallible alternative.
     pub fn ray_mesh(
-        &self, geom_id: usize, pnt: &[MjtNum; 3], vec: &[MjtNum; 3], normal_out: Option<&mut [MjtNum; 3]>
+        &mut self, geom_id: usize, pnt: &[MjtNum; 3], vec: &[MjtNum; 3], normal_out: Option<&mut [MjtNum; 3]>
     ) -> MjtNum {
         self.try_ray_mesh(geom_id, pnt, vec, normal_out).unwrap()
     }
@@ -1306,7 +1306,7 @@ impl<M: Deref<Target = MjModel>> MjData<M> {
     ///
     /// Use [`MjData::ray_mesh`] for a panicking alternative.
     pub fn try_ray_mesh(
-        &self, geom_id: usize, pnt: &[MjtNum; 3], vec: &[MjtNum; 3], normal_out: Option<&mut [MjtNum; 3]>
+        &mut self, geom_id: usize, pnt: &[MjtNum; 3], vec: &[MjtNum; 3], normal_out: Option<&mut [MjtNum; 3]>
     ) -> Result<MjtNum, MjDataError> {
         let ngeom = self.model.ffi().ngeom as usize;
         if geom_id >= ngeom {


### PR DESCRIPTION
The methods mentioned in the title of this pull request make mutable changes to the parameters of data, despite the latter being a const pointer. This currently allows borrow-checker to pass on data racing code (e.g., constantly borrowing `bvh_active` and afterwards calling the said methods.

This PR fixes the mutability by making the Rust wrappers take `&mut self`.