### PR TITLE
Deprecate tendon wrapping having non-reachable failures

### DIFF
--- a/.claude/rules/coding-conventions.md
+++ b/.claude/rules/coding-conventions.md
@@ -176,6 +176,10 @@ Additional rules:
   - Mark new items with `:sup:\`new\`` (e.g. `` ``try_jac`` :sup:\`new\` ``).
   - Use `` ``double backticks`` `` for inline code (method names, types, values).
   - Use `.. code-block:: rust` for multi-line code examples in migration.rst.
+  - **Em dashes in RST use `---` (three hyphens), not `--`.** reStructuredText renders `---` as an
+    em dash and `--` as an en dash, so prose em dashes in `docs/guide/source/*.rst` must use `---`.
+    This is an RST-specific exception to the general ASCII rule (which uses `--` in Rust source and
+    `.claude/` files); `--` inside RST stays only where an en dash or a literal CLI flag is meant.
   - Prefer lines below ~100 characters. Hard limit: 120 characters.
 - **Changelog section ordering.** Each version entry in `changelog.rst` uses `.. rubric::` sections
   in this fixed order: Breaking changes, Error handling, New features and improvements, Bug fixes,

--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doc
-description: Build rustdoc and Sphinx documentation, verifying both for warnings, broken links, and content correctness. Use this when asked to build docs, check doc comments, or verify documentation.
+description: Build rustdoc and Sphinx documentation, verifying both for warnings, broken links, content correctness, and changelog/migration completeness against the code. Use this when asked to build docs, check doc comments, or verify documentation.
 ---
 
 # Building Documentation
@@ -92,6 +92,43 @@ undefined symbols are illustrative snippets -- skip those.
   prose if needed.
 - **Illustrative snippets** (contain `...`, use undefined vars, or are clearly not
   standalone programs): leave unchanged; they are not expected to compile.
+
+## Part 5 - Changelog and migration completeness
+
+Verify the changelog and migration guide are well-formed and complete against the actual
+public-API changes since the last release.
+
+1. **Changelog well-formed.** The top entry of `docs/guide/source/changelog.rst` must use
+   `.. rubric::` sections in the fixed order: Breaking changes, Deprecations, Error handling,
+   New features and improvements, Bug fixes, Other changes (not all are required, but the
+   relative order must hold). Only public-facing changes are listed, and entries stay concise
+   about *why* (see `.claude/rules/coding-conventions.md` changelog rules).
+2. **Migration entries for breaking changes.** Every breaking change must have a
+   `docs/guide/source/migration.rst` entry with a descriptive heading, prose, and
+   `.. code-block:: rust` Before/After blocks (or a `.. list-table::` for simple signature
+   changes). The migration guide is *only* for breaking changes; non-breaking additions belong
+   in the changelog only (a non-breaking deprecation may still carry an optional migration entry).
+3. **Completeness against the real diff.** Delegate this to a subagent (it is verbose): diff the
+   public API between the most recent release tag and HEAD and confirm every public / breaking
+   change is documented. Release tags have no `v` prefix (e.g. `4.0.1`); pick the highest such
+   tag as the baseline unless the caller supplies one (e.g. `/release` passes its Phase 0
+   baseline). Work accumulates on `develop`/pre-release branches that may be ahead of `main`,
+   so diff against the **tag**, not `main`.
+
+   Subagent prompt essentials (per `.claude/rules/subagent-policy.md` -- point it at the rules,
+   do not paste them):
+   - Read `.claude/rules/coding-conventions.md` (Documentation + changelog/migration rules)
+     and `.claude/rules/disallowed-commands.md`.
+   - Run `git diff <baseline_tag> HEAD -- src/ Cargo.toml` and extract every change to a public
+     item (new/removed/renamed/re-typed `pub` fn/struct/enum/trait/variant, signature changes,
+     new `unsafe fn`, error-type changes, deprecations, feature changes).
+   - For each, confirm it appears in `changelog.rst`; for each breaking one, confirm a
+     `migration.rst` entry with valid Before/After Rust.
+   - Argue every gap from both sides (for/against) per the subagent-policy audit rule.
+   - Return a concise table: change | documented? (changelog / migration) | verdict, plus a
+     list of undocumented changes. No raw file dumps.
+
+Fix any gaps before considering documentation work done.
 
 > [!NOTE]
 > - Always run `/doc` after adding or modifying public items, doc comments, `#[cfg(docsrs)]` attributes, or any `.rst` file.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -104,35 +104,19 @@ Report a table of every checked location with its current value vs the expected 
 
 ## Phase 2 -- Changelog and migration completeness
 
-1. **Changelog section exists and is well-formed.** `docs/guide/source/changelog.rst` must
-   have a top entry `X.Y.Z (MuJoCo A.B.C)`. Its `.. rubric::` sections must follow the fixed
-   order: Breaking changes, Deprecations, Error handling, New features and improvements,
-   Bug fixes, Other changes (not all are required, but order must hold). Only public-facing
-   changes; entries concise about *why* (see coding-conventions changelog rules).
-2. **Migration section exists (major bumps).** For a major bump, `migration.rst` needs a
-   `Migrating to X.Y.Z` section with a prose explanation and `.. code-block:: rust`
-   Before/After blocks (or a `list-table` for simple signature changes) for **every**
-   breaking change.
-3. **Completeness against the real diff.** Delegate this to a subagent (it is verbose): diff
-   the public API between the previous tag and HEAD and confirm every breaking/public change
-   is documented in both changelog and (if breaking) migration. Release work accumulates on
-   `develop` and the current pre-release branch, which may be ahead of `main`; diff against the
-   previous release **tag** (Phase 0 baseline), not `main`, so unmerged changes are included.
+The changelog/migration **verification** lives in `/doc` (Part 5): `.. rubric::` ordering,
+migration Before/After blocks for every breaking change, and the subagent-driven completeness
+audit of the public-API diff. `/doc` runs in Phase 3 -- pass it the Phase 0 baseline tag so the
+diff uses the correct previous release. Do not duplicate that audit here.
 
-   Subagent prompt essentials (per `.claude/rules/subagent-policy.md` -- point it at rules,
-   do not paste them):
-   - Read `.claude/rules/coding-conventions.md` (Documentation + changelog/migration rules)
-     and `.claude/rules/disallowed-commands.md`.
-   - Run `git diff <prev_tag> HEAD -- src/ Cargo.toml` and extract every change to a public
-     item (new/removed/renamed/re-typed `pub` fn/struct/enum/trait/variant, signature
-     changes, new `unsafe fn`, error-type changes, feature changes).
-   - For each, confirm it appears in `changelog.rst`; for each breaking one, confirm a
-     `migration.rst` entry with valid Before/After Rust.
-   - Argue every gap from both sides (for/against) per the subagent-policy audit rule.
-   - Return a concise table: change | documented? (changelog / migration) | verdict, plus a
-     list of undocumented changes. No raw file dumps.
+Confirm only the **release-specific** facts that `/doc` cannot infer on its own:
 
-Fix any gaps before moving on.
+1. **Top entry matches the target version.** `docs/guide/source/changelog.rst`'s top entry must
+   be `X.Y.Z (MuJoCo A.B.C)` for this exact release.
+2. **Major bump needs a `Migrating to X.Y.Z` section.** For a major bump, `migration.rst` must
+   have a `Migrating to X.Y.Z` section grouping this release's breaking changes.
+
+Fix any gaps here; the deep completeness audit itself runs inside `/doc` in Phase 3.
 
 ---
 
@@ -153,8 +137,9 @@ Run the existing gate skills. Each already sets `MUJOCO_DYNAMIC_LINK_DIR` /
 2. **`/test`** -- run the suite with `--features renderer` (and `--release` once). All green.
 3. **`/clippy`** -- lint clean (CI does not run clippy, so this gate is local-only).
 4. **`/doc`** -- rustdoc (`DOCS_RS=y ... --all-features`) and the Sphinx guide both clean,
-   plus the content-verification and RST-example-compile passes the doc skill defines. This
-   is where Phase 1/2 doc edits get validated.
+   plus the content-verification, RST-example-compile, and changelog/migration completeness
+   passes the doc skill defines. Pass the Phase 0 baseline tag so the completeness diff uses
+   the correct previous release. This is where the Phase 1/2 doc edits get validated.
 5. **FFI safety (recommended for major bumps / FFI version bumps): `/asan`, `/miri`, and the
    `/verify` audit.** A MuJoCo FFI bump changes the C ABI surface; run these to catch UB at
    the boundary. For a patch release with no `unsafe`/FFI changes they may be skipped -- say
@@ -234,8 +219,8 @@ The report must contain:
   one row per Phase 3 gate (build debug/release, test, clippy, doc, asan, miri, verify,
   cross-arch check). Skipped gates state the reason.
 - **Version-consistency table** (Phase 1): `Location | Current value | Expected value | Status`.
-- **Docs completeness** (Phase 2): changelog + migration present and complete? list any gaps as
-  cards.
+- **Docs completeness** (Phase 2 release-specific checks + `/doc` Part 5 audit): changelog +
+  migration present and complete? list any gaps as cards.
 - **Packaging** (Phase 4): `cargo package --list` clean? dry-run build result; any stray files.
 - A **"Manual maintainer steps"** section rendering the Phase 6 checklist with concrete values
   filled in (so the report is a complete hand-off artifact).

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -25,7 +25,7 @@ errors in macro invocations, unsafe code correctness, and potential undefined be
 - **No fixes during scouting or verification.** All code edits happen only in Phase 5 (Fix),
   after findings are fully evaluated. Do not edit source files in any earlier phase.
 
-## The nine concern groups
+## The ten concern groups
 
 ### A. Stride / dimension correctness (`info_method!` fields)
 - Each `info_method!` field stride vs `mjmodel.h` / `mjdata.h` dimension comment.
@@ -110,6 +110,34 @@ the check is applied iff it is needed:
 This group overlaps with `/safety` (a constrained-but-unchecked field is often an OOB-from-safe-code
 hole); here verify only the *presence and shape* of the check mechanism, not a full soundness proof.
 
+### J. Unreachable error / `Option` contracts (documented-but-impossible failure values)
+A wrapper method that documents returning `None`, `Err`, or a sentinel for a failure condition that
+the underlying C function makes **unreachable** -- because C calls `mju_error` (which aborts the
+process and never returns) or asserts on that condition instead of returning null / an error code.
+The documented failure value can then never be produced: the contract is a lie and the real
+behaviour is an abort, while the bound itself goes unchecked on the Rust side.
+
+For every method whose return type is `Option<T>` / `Result<T, E>` (or whose docs claim a
+`None`/`Err`/sentinel-on-failure case) that is backed by an FFI call, read the C function it calls
+and decide whether the documented failure path is actually reachable:
+
+- **Unreachable failure contract = BUG.** If the C function aborts via `mju_error` / `mju_error_v` /
+  `mju_error_raw` (or `assert`) on the documented failure condition and never returns the
+  null/sentinel, the `None`/`Err` arm is dead code and the doc is wrong (and the precondition is
+  effectively unchecked from safe Rust). The fix is to validate the precondition in Rust and either
+  panic, or use the panicking + `try_` fallible split per `coding-conventions.md`, since C provides
+  no recoverable signal. Quote the Rust return type + doc claim AND the exact C failure handling
+  (the line that calls `mju_error` vs returns null).
+- **Reachable failure contract = OK.** If the C function genuinely returns null / an error code for
+  that condition (e.g. `mj_loadXML` writing an error buffer, a getter that returns `nullptr` for a
+  missing element), the `Option`/`Result` is correct.
+
+The canonical example is `mjs_getWrap`, which calls `mju_error("Wrap index out of range...")`, so
+`MjsTendon::wrap`'s old `-> Option<&MjsWrap>` "returns `None` if out of bounds" doc was unreachable
+(fixed as T106). Look especially at `mjs_get*` / index-accessor wrappers and any wrapper returning
+`Option`/`Result` whose `None`/`Err` is documented for an out-of-range index or missing-by-name
+lookup.
+
 ## Methodology -- parallel multi-agent (drive with the `Workflow` tool)
 
 ### Phase 0 -- Inline recon (before launching Workflow)
@@ -133,9 +161,10 @@ One agent reads all source files and C headers and emits a structured, numbered 
 4. For every `info_method!`, `array_slice_dyn! { ... }` (basic form),
    `array_slice_dyn! { sublen_dep { ... } }`, `array_slice_dyn! { summed { ... } }`,
    `mj_model_dyn_range!`, unsafe block, enum dispatch, bounds check, Drop impl,
-   `unsafe impl Send/Sync`, and every value-writing `getter_setter!` / `vec_set!` field
-   (for group I) -- emit one numbered task entry with:
-   `{ id, category (A-I), description, rust_file, rust_lines, c_header }`
+   `unsafe impl Send/Sync`, every value-writing `getter_setter!` / `vec_set!` field
+   (for group I), and every FFI-backed method returning `Option`/`Result` or documenting a
+   `None`/`Err`-on-failure case (for group J) -- emit one numbered task entry with:
+   `{ id, category (A-J), description, rust_file, rust_lines, c_header }`
 
 The scout returns a JSON array of tasks. The total task count typically ranges from 150-400.
 
@@ -163,9 +192,12 @@ QUOTING RULE: Quote the actual code for every item. Examples:
   "error_buffer: [0i8; 100], mj_loadXML gets 100 -> OK"
   "MjsSensor::objtype setter: has { check_objtype } check; C indexes object_lists_[objtype] -> OK"
   "<field> setter: no { check }; C uses value as unguarded array index / unchecked discriminant -> BUG (group I)"
+  "MjsTendon::wrap -> Option: doc says None on OOB but mjs_getWrap calls mju_error (aborts) -> BUG (group J)"
 
 For group I, the reference is the C *usage* of the field value (how the C side consumes it), not a
-dimension comment. If you cannot find the Rust value, say UNCERTAIN.
+dimension comment. For group J, the reference is the C function's failure handling (does it return
+null/an error code, or call mju_error / assert and abort?). If you cannot find the Rust value, say
+UNCERTAIN.
 ```
 
 Each agent returns structured findings:
@@ -245,7 +277,7 @@ Concretely:
 
 The file must be self-contained (inline `<style>`), ASCII-only, and contain:
 
-- A header and a short **method note** describing the phases and the nine concern groups (A-I).
+- A header and a short **method note** describing the phases and the ten concern groups (A-J).
 - An **overview table** of all findings accumulated this chat:
   `ID | Severity (pill) | Category (badge) | One-line description | Location | Fix applied? | Status`
   If no findings exist, the table says "No bugs confirmed in this session."
@@ -259,7 +291,7 @@ Styling: use the same Claude aesthetic as `mujoco-rs-memory-safety-audit.html` -
 background, coral accent, warm near-black ink, Georgia serif headings, rounded pill badges, white
 finding cards on the canvas, and a hairline-border overview table. Severity pills
 (`sev-critical/high/medium/low/info`), status badges (`st-open` / `st-fixed` / `st-wont-fix`),
-category badges `cat-a` through `cat-i` each in a distinct hue.
+category badges `cat-a` through `cat-j` each in a distinct hue.
 
 Statuses:
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -198,6 +198,12 @@ update of MuJoCo alone can increase the major version.
   Users are expected to use
   :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>delete_element`
   instead.
+- Deprecated |mjs_tendon|'s ``try_wrap_site``, ``try_wrap_geom``, ``try_wrap_joint``, and
+  ``try_wrap_pulley`` --- their ``MjEditError::AllocationFailed`` arm is unreachable and an
+  allocation failure cannot be recovered soundly (MuJoCo aborts the process, or writes through the
+  null pointer before returning). Use the panicking ``wrap_site`` / ``wrap_geom`` / ``wrap_joint`` /
+  ``wrap_pulley`` instead. These methods may be undeprecated in the future if MuJoCo's upstream C++
+  code is changed to return null recoverably.
 
 .. rubric:: Error handling
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -182,6 +182,15 @@ update of MuJoCo alone can increase the major version.
   in a type that demands ``Sync``) will no longer compile; transfer ownership instead, as ``MjSpec``
   remains ``Send``.
 
+*MjsTendon::wrap / wrap_mut no longer return* ``Option``
+
+- |mjs_tendon|'s ``wrap`` and ``wrap_mut`` now return ``&MjsWrap`` / ``&mut MjsWrap`` (previously
+  ``Option<&MjsWrap>`` / ``Option<&mut MjsWrap>``) and panic if the index is out of bounds. The old
+  signature documented ``None`` on an out-of-range index, but the underlying C ``mjs_getWrap`` aborts
+  the process for such an index and never returns null, so the ``None`` arm was unreachable. Drop the
+  ``.unwrap()`` on existing calls and ensure the index is in range (``< wrap_num()``), or use the new
+  fallible ``try_wrap`` / ``try_wrap_mut``.
+
 .. rubric:: Deprecations
 
 - Deprecated :docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>delete`
@@ -219,6 +228,16 @@ New error variants in pre-existing enums:
   ``MjsNumeric::set_size`` (see Breaking changes).
 
 .. rubric:: New features and improvements
+
+*Fallible tendon wrap accessors*
+
+- Added :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTendon::<method>try_wrap` and
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTendon::<method>try_wrap_mut`, the fallible
+  counterparts of ``wrap`` / ``wrap_mut``. They return
+  ``Result<&MjsWrap, MjEditError>`` and yield ``MjEditError::IndexOutOfBounds`` for an out-of-range
+  index instead of panicking. A new
+  :docs-rs:`~mujoco_rs::error::<enum>MjEditError` ``IndexOutOfBounds`` variant carries the offending
+  index and length.
 
 *MjrContext GPU re-upload methods*
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -336,6 +336,11 @@ runtime.
 
 .. rubric:: Bug fixes
 
+- Fixed |mjs_tendon|'s ``wrap`` / ``wrap_mut``, which documented returning ``None`` for an
+  out-of-bounds index but could never do so: the underlying C ``mjs_getWrap`` aborts the process for
+  such an index and never returns null, so the ``None`` case was unreachable. The accessors now
+  reject an out-of-range index in Rust --- panicking, or returning ``MjEditError::IndexOutOfBounds``
+  via the new ``try_wrap`` / ``try_wrap_mut`` (see Breaking changes).
 - Fixed a model-editing potential undefined behavior in |mjs_body|, which occurred
   when yielded references of body's items were not destroyed before the next entry
   to the iterator. This was problematic if individual references of yielded items

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -89,6 +89,28 @@ compared to the previous implementation.
   unsafe { spec.delete_element(body_ptr).unwrap() }
 
 
+``MjsTendon::wrap`` / ``wrap_mut`` no longer return ``Option``
+--------------------------------------------------------------
+|mjs_tendon|'s ``wrap`` and ``wrap_mut`` now return ``&MjsWrap`` / ``&mut MjsWrap`` (previously
+``Option<&MjsWrap>`` / ``Option<&mut MjsWrap>``) and panic if the index is out of bounds. The old
+signature documented ``None`` on an out-of-range index, but the underlying C ``mjs_getWrap`` aborts
+the process for such an index and never returns null, so the ``None`` arm was unreachable. Drop the
+``.unwrap()`` on existing calls and ensure the index is in range (``< wrap_num()``), or use the new
+fallible ``try_wrap`` / ``try_wrap_mut``.
+
+**Before (4.x)**:
+
+.. code-block:: rust
+
+  let wrap = tendon.wrap(i).unwrap();
+
+**After (5.0.0)**:
+
+.. code-block:: rust
+
+  let wrap = tendon.wrap(i);
+
+
 Deprecated fallible tendon-wrap methods
 ---------------------------------------
 |mjs_tendon|'s ``try_wrap_site``, ``try_wrap_geom``, ``try_wrap_joint``, and ``try_wrap_pulley``

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -1616,6 +1616,30 @@ Callers must ensure the model and data remain alive and at a stable address.
     let viewer = unsafe { MjViewerCpp::launch_passive(&model, &data, 100) };
 
 
+``MjsTendon::wrap`` / ``wrap_mut`` no longer return ``Option``
+--------------------------------------------------------------
+
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTendon::<method>wrap` and
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTendon::<method>wrap_mut` now return
+``&MjsWrap`` / ``&mut MjsWrap`` instead of ``Option<&MjsWrap>`` / ``Option<&mut MjsWrap>``, and
+panic when the index is out of bounds. Drop the ``.unwrap()`` and make sure the index is
+``< wrap_num()``, or use the new fallible ``try_wrap`` / ``try_wrap_mut``.
+
+**Before:**
+
+.. code-block:: rust
+
+    let wrap = tendon.wrap(1).unwrap();
+
+**After:**
+
+.. code-block:: rust
+
+    let wrap = tendon.wrap(1);
+    // or, fallibly:
+    let wrap = tendon.try_wrap(1)?;
+
+
 Removed deprecated methods
 ----------------------------
 

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -89,6 +89,31 @@ compared to the previous implementation.
   unsafe { spec.delete_element(body_ptr).unwrap() }
 
 
+Deprecated fallible tendon-wrap methods
+---------------------------------------
+|mjs_tendon|'s ``try_wrap_site``, ``try_wrap_geom``, ``try_wrap_joint``, and ``try_wrap_pulley``
+are now deprecated. Their ``MjEditError::AllocationFailed`` arm is unreachable: on an allocation
+failure MuJoCo aborts the process (or, under a non-default error configuration, writes through the
+null pointer before returning), so the failure cannot be recovered soundly. Switch to the panicking
+``wrap_site`` / ``wrap_geom`` / ``wrap_joint`` / ``wrap_pulley``, which return ``&mut MjsWrap``
+directly.
+
+These methods may be undeprecated in the future if MuJoCo's upstream C++ code is changed to return
+null recoverably.
+
+**Before (4.x)**:
+
+.. code-block:: rust
+
+  let wrap = tendon.try_wrap_geom("geom", "sidesite")?;
+
+**After (5.0.0)**:
+
+.. code-block:: rust
+
+  let wrap = tendon.wrap_geom("geom", "sidesite");
+
+
 ``MjrContext::upload_texture`` parameter type changed
 -----------------------------------------------------
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -311,6 +311,13 @@ pub enum MjEditError {
     },
     /// Returned when the parameters to the given method/function are invalid.
     InvalidParameter(String),
+    /// The given index is out of range.
+    IndexOutOfBounds {
+        /// The index that was supplied.
+        id: usize,
+        /// Exclusive upper bound of the valid range.
+        len: usize,
+    },
 }
 
 impl fmt::Display for MjEditError {
@@ -331,6 +338,10 @@ impl fmt::Display for MjEditError {
                 required_size + 1
             ),
             Self::InvalidParameter(msg) => write!(f, "{msg}"),
+            Self::IndexOutOfBounds { id, len } => write!(
+                f,
+                "index {id} is out of bounds (length is {len})"
+            ),
         }
     }
 }

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -1674,16 +1674,50 @@ impl MjsTendon {
         unsafe { mjs_getWrapNum(self) as usize }
     }
 
-    /// Return an indexed wrap object. Returns `None` if index is out of bounds.
-    pub fn wrap(&self, i: usize) -> Option<&MjsWrap> {
-        let ptr = unsafe { mjs_getWrap(self, i as i32) };
-        unsafe { ptr.as_ref() }
+    /// Return an indexed wrap object.
+    ///
+    /// # Panics
+    /// Panics if `i >= wrap_num()`. Use [`MjsTendon::try_wrap`] for a fallible alternative.
+    pub fn wrap(&self, i: usize) -> &MjsWrap {
+        self.try_wrap(i).unwrap()
     }
 
-    /// Return a mutable indexed wrap object. Returns `None` if index is out of bounds.
-    pub fn wrap_mut(&mut self, i: usize) -> Option<&mut MjsWrap> {
+    /// Fallible version of [`MjsTendon::wrap`].
+    ///
+    /// # Errors
+    /// Returns [`MjEditError::IndexOutOfBounds`] if `i >= wrap_num()`.
+    pub fn try_wrap(&self, i: usize) -> Result<&MjsWrap, MjEditError> {
+        let len = self.wrap_num();
+        // mjs_getWrap aborts the process via mju_error for an out-of-range index, so the bound is
+        // checked here and turned into a recoverable error instead.
+        if i >= len {
+            return Err(MjEditError::IndexOutOfBounds { id: i, len });
+        }
         let ptr = unsafe { mjs_getWrap(self, i as i32) };
-        unsafe { ptr.as_mut() }
+        // SAFETY: index validated above; mjs_getWrap returns a non-null pointer for in-range indices.
+        Ok(unsafe { &*ptr })
+    }
+
+    /// Return a mutable indexed wrap object.
+    ///
+    /// # Panics
+    /// Panics if `i >= wrap_num()`. Use [`MjsTendon::try_wrap_mut`] for a fallible alternative.
+    pub fn wrap_mut(&mut self, i: usize) -> &mut MjsWrap {
+        self.try_wrap_mut(i).unwrap()
+    }
+
+    /// Fallible version of [`MjsTendon::wrap_mut`].
+    ///
+    /// # Errors
+    /// Returns [`MjEditError::IndexOutOfBounds`] if `i >= wrap_num()`.
+    pub fn try_wrap_mut(&mut self, i: usize) -> Result<&mut MjsWrap, MjEditError> {
+        let len = self.wrap_num();
+        if i >= len {
+            return Err(MjEditError::IndexOutOfBounds { id: i, len });
+        }
+        let ptr = unsafe { mjs_getWrap(self, i as i32) };
+        // SAFETY: see try_wrap().
+        Ok(unsafe { &mut *ptr })
     }
 }
 
@@ -2873,11 +2907,43 @@ mod tests {
 
         assert_eq!(tendon.wrap_num(), 3);
 
-        let wrap = tendon.wrap(1).unwrap();
+        let wrap = tendon.wrap(1);
         assert_eq!(wrap.coef(), 0.5);
 
-        let wrap_pulley = tendon.wrap(2).unwrap();
+        let wrap_pulley = tendon.wrap(2);
         assert_eq!(wrap_pulley.divisor(), 1.5);
+    }
+
+    #[test]
+    fn test_tendon_wrap_out_of_bounds() {
+        let mut spec = MjSpec::new();
+        spec.world_body_mut().add_site().with_name("site1");
+
+        let tendon = spec.add_tendon();
+        tendon.wrap_site("site1");
+        assert_eq!(tendon.wrap_num(), 1);
+
+        // Index 3 is out of range; the fallible accessor reports it rather than aborting in C.
+        match tendon.try_wrap(3) {
+            Err(MjEditError::IndexOutOfBounds { id, len }) => {
+                assert_eq!(id, 3);
+                assert_eq!(len, 1);
+            }
+            _ => panic!("expected IndexOutOfBounds"),
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_tendon_wrap_out_of_bounds_panics() {
+        let mut spec = MjSpec::new();
+        spec.world_body_mut().add_site().with_name("site1");
+
+        let tendon = spec.add_tendon();
+        tendon.wrap_site("site1");
+
+        // The panicking accessor must panic in Rust, not abort the process in C.
+        let _ = tendon.wrap(3);
     }
 
     #[test]

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -1577,14 +1577,26 @@ impl MjsTendon {
     /// Wrap a site corresponding to `name`, using the tendon.
     ///
     /// # Panics
-    /// - When the `name` contains '\0' characters, a panic occurs.
-    /// - When MuJoCo fails to allocate the wrap element.
-    ///   Use [`MjsTendon::try_wrap_site`] for a fallible alternative.
+    /// When the `name` contains '\0' characters.
+    #[allow(deprecated)]
     pub fn wrap_site(&mut self, name: &str) -> &mut MjsWrap {
         self.try_wrap_site(name).expect("failed to wrap site")
     }
 
     /// Fallible version of [`MjsTendon::wrap_site`].
+    ///
+    /// # Note
+    ///
+    /// <div class="warning">
+    ///
+    /// By default, MuJoCo aborts the process on an allocation failure instead of
+    /// returning null. Under a non-default error configuration MuJoCo writes
+    /// through the null pointer on allocation failure before returning, so the
+    /// failure cannot be recovered soundly. Prefer the panicking
+    /// [`MjsTendon::wrap_site`]. This method may be undeprecated in the future
+    /// if MuJoCo's upstream C++ code is changed to return null recoverably.
+    ///
+    /// </div>
     ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] if MuJoCo returns a null
@@ -1592,6 +1604,10 @@ impl MjsTendon {
     ///
     /// # Panics
     /// When the `name` contains '\0' characters.
+    #[deprecated(
+        since = "5.0.0",
+        note = "allocation failure cannot be recovered soundly; use `wrap_site`"
+    )]
     pub fn try_wrap_site(&mut self, name: &str) -> Result<&mut MjsWrap, MjEditError> {
         let cname = CString::new(name).unwrap();
         let wrap_ptr = unsafe { mjs_wrapSite(self, cname.as_ptr()) };
@@ -1601,14 +1617,26 @@ impl MjsTendon {
     /// Wrap a geom corresponding to `name`, using the tendon.
     ///
     /// # Panics
-    /// - When the `name` or `sidesite` contain '\0' characters, a panic occurs.
-    /// - When MuJoCo fails to allocate the wrap element.
-    ///   Use [`MjsTendon::try_wrap_geom`] for a fallible alternative.
+    /// When `name` or `sidesite` contain '\0' characters.
+    #[allow(deprecated)]
     pub fn wrap_geom(&mut self, name: &str, sidesite: &str) -> &mut MjsWrap {
         self.try_wrap_geom(name, sidesite).expect("failed to wrap geom")
     }
 
     /// Fallible version of [`MjsTendon::wrap_geom`].
+    ///
+    /// # Note
+    ///
+    /// <div class="warning">
+    ///
+    /// By default, MuJoCo aborts the process on an allocation failure instead of
+    /// returning null. Under a non-default error configuration MuJoCo writes
+    /// through the null pointer on allocation failure before returning, so the
+    /// failure cannot be recovered soundly. Prefer the panicking
+    /// [`MjsTendon::wrap_geom`]. This method may be undeprecated in the future
+    /// if MuJoCo's upstream C++ code is changed to return null recoverably.
+    ///
+    /// </div>
     ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] if MuJoCo returns a null
@@ -1616,6 +1644,10 @@ impl MjsTendon {
     ///
     /// # Panics
     /// When `name` or `sidesite` contain '\0' characters.
+    #[deprecated(
+        since = "5.0.0",
+        note = "allocation failure cannot be recovered soundly; use `wrap_geom`"
+    )]
     pub fn try_wrap_geom(&mut self, name: &str, sidesite: &str) -> Result<&mut MjsWrap, MjEditError> {
         let cname = CString::new(name).unwrap();
         let csidesite = CString::new(sidesite).unwrap();
@@ -1629,14 +1661,26 @@ impl MjsTendon {
     /// Wrap a joint corresponding to `name`, using the tendon.
     ///
     /// # Panics
-    /// - When the `name` contains '\0' characters, a panic occurs.
-    /// - When MuJoCo fails to allocate the wrap element.
-    ///   Use [`MjsTendon::try_wrap_joint`] for a fallible alternative.
+    /// When `name` contains '\0' characters.
+    #[allow(deprecated)]
     pub fn wrap_joint(&mut self, name: &str, coef: f64) -> &mut MjsWrap {
         self.try_wrap_joint(name, coef).expect("failed to wrap joint")
     }
 
     /// Fallible version of [`MjsTendon::wrap_joint`].
+    ///
+    /// # Note
+    ///
+    /// <div class="warning">
+    ///
+    /// By default, MuJoCo aborts the process on an allocation failure instead of
+    /// returning null. Under a non-default error configuration MuJoCo writes
+    /// through the null pointer on allocation failure before returning, so the
+    /// failure cannot be recovered soundly. Prefer the panicking
+    /// [`MjsTendon::wrap_joint`]. This method may be undeprecated in the future
+    /// if MuJoCo's upstream C++ code is changed to return null recoverably.
+    ///
+    /// </div>
     ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] if MuJoCo returns a null
@@ -1644,6 +1688,10 @@ impl MjsTendon {
     ///
     /// # Panics
     /// When `name` contains '\0' characters.
+    #[deprecated(
+        since = "5.0.0",
+        note = "allocation failure cannot be recovered soundly; use `wrap_joint`"
+    )]
     pub fn try_wrap_joint(&mut self, name: &str, coef: f64) -> Result<&mut MjsWrap, MjEditError> {
         let cname = CString::new(name).unwrap();
         let wrap_ptr = unsafe { mjs_wrapJoint(self, cname.as_ptr(), coef) };
@@ -1651,19 +1699,33 @@ impl MjsTendon {
     }
 
     /// Wrap a pulley using the tendon.
-    ///
-    /// # Panics
-    /// When MuJoCo fails to allocate the wrap element.
-    /// Use [`MjsTendon::try_wrap_pulley`] for a fallible alternative.
+    #[allow(deprecated)]
     pub fn wrap_pulley(&mut self, divisor: f64) -> &mut MjsWrap {
         self.try_wrap_pulley(divisor).expect("failed to wrap pulley")
     }
 
     /// Fallible version of [`MjsTendon::wrap_pulley`].
     ///
+    /// # Note
+    ///
+    /// <div class="warning">
+    ///
+    /// By default, MuJoCo aborts the process on an allocation failure instead of
+    /// returning null. Under a non-default error configuration MuJoCo writes
+    /// through the null pointer on allocation failure before returning, so the
+    /// failure cannot be recovered soundly. Prefer the panicking
+    /// [`MjsTendon::wrap_pulley`]. This method may be undeprecated in the future
+    /// if MuJoCo's upstream C++ code is changed to return null recoverably.
+    ///
+    /// </div>
+    ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] if MuJoCo returns a null
     /// pointer.
+    #[deprecated(
+        since = "5.0.0",
+        note = "allocation failure cannot be recovered soundly; use `wrap_pulley`"
+    )]
     pub fn try_wrap_pulley(&mut self, divisor: f64) -> Result<&mut MjsWrap, MjEditError> {
         let wrap_ptr = unsafe { mjs_wrapPulley(self, divisor) };
         unsafe { wrap_ptr.as_mut() }.ok_or(MjEditError::AllocationFailed)


### PR DESCRIPTION
Deprecates tendon wrapping having non-reachable failures. The C++ implementation of the model editing parts of MuJoCo uses a lot of the `new` operator. By default, it is configured to just throw exceptions, thus allocation failures never return NULL. Even if MuJoCo is configured to do so, it would lead to writes to null pointers as MuJoCo's code assumes exceptions are thrown and don't do any checking directly (at some parts).