### PR TITLE
Fix more aliasing and threading unsoundness

### DIFF
--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -138,6 +138,22 @@ update of MuJoCo alone can increase the major version.
   ``ray_flex`` / ``ray_hfield`` are unaffected and remain ``&self``; ``multi_ray`` already took
   ``&mut self``.
 
+*MjvScene::find_selection now takes* ``&mut MjData``
+
+- :docs-rs:`~~mujoco_rs::wrappers::mj_visualization::<struct>MjvScene::<method>find_selection`
+  now takes ``data: &mut MjData<M>`` (previously ``&MjData<M>``). It calls ``mjv_select`` ->
+  ``mj_ray``, whose bounding-volume traversal mutates ``data.bvh_active`` (see Bug fixes), so an
+  exclusive borrow is required. This mirrors |mjv_scene|'s ``update`` (already ``&mut MjData``) and
+  the ``ray`` / ``ray_mesh`` change above.
+
+*MjSpec is no longer* ``Sync``
+
+- |mj_spec| is now ``Send`` but no longer ``Sync`` (see Bug fixes). Several ``&self`` methods --
+  notably ``clone`` / ``try_clone`` -- drive C-side writes to the spec, so sharing a ``&MjSpec``
+  across threads is unsound. Code that required ``MjSpec: Sync`` (for example placing a ``&MjSpec``
+  in a type that demands ``Sync``) will no longer compile; transfer ownership instead, as ``MjSpec``
+  remains ``Send``.
+
 .. rubric:: Deprecations
 
 - Deprecated :docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>delete`
@@ -318,7 +334,7 @@ runtime.
   concurrently; ``mjs_setName`` reaches model-global state (``mjCModel::CheckRepeat`` and the
   shared error buffer), so the calls raced on the one arena -- undefined behavior. The handles
   (and ``MjsDefault``) are now ``!Send + !Sync``, so such a mutation can no longer cross a
-  thread boundary; the owning |mj_spec| stays ``Send + Sync``.
+  thread boundary; the owning |mj_spec| stays ``Send`` (it is now ``!Sync``; see below).
 - Closed an unsoundness reachable from safe code in
   :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>ray` and
   :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>ray_mesh`, which took ``&self``
@@ -328,6 +344,26 @@ runtime.
   ``MjData<M>: Sync`` two threads could race on ``bvh_active``, and a ``&[bool]`` borrowed from the
   safe ``bvh_active`` accessor could be mutated while still live. ``ray``, ``ray_mesh``, and
   ``try_ray_mesh`` now take ``&mut self``. See the Breaking changes section and the migration guide.
+- Closed an unsoundness reachable from safe code in
+  :docs-rs:`~~mujoco_rs::wrappers::mj_visualization::<struct>MjvScene::<method>find_selection`, which
+  took a shared ``&MjData`` although it calls ``mjv_select`` -> ``mj_ray``, whose bounding-volume
+  traversal writes ``data.bvh_active`` (the same ``const mjData*``-but-mutating path as ``ray``
+  above). The shared borrow let safe code drive that mutation: with ``MjData<M>: Sync`` two threads
+  could race on ``bvh_active``, and a ``&[bool]`` from the safe ``bvh_active`` accessor could be
+  mutated while still live. ``find_selection`` now takes ``&mut MjData``. See the Breaking changes
+  section and the migration guide.
+- Closed an unsoundness reachable from safe code in |mj_spec|, which carried an unconditional
+  ``unsafe impl Sync``. ``clone`` / ``try_clone`` produce a faithful, independent copy, but the C++
+  copy constructor behind ``mj_copySpec`` is not strictly ``const`` on the source: for each actuator
+  it clears two ``std::map`` keyframe-resolution caches (``ForgetKeyframes``). Those maps are empty
+  for a normally-built spec, yet ``std::map::clear`` rewrites the tree header unconditionally, so two
+  threads sharing a ``&MjSpec`` and cloning concurrently raced on those writes (no spec data is lost).
+  |mj_spec| is now ``!Sync`` (it stays ``Send``). See the Breaking changes section and the migration
+  guide.
+- Closed an out-of-bounds write reachable from safe code in
+  :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_normalize`. On an empty slice the C function
+  computes a zero norm and then writes ``res[0] = 1`` followed by ``mju_zero(res + 1, -1)`` -- a
+  ``memset`` of ``(size_t)(-1)`` bytes, both out of bounds. The wrapper now panics on an empty slice.
 
 
 .. rubric:: Other changes

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -111,7 +111,8 @@ update of MuJoCo alone can increase the major version.
   ``!Send + !Sync``; they previously carried a blanket ``unsafe impl Send``/``Sync``. Each
   handle is only a raw pointer into one shared ``mjSpec``/``mjCModel`` arena, so moving or
   sharing one across threads was unsound (see Bug fixes). Code that did so will no longer
