### PR TITLE
Document macOS visualization patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Optional Cargo features can be enabled:
 By default, no optional features are enabled. Enable the features you need explicitly
 (e.g. ``cargo add mujoco-rs --features "viewer-ui renderer-winit-fallback"``).
 
+On macOS, the visualization features (``viewer`` and ``renderer``) do not work without
+patching the ``glutin`` dependency. See
+[installation](https://mujoco-rs.readthedocs.io/en/v5.0.x/installation.html#macos-glutin-patch)
+for instructions.
+
 
 ## Example
 This example requires the ``viewer`` or the ``viewer-ui`` feature

--- a/docs/guide/source/index.rst
+++ b/docs/guide/source/index.rst
@@ -84,6 +84,12 @@ Optional Cargo features can be enabled:
 By default, no optional features are enabled. Enable the features you need explicitly
 (e.g. ``cargo add mujoco-rs --features "viewer-ui renderer-winit-fallback"``).
 
+.. note::
+
+    On macOS, the visualization features (``viewer`` and ``renderer``) do not work without
+    patching the ``glutin`` dependency. See :ref:`the installation guide <macos-glutin-patch>`
+    for instructions.
+
 
 Table of contents
 ===================

--- a/docs/guide/source/installation.rst
+++ b/docs/guide/source/installation.rst
@@ -35,6 +35,19 @@ MuJoCo-rs can be added to your project like so:
     On Windows and macOS the ``renderer-winit-fallback`` feature is **required** whenever the
     ``renderer`` feature is enabled (the build fails otherwise). It is optional on Linux.
 
+.. _macos-glutin-patch:
+
+.. attention::
+
+    **macOS**: visualization (the viewer and the renderer) does not work on macOS with the
+    upstream ``glutin`` crate. To make it work, patch ``glutin`` in your project's
+    ``Cargo.toml`` with the following fork:
+
+    .. code-block:: toml
+
+        [patch.crates-io]
+        glutin = { git = "https://github.com/davidhozic/glutin", rev = "e95fe97f1857c0498ed2236c0e8d60e5a30a2854" }
+
 See :ref:`opt-cargo-features` for information about available Cargo features.
 Visualization and rendering features are opt-in to keep compilation fast for headless use cases.
 

--- a/docs/guide/source/programming/visualization/visualization.rst
+++ b/docs/guide/source/programming/visualization/visualization.rst
@@ -10,6 +10,11 @@ MuJoCo-rs provides three main ways of visualization (requires enabling the corre
 - :ref:`mj_renderer` for offscreen rendering (array or a file) --- ``renderer`` feature
 - :ref:`mj_cpp_viewer` for onscreen visualization using MuJoCo's official C++ viewer --- ``cpp-viewer`` feature
 
+.. attention::
+
+    On macOS, visualization does not work without patching the ``glutin`` dependency.
+    See :ref:`the installation guide <macos-glutin-patch>` for instructions.
+
 
 .. toctree::
     :caption: Table of contents

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,11 @@
 //! (e.g. `cargo add mujoco-rs --features "viewer-ui renderer-winit-fallback"` for support
 //! with the viewer and the viewer's extra UI, and the render with invisible window as a fallback).
 //!
+//! On macOS, the visualization features (`viewer` and `renderer`) do not work without
+//! patching the `glutin` dependency. See
+//! [installation](https://mujoco-rs.readthedocs.io/en/v5.0.x/installation.html#macos-glutin-patch)
+//! for instructions.
+//!
 //!
 use std::ffi::CStr;
 


### PR DESCRIPTION
Visualization does currently not work on macOS due to MuJoCo-incompatible settings for macOS in `glutin` (issue #100). This PR introduces documentation changes that note what needs to be done for visualization to work on macOS.