### PR TITLE
Fix clippy warnings and fix PyO3 example security

### DIFF
--- a/examples/standalone/pyo3_application/Cargo.toml
+++ b/examples/standalone/pyo3_application/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2024"
 [lib]
 crate-type = ["cdylib"]
 
+[workspace]
 
 [dependencies]
-mujoco-rs = {path = "../../", features = ["viewer-ui"]}
+mujoco-rs = {path = "../../../", features = ["viewer-ui"]}
 pyo3 = { version = "0.29.0", features = ["abi3-py39", "extension-module"] }

--- a/examples/standalone/pyo3_application/Cargo.toml
+++ b/examples/standalone/pyo3_application/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 mujoco-rs = {path = "../../", features = ["viewer-ui"]}
-pyo3 = { version = "0.28.2", features = ["abi3", "extension-module"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py39", "extension-module"] }

--- a/examples/standalone/pyo3_application/pyproject.toml
+++ b/examples/standalone/pyo3_application/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pyo3_application"
 version = "0.1.0"
 description = "A Python extension, written in Rust."
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [tool.maturin]
 # Optionally enable manylinux compatibility (example here shows GLIBC version 2.31)

--- a/src/cpp_viewer.rs
+++ b/src/cpp_viewer.rs
@@ -81,7 +81,7 @@ impl MjViewerCpp {
     pub unsafe fn launch_passive<M: Deref<Target = MjModel> + Clone + Send + Sync>(model: M, data: &MjData<M>, max_user_geom: usize) -> Self {
         // Allocate on the heap as the data must not be moved due to C++ bindings
         let mut cam = Box::new(MjvCamera::default());
-        let mut opt: Box<MjvOption> = Box::new(MjvOption::default());
+        let mut opt = Box::new(MjvOption::default());
         let mut pert = Box::new(MjvPerturb::default());
         let mut user_scn = Box::new(MjvScene::new(model.clone(), max_user_geom));
 

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -1948,7 +1948,7 @@ impl MjViewerBuilder {
 
         // User interface
         #[cfg(feature = "viewer-ui")]
-        let ui = ui::ViewerUI::new(&*model, window, &gl_surface.display())?;
+        let ui = ui::ViewerUI::new(&model, window, &gl_surface.display())?;
         #[cfg(feature = "viewer-ui")]
         let mut status = ViewerStatusBit::UI;
         #[cfg(not(feature = "viewer-ui"))]

--- a/src/viewer/ui.rs
+++ b/src/viewer/ui.rs
@@ -680,9 +680,9 @@ impl ViewerUI {
                                 ui.horizontal_wrapped(|ui| {
                                     for i in 0..mjNGROUP as usize {
                                         let mask = 1 << i;
-                                        let mut is_enabled = (options.disableactuator & (mask as i32)) == 0;
+                                        let mut is_enabled = (options.disableactuator & mask) == 0;
                                         if ui.toggle_value(&mut is_enabled, format!("Act Group {i}")).changed() {
-                                            set_flag!(options.disableactuator, mask as i32, !is_enabled);
+                                            set_flag!(options.disableactuator, mask, !is_enabled);
                                         }
                                     }
                                 });


### PR DESCRIPTION
Fixes some Clippy warnings inside the crate, as well as upgrades the Python bindings example to use PyO3 with latest security patches. 