-  compile --- move or read-share the owning |mj_spec| instead, which remains ``Send + Sync``.
+  compile --- move the owning |mj_spec| instead, which remains ``Send`` (it is no longer
+  ``Sync``; see below).
 
 *MjData::add_contact is now an ``unsafe fn``*
 
@@ -184,6 +185,9 @@ New error variants in pre-existing enums:
 - :docs-rs:`~mujoco_rs::renderer::<enum>RendererError`: ``SignatureMismatch`` (model structure does
   not match the renderer's current scene), ``ContextError(MjrContextError)`` (wraps a rendering-context error,
   e.g. an out-of-range asset ID).
+- :docs-rs:`~mujoco_rs::error::<enum>MjEditError`: ``InvalidParameter(String)`` (an actuator
+  configuration helper rejected a parameter; the string is MuJoCo's rejection message). Returned by
+  the new ``set_to_*`` actuator helpers (see New features and improvements).
 
 .. rubric:: New features and improvements
 

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -312,6 +312,61 @@ visualization flag is set, even though the underlying MuJoCo C functions are dec
     let (geomid, dist) = data.ray(&pnt, &vec, None, false, None, None);
 
 
+``MjvScene::find_selection`` now takes ``&mut MjData``
+------------------------------------------------------
+
+|mjv_scene|'s ``find_selection`` now takes ``data: &mut MjData<M>`` (previously ``&MjData<M>``).
+It calls ``mjv_select`` -> ``mj_ray``, whose bounding-volume traversal writes ``data.bvh_active``
+(the same ``const mjData*``-but-mutating path as ``ray`` above), so a shared borrow was unsound.
+Pass an exclusive borrow instead. (``MjvScene::update`` already took ``&mut MjData``.)
+
+**Before (4.x):**
+
+.. code-block:: rust
+
+    let data = model.make_data();
+    let sel = scene.find_selection(&data, &opt, aspect, relx, rely);
+
+**After:**
+
+.. code-block:: rust
+
+    let mut data = model.make_data();
+    let sel = scene.find_selection(&mut data, &opt, aspect, relx, rely);
+
+
+``MjSpec`` is no longer ``Sync``
+--------------------------------
+
+|mj_spec| is now ``Send`` but no longer ``Sync``. ``clone`` / ``try_clone`` make a faithful,
+independent copy, but the underlying C++ copy constructor is not strictly ``const`` on the source
+(it rewrites transient, normally-empty per-actuator keyframe-cache maps), so two threads cloning a
+shared ``&MjSpec`` concurrently is a data race. ``MjSpec`` still moves between threads (``Send``);
+only shared cross-thread access is removed. Code that placed a ``&MjSpec`` in a ``Sync``-requiring
+context must transfer ownership (or clone per thread) instead.
+
+**Before (4.x):**
+
+.. code-block:: rust
+
+    // relied on &MjSpec being shareable across threads
+    std::thread::scope(|s| {
+        s.spawn(|| { let _ = spec.clone(); });
+        s.spawn(|| { let _ = spec.clone(); });
+    });
+
+**After:**
+
+.. code-block:: rust
+
+    // move an owned MjSpec into each thread (clone up front if needed)
+    let spec2 = spec.clone();
+    std::thread::scope(|s| {
+        s.spawn(move || { let _ = spec; });
+        s.spawn(move || { let _ = spec2; });
+    });
+
+
 .. _migrate_4_0_0:
 
 Migrating to 4.0.0

--- a/src/wrappers/fun/utility.rs
+++ b/src/wrappers/fun/utility.rs
@@ -110,8 +110,14 @@ pub fn mju_add_scl(res: &mut [MjtNum], vec1: &[MjtNum], vec2: &[MjtNum], scl: Mj
 }
 
 /// Normalize a vector in place and return its length before normalization.
+///
+/// # Panics
+/// Panics if `res` is empty.
 pub fn mju_normalize(res: &mut [MjtNum]) -> MjtNum {
-    // SAFETY: pointer and length derived from a valid slice.
+    // For n == 0 the C function writes res[0] = 1 and then mju_zero(res + 1, n - 1),
+    // i.e. memset with a (size_t)(-1) length, both out of bounds.
+    assert!(!res.is_empty());
+    // SAFETY: pointer and length derived from a valid, non-empty slice.
     unsafe { mujoco_c::mju_normalize(res.as_mut_ptr(), res.len() as i32) }
 }
 
@@ -755,6 +761,15 @@ mod tests {
         let len = mju_normalize(&mut a);
         assert!((len - 5.0).abs() < 1e-10);
         assert!((mju_norm(&a) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_mju_normalize_panics_on_empty() {
+        // An empty slice would make the C function write res[0] and memset a (size_t)(-1)
+        // length, both out of bounds; the wrapper must reject it instead.
+        let mut empty = [];
+        mju_normalize(&mut empty);
     }
 
     #[test]

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -146,8 +146,15 @@ impl MjsCompiler {
 #[derive(Debug)]
 pub struct MjSpec(NonNull<mjSpec>);
 
-// SAFETY: The pointer cannot be accessed without borrowing the wrapper.
-unsafe impl Sync for MjSpec {}
+// SAFETY: `MjSpec` owns its `mjSpec` exclusively, so moving it between threads transfers
+// sole ownership and cannot race.
+//
+// It is intentionally NOT `Sync`. `clone`/`try_clone` produce a faithful, independent copy, but
+// the C++ copy constructor behind `mj_copySpec` is not strictly `const` on the source: for every
+// actuator it calls `ForgetKeyframes`, which clears two `std::map` keyframe-resolution caches
+// (`act_`/`ctrl_`). Those maps are empty for a normally-built spec, yet `std::map::clear` rewrites
+// the tree header unconditionally, so two threads sharing a `&MjSpec` and cloning concurrently
+// would race on those writes (a data race, though no spec data is lost). Hence the type stays `!Sync`.
 unsafe impl Send for MjSpec {}
 
 impl MjSpec {

--- a/src/wrappers/mj_editing/default.rs
+++ b/src/wrappers/mj_editing/default.rs
@@ -99,4 +99,4 @@ impl SpecItem for MjsDefault {
 // element handles: it is a raw pointer into the shared mjSpec arena and its `&mut self`
 // mutators reach into model-global state. The raw-pointer field already makes it
 // auto-`!Send + !Sync`; do NOT add `unsafe impl Send`/`Sync` here. The owning `MjSpec`
-// remains `Send + Sync`, so the spec itself can still cross threads.
+// remains `Send` (but not `Sync`), so the spec itself can still move between threads.

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -16,19 +16,6 @@ pub(crate) mod sealed {
 /// This is pre-implemented for all the specification types and is not
 /// meant to be implemented by the user.
 ///
-/// # Thread safety
-/// Every `Mjs*` handle borrows into a single shared `mjSpec`/`mjCModel` arena, and the
-/// mutators below reach through that arena to read siblings and write model-global state
-/// (for example [`set_name`](SpecItem::set_name) -> `mjs_setName` runs `mjCModel::CheckRepeat`).
-/// The handles are therefore deliberately `!Send + !Sync`, so a mutation cannot be moved
-/// to another thread to race on the shared model:
-/// ```compile_fail
-/// fn is_send<T: Send>() {}
-/// // Fails to compile on purpose: every `Mjs*` handle is intentionally `!Send`.
-/// is_send::<mujoco_rs::wrappers::mj_editing::MjsGeom>();
-/// ```
-/// The owning [`MjSpec`](super::MjSpec) is itself `Send + Sync`, so a whole spec can still
-/// move between threads, and a shared `&MjSpec` can be read concurrently.
 pub trait SpecItem: Sized + sealed::Sealed {
     /// Returns the internal element struct.
     /// The element struct is the C++ implementation of the

--- a/src/wrappers/mj_editing/utility.rs
+++ b/src/wrappers/mj_editing/utility.rs
@@ -409,9 +409,8 @@ macro_rules! mjs_struct {
         // thread boundary would let two such accesses race on the one arena from safe code.
         // The raw-pointer field already makes the type auto-`!Send + !Sync`, so we simply
         // do not add the impls. Do NOT add `unsafe impl Send`/`Sync` here: the owning
-        // `MjSpec` is itself `Send + Sync`, so a whole spec can still move between threads
-        // and a shared `&MjSpec` can be read concurrently --- handles derived from it just
-        // stay on the thread that created them.
+        // `MjSpec` is itself `Send` (but `!Sync`), so a whole spec can still move between
+        // threads --- handles derived from it just stay on the thread that created them.
     }};
 }
 

--- a/src/wrappers/mj_visualization.rs
+++ b/src/wrappers/mj_visualization.rs
@@ -871,7 +871,7 @@ impl MjvScene {
     /// # Panics
     /// Panics if `data` was created from a different model than this scene.
     pub fn find_selection<M: Deref<Target = MjModel>>(
-        &self, data: &MjData<M>, option: &MjvOption,
+        &self, data: &mut MjData<M>, option: &MjvOption,
         aspect_ratio: MjtNum, relx: MjtNum, rely: MjtNum,
     ) -> SceneSelection {
         self.assert_signature(data.model().signature());


### PR DESCRIPTION
Most of the crate properly wraps the C MuJoCo library. However some issues still remain with respect to the Rust's assumptions of the borrow-checker and threading. This PR addresses some of them.