### PR TITLE
MuJoCo 3.12 raw bindings and some wrappers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ unnecessary_lazy_evaluations = "allow"
 
 [package]
 name = "mujoco-rs"
-version = "6.0.0+mj-3.11.0"
+version = "6.0.0+mj-3.12.0"
 edition = "2024"
 license.workspace = true
 description = "A high-level Rust wrapper around the MuJoCo C library, with a native viewer (re-)written in Rust."

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/v/mujoco-rs.svg)](https://crates.io/crates/mujoco-rs)
 
 > [!IMPORTANT]
-> **Upgrading from 5.x to 6.0.0?** This release updates MuJoCo to 3.11.0.
+> **Upgrading from 5.x to 6.0.0?** This release updates MuJoCo to 3.12.0.
 > Read the [migration guide](https://mujoco-rs.readthedocs.io/en/v6.0.x/migration.html)
 > before upgrading.
 
@@ -20,7 +20,7 @@ More detailed documentation is available at the:
 - [**Guide book**](https://mujoco-rs.readthedocs.io/en/v6.0.x/)
 
 ## MuJoCo version
-This library uses FFI bindings to MuJoCo **3.11.0**.
+This library uses FFI bindings to MuJoCo **3.12.0**.
 
 ## Minimum Rust version
 Rust version 1.88 or newer is required.

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -35,24 +35,25 @@ update of MuJoCo alone can increase the major version.
   .. rubric:: Bug fixes
   .. rubric:: Other changes
 
-6.0.0 (MuJoCo 3.11.0)
+6.0.0 (MuJoCo 3.12.0)
 ======================
 
 .. rubric:: Breaking changes
 
-*MuJoCo FFI upgraded to 3.11.0*
+*MuJoCo FFI upgraded to 3.12.0*
 
-- MuJoCo-rs now builds against MuJoCo 3.11.0 FFI. This is a breaking
-  dependency-level change for consumers tied to older MuJoCo C ABI details.
+- MuJoCo-rs now builds against MuJoCo 3.12.0 FFI, which rolls up the upstream 3.10.0,
+  3.11.0 and 3.12.0 releases. This is a breaking dependency-level change for consumers
+  tied to older MuJoCo C ABI details.
   See MuJoCo's changelog for this release:
-  https://mujoco.readthedocs.io/en/3.11.0/changelog.html
+  https://mujoco.readthedocs.io/en/3.12.0/changelog.html
 
-*Removed the* |mj_data| ``qM`` *accessor*
+*Removed the* |mj_data| ``q_m`` *accessor*
 
 - MuJoCo 3.11.0 removed the legacy sparse ancestor-walk inertia matrix ``mjData.qM``; the
   joint-space inertia matrix is now stored exclusively in the compressed sparse row (CSR)
-  format ``mjData.M``. The |mj_data| ``qM()``/``qM_mut()`` accessors were removed; use
-  ``M()`` (with the |mj_model| ``M_rownnz``/``M_rowadr``/``M_colind`` index arrays) or
+  format ``mjData.M``. The |mj_data| ``q_m()``/``q_m_mut()`` accessors were removed; use
+  ``m()`` (with the |mj_model| ``m_rownnz``/``m_rowadr``/``m_colind`` index arrays) or
   :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>full_m` for a dense copy.
 
 *``MjvCamera::move_`` no longer takes a scene*
@@ -60,55 +61,24 @@ update of MuJoCo alone can increase the major version.
 - |mjv_camera| ``move_`` lost its ``scene: &MjvScene`` parameter, following the upstream
   removal of the unneeded ``mjvScene`` argument from ``mjv_moveCamera``.
 
-*Raw FFI enum types renamed*
+*Shifted actuator enum discriminants*
 
-- The raw FFI enums from ``mjtype.h`` and ``mjui.h`` in ``mujoco_c`` are now emitted
-  without the trailing underscore (e.g. ``mjtObj_`` is now ``mjtObj``, ``mjtState_`` is now
-  ``mjtState``, ``mjtButton_`` is now ``mjtButton``). The un-suffixed names, which previously
-  existed as aliases, remain valid; only code that referenced the underscored names breaks.
-  The visualization, renderer and plugin enums (``mjtCatBit``, ``mjtMouse``, ``mjtCamera``,
-  ``mjtGridPos``, ``mjtPluginCapabilityBit``, etc.) keep their underscored definitions plus
-  aliases, and the wrapper-level ``MjtX`` aliases are unaffected.
-
-*Shifted ``MjtGain``/``MjtBias`` discriminants and a new ``MjtTrn`` variant*
-
-- ``MjtGain`` and ``MjtBias`` gained the ``mjGAIN_SO3``/``mjBIAS_SO3`` variants, shifting
-  the values of ``mjGAIN_USER`` and ``mjBIAS_USER`` from 4 to 5.
-- ``MjtTrn`` gained ``mjTRN_SO3`` (value 6) for the new so3 transmission. The existing values
-  are unchanged, but an exhaustive ``match`` on ``MjtTrn`` no longer compiles.
+- ``MjtGain``, ``MjtBias``, ``MjtDyn`` and ``MjtTrn`` gained new variants, so an exhaustive
+  ``match`` on any of them no longer compiles. The raw value of ``mjGAIN_USER`` moved from 4 to 6,
+  ``mjBIAS_USER`` from 4 to 5 and ``mjDYN_USER`` from 6 to 7.
 
 *Removed and renamed* |mj_data| *accessors*
 
-- The |mj_data| accessor ``efc_diagApprox`` was renamed to ``efc_diagA``,
+- The |mj_data| accessor ``efc_diag_approx`` was renamed to ``efc_diag_a``,
   following the upstream field rename (it can now hold either the exact or
   approximate diagonal of the :math:`A` matrix).
-- Removed the island-specific inertia accessors ``iM_rownnz``, ``iM_rowadr``,
-  ``iM_colind``, ``iM``, ``iLD``, ``iLDiagInv``, and the island Jacobian
-  accessors ``iefc_J_rownnz``, ``iefc_J_rowadr``, ``iefc_J_rowsuper``,
-  ``iefc_J_colind``, ``iefc_J``. Upstream moved these matrices off the arena
+- Removed the island-specific inertia accessors ``i_m_rownnz``, ``i_m_rowadr``,
+  ``i_m_colind``, ``i_m``, ``i_ld``, ``i_ldiag_inv``, and the island Jacobian
+  accessors ``iefc_j_rownnz``, ``iefc_j_rowadr``, ``iefc_j_rowsuper``,
+  ``iefc_j_colind``, ``iefc_j``. Upstream moved these matrices off the arena
   onto the stack, so they are no longer reachable as ``mjData`` fields.
 - Removed the ``maxuse_threadstack`` accessor; the old per-thread stack
   statistic was removed together with the legacy engine threading API.
-
-*Removed the legacy engine threading raw FFI*
-
-- Following the upstream removal of ``mjthread.h``, the raw FFI types
-  ``mjThreadPool``, ``mjTask``, ``mjtTaskStatus`` and ``mjfTask``, the constant
-  ``mjMAXTHREAD`` and the functions ``mju_threadPoolCreate``, ``mju_bindThreadPool``,
-  ``mju_threadPoolEnqueue``, ``mju_threadPoolDestroy``, ``mju_defaultTask`` and
-  ``mju_taskJoin`` no longer exist in ``mujoco_c``. Use |mj_data|
-  ``set_threadpool`` (wrapping ``mju_threadpool``) instead.
-
-*Removed and changed raw FFI functions*
-
-- ``mju_error_i``, ``mju_error_s``, ``mju_warning_i`` and ``mju_warning_s``
-  were removed upstream in MuJoCo 3.10.0, superseded by the unified logging API.
-- The raw ``mj_fullM`` signature changed from ``mj_fullM(m, dst, M)`` to
-  ``mj_fullM(m, d, dst)`` as part of the upstream ``mjData.qM`` removal.
-- ``mj_encode`` and the ``mjfEncode`` plugin callback now return ``mjtSize``
-  instead of ``c_int``, and ``mjpResourceProvider`` gained a ``write`` callback
-  field (``mjfWriteResource``) for resource writing, which breaks struct-literal
-  construction of the provider.
 
 *MIMO-aware actuator dimensions*
 
@@ -124,23 +94,29 @@ update of MuJoCo alone can increase the major version.
   dynamic ranges based on ``actuator_ctrladr``/``actuator_ctrlnum`` and
   ``actuator_outadr``/``actuator_outnum``. For single-input single-output actuators
   ``nactuator == nu == nout`` and behavior is unchanged.
-- |mj_data| ``read_ctrl``/``try_read_ctrl`` now take an actuator index bounded by ``nactuator``
-  (previously a control index bounded by ``nu``), because the control history is stored per
-  actuator.
+- |mj_data| ``read_ctrl``/``try_read_ctrl`` and ``init_ctrl_history`` now take an actuator index
+  bounded by ``nactuator`` (previously a control index bounded by ``nu``), because the control
+  history is stored per actuator.
 
 *Stricter* |mjr_context| *accessor types*
 
-- ``glInitialized``, ``windowAvailable``, ``windowStereo`` and ``windowDoublebuffer`` now read as
-  ``bool`` instead of ``i32``; MuJoCo stores only 0 or 1 in them.
-- ``fontScale`` and ``readDepthMap`` now read as ``MjtFontScale`` and ``MjtDepthMap`` instead of
-  ``i32``; MuJoCo stores only declared enum variants in them.
+- ``gl_initialized``, ``window_available``, ``window_stereo`` and ``window_doublebuffer`` now
+  read as ``bool`` instead of ``i32``; MuJoCo stores only 0 or 1 in them.
+- ``font_scale`` and ``read_depth_map`` now read as ``MjtFontScale`` and ``MjtDepthMap`` instead
+  of ``i32``; MuJoCo stores only declared enum variants in them.
 
 *Mutable access to* |mj_model| ``actuator_gaintype`` *and* ``actuator_ctrlspec``
 
 - Both fields now need ``unsafe`` to mutate, and moved to the read-only actuator view. MuJoCo
-  3.12.0 added ``mjGAIN_SO3``, which writes three output elements without consulting
+  3.11.0 added ``mjGAIN_SO3``, which writes three output elements without consulting
   ``actuator_outnum``, while ``ctrlspec`` selects how many ``ctrl`` elements the engine reads, so
   a safe write to either can overrun an array.
+
+*Renamed* ``DcMotorConfig`` *input field*
+
+- The public field ``DcMotorConfig::input_mode`` is now ``ctrlspec`` and the builder
+  ``with_input_mode`` is now ``with_ctrlspec``, following the renamed C field. The value is now
+  a bitmask of ``MjtCtrlInput`` values instead of a single mode selector.
 
 .. rubric:: New features and improvements
 
@@ -156,9 +132,9 @@ update of MuJoCo alone can increase the major version.
     MIMO actuator layout (the actuator views gained matching fields).
   - ``nactuator`` :sup:`new`, ``nout`` :sup:`new`, ``npolygonmax`` :sup:`new` and
     ``nmeshdegmax`` :sup:`new` size accessors.
-  - ``nefm0dof`` :sup:`new` and ``nefm0L`` :sup:`new` size accessors, and the
-    ``efm0_dofid`` :sup:`new`, ``efm0_L_rownnz`` :sup:`new`, ``efm0_L_rowadr`` :sup:`new`,
-    ``efm0_L_colind`` :sup:`new` and ``efm0_L`` :sup:`new` array accessors for the constant
+  - ``nefm0dof`` :sup:`new` and ``nefm0_l`` :sup:`new` size accessors, and the
+    ``efm0_dofid`` :sup:`new`, ``efm0_l_rownnz`` :sup:`new`, ``efm0_l_rowadr`` :sup:`new`,
+    ``efm0_l_colind`` :sup:`new` and ``efm0_l`` :sup:`new` array accessors for the constant
     part of the implicit effective-metric factorization (matching the |mj_data| ``efm_*``
     accessors).
   - ``flg_gravcomp`` :sup:`new`, ``flg_surfacevel`` :sup:`new` and ``flg_adhesion`` :sup:`new`
@@ -168,10 +144,10 @@ update of MuJoCo alone can increase the major version.
 
   - ``qfrc_adhesion`` :sup:`new` (passive contact adhesion force; also available in the joint
     views) and ``flexelem_krot`` :sup:`new` array accessors.
-  - ``efm_c`` :sup:`new`, ``efm_K_rownnz`` :sup:`new`, ``efm_K_rowadr`` :sup:`new`,
-    ``efm_K_colind`` :sup:`new`, ``efm_K_val`` :sup:`new`, ``efm_dofid`` :sup:`new` and
-    ``efm_L`` :sup:`new` array accessors, plus the ``efm_active`` :sup:`new`, ``nefmK`` :sup:`new`,
-    ``nefmdof`` :sup:`new` and ``nefmL`` :sup:`new` scalar accessors, exposing the implicit
+  - ``efm_c`` :sup:`new`, ``efm_k_rownnz`` :sup:`new`, ``efm_k_rowadr`` :sup:`new`,
+    ``efm_k_colind`` :sup:`new`, ``efm_k_val`` :sup:`new`, ``efm_dofid`` :sup:`new` and
+    ``efm_l`` :sup:`new` array accessors, plus the ``efm_active`` :sup:`new`, ``nefm_k`` :sup:`new`,
+    ``nefmdof`` :sup:`new` and ``nefm_l`` :sup:`new` scalar accessors, exposing the implicit
     effective-metric (M+K) solver state.
 
 - Model-editing (``MjSpec``) accessors: ``MjsBody::simple()`` :sup:`new`,
@@ -181,9 +157,6 @@ update of MuJoCo alone can increase the major version.
   field, so it has ``surfacevel_mut()``/``with_surfacevel()`` instead of ``set_surfacevel()``).
 - Added ``MjtCtrlChart`` :sup:`new` as an alias for the new ``mjtCtrlChart`` enum
   (values of ``m->actuator_ctrlspec``).
-- The raw FFI structs ``mjContact`` and ``mjvGeom`` gained the public fields
-  ``adhesion`` and ``texid``/``texuniform``/``texrepeat`` respectively,
-  following the upstream struct changes.
 
 *New accessors for 3.10.0 structs*
 
@@ -253,10 +226,25 @@ update of MuJoCo alone can increase the major version.
   matching ``softness`` and ``extrema`` fields in the light and mesh info views.
 - |mjs_light|: ``softness`` :sup:`new`.
 - |mjs_actuator|: ``velrange`` :sup:`new` and ``ffrange`` :sup:`new`.
+- Added ``MjtCtrlInput`` :sup:`new` as an alias for the new ``mjtCtrlInput`` enum, whose values
+  are OR-ed into ``m->actuator_ctrlspec`` to select the inputs of a servo-family actuator.
+
+*New servo actuator constructors*
+
+- |mjs_actuator|:
+
+  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator::<method>set_to_pid` :sup:`new`,
+    wrapping ``mjs_setToPID``, makes the actuator a PID controller on a single force output. The
+    controller is configured through the new
+    :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>PidConfig` :sup:`new` builder.
+  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator::<method>set_to_orientation`
+    :sup:`new`, wrapping ``mjs_setToOrientation``, makes the actuator a geodesic PD orientation
+    servo on a ball joint or a site. It is configured through the new
+    :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>OrientationConfig` :sup:`new` builder.
 
 *Relaxed mutability on fields that cannot cause a memory fault*
 
-- Mutating |mj_model| ``paths`` and |mjr_context| ``textureType`` no longer needs ``unsafe``,
+- Mutating |mj_model| ``paths`` and |mjr_context| ``texture_type`` no longer needs ``unsafe``,
   because a write can at worst give wrong rendering, never a memory fault.
 - |mj_data| ``body_awake`` moved into the mutable body view, which matches its array accessor.
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -16,6 +16,8 @@ Changelog
 .. |mjs_wrap| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsWrap`
 .. |mjv_camera| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_visualization::<type>MjvCamera`
 .. |mjr_context| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext`
+.. |mjs_light| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsLight`
+.. |mjs_actuator| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator`
 
 
 Versioning
@@ -126,6 +128,20 @@ update of MuJoCo alone can increase the major version.
   (previously a control index bounded by ``nu``), because the control history is stored per
   actuator.
 
+*Stricter* |mjr_context| *accessor types*
+
+- ``glInitialized``, ``windowAvailable``, ``windowStereo`` and ``windowDoublebuffer`` now read as
+  ``bool`` instead of ``i32``; MuJoCo stores only 0 or 1 in them.
+- ``fontScale`` and ``readDepthMap`` now read as ``MjtFontScale`` and ``MjtDepthMap`` instead of
+  ``i32``; MuJoCo stores only declared enum variants in them.
+
+*Mutable access to* |mj_model| ``actuator_gaintype`` *and* ``actuator_ctrlspec``
+
+- Both fields now need ``unsafe`` to mutate, and moved to the read-only actuator view. MuJoCo
+  3.12.0 added ``mjGAIN_SO3``, which writes three output elements without consulting
+  ``actuator_outnum``, while ``ctrlspec`` selects how many ``ctrl`` elements the engine reads, so
+  a safe write to either can overrun an array.
+
 .. rubric:: New features and improvements
 
 *New accessors for 3.11.0 fields*
@@ -153,8 +169,7 @@ update of MuJoCo alone can increase the major version.
   - ``qfrc_adhesion`` :sup:`new` (passive contact adhesion force; also available in the joint
     views) and ``flexelem_krot`` :sup:`new` array accessors.
   - ``efm_c`` :sup:`new`, ``efm_K_rownnz`` :sup:`new`, ``efm_K_rowadr`` :sup:`new`,
-    ``efm_K_colind`` :sup:`new`, ``efm_K_val`` :sup:`new`, ``efm_dofid`` :sup:`new`,
-    ``efm_L_rownnz`` :sup:`new`, ``efm_L_rowadr`` :sup:`new`, ``efm_L_colind`` :sup:`new` and
+    ``efm_K_colind`` :sup:`new`, ``efm_K_val`` :sup:`new`, ``efm_dofid`` :sup:`new` and
     ``efm_L`` :sup:`new` array accessors, plus the ``efm_active`` :sup:`new`, ``nefmK`` :sup:`new`,
     ``nefmdof`` :sup:`new` and ``nefmL`` :sup:`new` scalar accessors, exposing the implicit
     effective-metric (M+K) solver state.
@@ -231,6 +246,19 @@ update of MuJoCo alone can increase the major version.
 
 - Added ``MjrCamera`` :sup:`new` as a type alias for ``MjvGLCamera``, matching MuJoCo's own
   ``mjrCamera`` alias convention.
+
+*New accessors for 3.12.0 fields*
+
+- |mj_model|: ``light_softness`` :sup:`new` and ``mesh_extrema`` :sup:`new` array accessors, with
+  matching ``softness`` and ``extrema`` fields in the light and mesh info views.
+- |mjs_light|: ``softness`` :sup:`new`.
+- |mjs_actuator|: ``velrange`` :sup:`new` and ``ffrange`` :sup:`new`.
+
+*Relaxed mutability on fields that cannot cause a memory fault*
+
+- Mutating |mj_model| ``paths`` and |mjr_context| ``textureType`` no longer needs ``unsafe``,
+  because a write can at worst give wrong rendering, never a memory fault.
+- |mj_data| ``body_awake`` moved into the mutable body view, which matches its array accessor.
 
 .. rubric:: Other changes
 

--- a/docs/guide/source/installation.rst
+++ b/docs/guide/source/installation.rst
@@ -4,7 +4,7 @@
 Installation
 =============================
 
-.. _mj_download: https://github.com/google-deepmind/mujoco/releases/tag/3.11.0
+.. _mj_download: https://github.com/google-deepmind/mujoco/releases/tag/3.12.0
 
 
 MuJoCo-rs

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -24,7 +24,7 @@ For a full list of changes, see the :ref:`changelog`.
 Migrating to 6.0.0
 ======================
 
-Version 6.0.0 updates MuJoCo to 3.11.0, which removed and renamed several
+Version 6.0.0 updates MuJoCo to 3.12.0, which removed and renamed several
 |mj_data| fields, reworked the actuator dimensions for MIMO actuators, and
 changed a few visualization and model signatures.
 
@@ -32,27 +32,27 @@ changed a few visualization and model signatures.
 MuJoCo upgrade
 -----------------------
 
-This release links against MuJoCo **3.11.0**. Download the matching release and
+This release links against MuJoCo **3.12.0**. Download the matching release and
 update your library path. See :ref:`installation` for details.
 
 
-Removed ``MjData::qM`` accessor
--------------------------------
+Removed ``MjData::q_m`` accessor
+---------------------------------
 MuJoCo removed the legacy sparse ``mjData.qM`` inertia matrix; the joint-space inertia matrix
-is now stored exclusively in the CSR format ``mjData.M``. Use the ``M`` accessor together with
-the |mj_model| ``M_rownnz``/``M_rowadr``/``M_colind`` index arrays, or ``full_m`` for a dense copy.
+is now stored exclusively in the CSR format ``mjData.M``. Use the ``m`` accessor together with
+the |mj_model| ``m_rownnz``/``m_rowadr``/``m_colind`` index arrays, or ``full_m`` for a dense copy.
 
 **Before:**
 
 .. code-block:: rust
 
-    let inertia = data.qM();
+    let inertia = data.q_m();
 
 **After:**
 
 .. code-block:: rust
 
-    let inertia = data.M();  // CSR values; indices in model.M_rownnz()/M_rowadr()/M_colind()
+    let inertia = data.m();  // CSR values; indices in model.m_rownnz()/m_rowadr()/m_colind()
 
     // or, for a dense nv x nv matrix:
     let nv = model.nv() as usize;
@@ -78,8 +78,8 @@ parameter was dropped from |mjv_camera| ``move_``.
     camera.move_(MjtMouse::mjMOUSE_ZOOM, &model, 0.0, -1.0);
 
 
-``MjData::efc_diagApprox`` renamed to ``efc_diagA``
----------------------------------------------------
+``MjData::efc_diag_approx`` renamed to ``efc_diag_a``
+------------------------------------------------------
 MuJoCo renamed the ``efc_diagApprox`` field to ``efc_diagA``, since it can now hold either
 the exact or the approximate diagonal of the :math:`A` matrix. The |mj_data| accessor was
 renamed to match.
@@ -88,22 +88,22 @@ renamed to match.
 
 .. code-block:: rust
 
-    let diag = data.efc_diagApprox();
+    let diag = data.efc_diag_approx();
 
 **After:**
 
 .. code-block:: rust
 
-    let diag = data.efc_diagA();
+    let diag = data.efc_diag_a();
 
 
 Removed island matrix |mj_data| accessors
 -----------------------------------------
 MuJoCo moved the island-specific inertia and Jacobian matrices off the arena onto the stack,
 so they are no longer exposed as ``mjData`` fields. The following |mj_data| accessors were
-removed with no replacement: ``iM_rownnz``, ``iM_rowadr``, ``iM_colind``, ``iM``, ``iLD``,
-``iLDiagInv``, ``iefc_J_rownnz``, ``iefc_J_rowadr``, ``iefc_J_rowsuper``, ``iefc_J_colind``,
-and ``iefc_J``.
+removed with no replacement: ``i_m_rownnz``, ``i_m_rowadr``, ``i_m_colind``, ``i_m``, ``i_ld``,
+``i_ldiag_inv``, ``iefc_j_rownnz``, ``iefc_j_rowadr``, ``iefc_j_rowsuper``, ``iefc_j_colind``,
+and ``iefc_j``.
 
 
 Removed ``MjData::maxuse_threadstack`` accessor
@@ -151,15 +151,102 @@ views to dynamic ranges based on ``actuator_ctrladr``/``actuator_ctrlnum`` and
         let range = model.actuator_ctrlrange()[ctrl];  // control-indexed
     }
 
-The |mj_data| control-history readers follow the same rule: ``read_ctrl`` and ``try_read_ctrl``
-now take an actuator index bounded by ``nactuator``, not a control index bounded by ``nu``.
+The |mj_data| control-history methods follow the same rule: ``read_ctrl``, ``try_read_ctrl`` and
+``init_ctrl_history`` now take an actuator index bounded by ``nactuator``, not a control index
+bounded by ``nu``.
 
 
-Shifted ``MjtGain``/``MjtBias`` discriminants
----------------------------------------------
-``MjtGain`` and ``MjtBias`` gained the ``mjGAIN_SO3``/``mjBIAS_SO3`` variants, shifting the
-raw values of ``mjGAIN_USER`` and ``mjBIAS_USER`` from 4 to 5. Code that persists or compares
-raw discriminants (rather than the enum variants) needs to be updated.
+Shifted actuator enum discriminants
+-------------------------------------
+``MjtGain``, ``MjtBias``, ``MjtDyn`` and ``MjtTrn`` gained new variants, so an exhaustive
+``match`` on any of them no longer compiles. The raw value of ``mjGAIN_USER`` moved from 4 to 6,
+``mjBIAS_USER`` from 4 to 5 and ``mjDYN_USER`` from 6 to 7, so code that stores or compares raw
+discriminants (rather than the enum variants) needs the new values.
+
+
+Stricter |mjr_context| accessor types
+---------------------------------------
+The |mjr_context| flags ``gl_initialized``, ``window_available``, ``window_stereo`` and
+``window_doublebuffer`` now read as ``bool``, and ``font_scale`` and ``read_depth_map`` now read
+as ``MjtFontScale`` and ``MjtDepthMap``, instead of ``i32``.
+
+**Before:**
+
+.. code-block:: rust
+
+    if context.gl_initialized() != 0 && context.window_doublebuffer() != 0 {
+        let scale: i32 = context.font_scale();
+        let depth: i32 = context.read_depth_map();
+    }
+
+**After:**
+
+.. code-block:: rust
+
+    if context.gl_initialized() && context.window_doublebuffer() {
+        let scale: MjtFontScale = context.font_scale();
+        let depth: MjtDepthMap = context.read_depth_map();
+    }
+
+
+Unsafe mutation of |mj_model| ``actuator_gaintype``
+-----------------------------------------------------
+``actuator_gaintype_mut`` is now an ``unsafe fn``, and ``MjActuatorModelViewMut::gaintype``
+became a ``PointerViewUnsafeMut``, so a write through the view needs ``as_mut_slice`` inside
+``unsafe``. A wrong gain type makes the engine write more force outputs than the actuator owns.
+
+**Before:**
+
+.. code-block:: rust
+
+    model.actuator_gaintype_mut()[id] = MjtGain::mjGAIN_AFFINE;
+    view.gaintype[0] = MjtGain::mjGAIN_AFFINE;
+
+**After:**
+
+.. code-block:: rust
+
+    // SAFETY: mjGAIN_AFFINE writes exactly one force output, which this actuator owns.
+    unsafe { model.actuator_gaintype_mut()[id] = MjtGain::mjGAIN_AFFINE };
+    unsafe { view.gaintype.as_mut_slice()[0] = MjtGain::mjGAIN_AFFINE };
+
+
+Renamed ``DcMotorConfig`` input field
+---------------------------------------
+The public field ``DcMotorConfig::input_mode`` is now ``ctrlspec`` and the builder
+``with_input_mode`` is now ``with_ctrlspec``. The value is a bitmask of ``MjtCtrlInput`` values
+instead of a single mode selector.
+
+**Before:**
+
+.. code-block:: rust
+
+    let config = DcMotorConfig::default().with_input_mode(0);
+
+**After:**
+
+.. code-block:: rust
+
+    let config = DcMotorConfig::default()
+        .with_ctrlspec(MjtCtrlInput::mjINPUT_VOLTAGE as i32);
+
+
+Relaxed |mj_data| ``body_awake`` view mutability
+--------------------------------------------------
+``MjBodyDataViewMut::awake`` became a ``PointerViewMut``, so a write through the view no longer
+needs ``as_mut_slice`` inside ``unsafe``.
+
+**Before:**
+
+.. code-block:: rust
+
+    unsafe { view.awake.as_mut_slice()[0] = MjtSleepState::mjS_AWAKE };
+
+**After:**
+
+.. code-block:: rust
+
+    view.awake[0] = MjtSleepState::mjS_AWAKE;
 
 
 .. _migrate_5_0_0:

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -14,7 +14,7 @@ Model editing
 The most general way to create an |mj_model| instance is by loading an XML file
 via :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>from_xml`.
 Due to |mj_model| only allowing (some) changes to parameters and not to the actual
-geometry, MuJoCo introduced `Model Editing <https://mujoco.readthedocs.io/en/3.11.0/programming/modeledit.html>`_.
+geometry, MuJoCo introduced `Model Editing <https://mujoco.readthedocs.io/en/3.12.0/programming/modeledit.html>`_.
 
 In MuJoCo-rs, we created a high-level wrapper around MuJoCo's C API, which provides
 safe wrappers around C structs, as well as methods. Aside from that, we try to stay faithful
@@ -108,9 +108,10 @@ We can now add our ball's body, geom and joint like so:
 
     In the above block, we used methods that have the ``with_`` prefix.
     These allow method chaining.
-    Alternatively, methods that have the ``set_`` prefix can be used. Field setters
-    (e.g. ``set_pos``, ``set_size``) return nothing, while ``set_name`` and ``set_default``
-    return a ``Result`` (``set_name`` fails on a duplicate name, ``set_default`` on an unknown class).
+    Alternatively, methods that have the ``set_`` prefix can be used. A plain field setter
+    (e.g. ``set_group``, ``set_mass``) returns nothing, while a validated setter returns a
+    ``Result`` (``set_name`` fails on a duplicate name, ``set_default`` on an unknown class, and
+    ``MjsNumeric::set_size`` on a negative size).
     Setter (``set_``) methods are available for many common fields, including strings and
     several vector/buffer fields. For nested or structured data, use getters that end with
     the ``_mut`` suffix.
@@ -227,7 +228,7 @@ already been deleted, which would make MuJoCo operate on freed memory.
 
 Class inheritance (defaults)
 ==============================
-MuJoCo supports `default classes <https://mujoco.readthedocs.io/en/3.11.0/XMLreference.html#default>`_,
+MuJoCo supports `default classes <https://mujoco.readthedocs.io/en/3.12.0/XMLreference.html#default>`_,
 which allow shared attribute values to be set in one place and then inherited by multiple elements.
 In MuJoCo-rs, default classes can be created with
 :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>add_default`.
@@ -323,14 +324,16 @@ Configuring actuators
 An actuator added with :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>add_actuator`
 can be configured into one of MuJoCo's predefined actuator types with the ``set_to_*`` family of
 methods on |mjs_actuator| (motor, position, integrated velocity, velocity, damper, cylinder,
-muscle, adhesion, and DC motor), mirroring MuJoCo's ``mjs_setToX`` C API.
+muscle, adhesion, DC motor, PID, and orientation), mirroring MuJoCo's ``mjs_setToX`` C API.
 
 A method whose parameters are all mandatory takes them positionally (for example
 ``set_to_velocity(kv)`` or ``set_to_cylinder(timeconst, bias, area, diameter)``). A method whose
 underlying C function accepts *nullable* parameters instead takes a dedicated ``Default``-able
 config struct --- :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>PositionConfig`,
-:docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>IntVelocityConfig`, and
-:docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>DcMotorConfig` --- in which those nullable
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>IntVelocityConfig`,
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>DcMotorConfig`,
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>PidConfig`, and
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>OrientationConfig` --- in which those nullable
 parameters are ``Option`` fields. A config is built either with struct-update syntax or with the
 chainable ``with_*`` builder methods (which take the inner value and wrap optional fields in
 ``Some``), so only the relevant fields need to be set; everything else stays at its MuJoCo default:
@@ -366,7 +369,7 @@ always-valid ones (``set_to_motor``, ``set_to_velocity``, ``set_to_cylinder``) r
 
 Procedural flex generation
 ==========================
-A `flexcomp <https://mujoco.readthedocs.io/en/3.11.0/XMLreference.html#body-flexcomp>`_ procedurally
+A `flexcomp <https://mujoco.readthedocs.io/en/3.12.0/XMLreference.html#body-flexcomp>`_ procedurally
 generates a deformable |mjs_flex| together with its supporting bodies, joints, and optional
 equality constraints --- handy for cloth, ropes, and soft volumes. In MuJoCo-rs it is created with
 :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsBody::<method>add_flexcomp` (or the fallible

--- a/docs/guide/source/programming/simulation/basic.rst
+++ b/docs/guide/source/programming/simulation/basic.rst
@@ -108,7 +108,7 @@ Similarly, :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>ste
 :docs-rs:`~~mujoco_rs::mujoco_c::<fn>mj_step1` and :docs-rs:`~~mujoco_rs::mujoco_c::<fn>mj_step2`, respectively.
 
 For more information about specific MuJoCo functions, see the
-`MuJoCo documentation <https://mujoco.readthedocs.io/en/3.11.0/APIreference/APIfunctions.html#mj-step>`_.
+`MuJoCo documentation <https://mujoco.readthedocs.io/en/3.12.0/APIreference/APIfunctions.html#mj-step>`_.
 
 Real-time
 ----------------------
@@ -151,7 +151,7 @@ such as physics parameters --- part of |mj_model|.
 .. danger::
 
     Not all parameters of |mj_model| are safe to change.
-    See `MuJoCo's documentation <https://mujoco.readthedocs.io/en/3.11.0/programming/simulation.html#mjmodel-changes>`_
+    See `MuJoCo's documentation <https://mujoco.readthedocs.io/en/3.12.0/programming/simulation.html#mjmodel-changes>`_
     for a list of parameters that are safe to change.
 
 Direct mutation with ``model_opt_mut`` / ``model_vis_mut`` / ``model_stat_mut``

--- a/docs/guide/source/programming/simulation/ffi.rst
+++ b/docs/guide/source/programming/simulation/ffi.rst
@@ -6,9 +6,10 @@ Interface to C API
 
 When the user requires extra flexibility that MuJoCo-rs does not offer, direct FFI bindings to the
 C language structs and functions can be used. Most structs have their attributes public.
-The exceptions are the model-editing structs (``mjs*``) and the structs whose raw fields are
-unsafe to write directly (``mjLogConfig``, ``mjLogMessage``, ``mjrRendererInfo``); read and write
-the fields of these structs through the accessors of the matching wrapper.
+The exceptions are the model-editing structs (``mjs*``, apart from the plain-data
+``mjsOrientation``, ``mjsElement`` and ``mjsAuthored``) and the structs whose raw fields are
+unsafe to write directly (``mjLogConfig``, ``mjLogMessage``); read and write the fields of these
+structs through the accessors of the matching wrapper.
 
 Direct FFI bindings are available inside the :docs-rs:`mujoco_rs::mujoco_c` module.
 

--- a/docs/guide/source/programming/simulation/views.rst
+++ b/docs/guide/source/programming/simulation/views.rst
@@ -7,7 +7,7 @@ Attribute views
 The MuJoCo library stores data about joints, bodies, and other elements in contiguous arrays.
 These can be challenging to work with, particularly when the array's length varies between elements.
 For example, different types of joints may have a different number of degrees of freedom.
-`MuJoCo's Python bindings <https://mujoco.readthedocs.io/en/3.11.0/python.html>`_ solve
+`MuJoCo's Python bindings <https://mujoco.readthedocs.io/en/3.12.0/python.html>`_ solve
 this issue by providing views to specific ranges in the corresponding arrays.
 
 Like MuJoCo's Python bindings, MuJoCo-rs also provides views. Specifically, we provide views for

--- a/docs/guide/source/programming/visualization/viewer.rst
+++ b/docs/guide/source/programming/visualization/viewer.rst
@@ -33,7 +33,7 @@ A screenshot of the Rust 3D viewer is shown below.
 
     Rust-native interactive 3D viewer.
     Showing the `Spot <https://github.com/google-deepmind/mujoco_menagerie/tree/main/boston_dynamics_spot>`_ scene from
-    `MuJoCo's menagerie <https://mujoco.readthedocs.io/en/3.11.0/models.html>`_.
+    `MuJoCo's menagerie <https://mujoco.readthedocs.io/en/3.12.0/models.html>`_.
 
 The viewer can be launched only in **passive mode**, i.e. it won't run as a separate application,
 and needs to be periodically "synced" by the user application.
@@ -136,7 +136,8 @@ This is optional and can be removed or reduced to run the simulation faster than
     of :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData` required for visualization
     (kinematics, contacts, sensor data, etc.), skipping large computed arrays
     (the mass and factorization matrices ``crb``, ``M``, ``qLD``, ``qH``, ``qDeriv``, ``qLU``,
-    and the sparse constraint Jacobian blocks ``efc_J_*``, ``efc_Y_*``, ``efc_AR_*``). This is faster.
+    and the sparse constraint Jacobian blocks ``efc_J``, ``efc_Y``, ``efc_AR`` and their index
+    arrays). This is faster.
     :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>sync_data_full` copies the **entire**
     ``MjData`` struct and should only be used when those large arrays are needed inside the
     viewer (for example, when using
@@ -151,12 +152,14 @@ This is optional and can be removed or reduced to run the simulation faster than
     such as:
 
     - :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>sync_data`;
-    - :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>running`;
+    - :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>sync_model`;
     - etc.;
 
     internally acquire a mutex lock to the shared state.
     Sequential calls to more than one of these can consequently
     hurt performance.
+    :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>running` is an exception: it reads
+    an atomic flag and never locks.
 
     A more optimized way to use these methods is to call their equivalents on the shared
     state directly. The shared state can be accessed mainly through:
@@ -174,7 +177,7 @@ This is optional and can be removed or reduced to run the simulation faster than
     .. code-block:: rust
 
         viewer.with_state_lock(|mut lock| {
-            lock.sync_data(&mut data);  // both calls share one lock
+            lock.sync_data(&mut data);  // one lock for the whole closure
             viewer_running = lock.running();
         }).unwrap();
 
@@ -261,6 +264,8 @@ This allows you to create custom windows, panels, and other UI elements using
     Callbacks added via :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>add_ui_callback`
     receive the passive simulation state (:docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData`).
     This requires locking the mutex to the shared state, which may slow down the program.
+    The lock is held for the whole callback, so the callback must not lock the shared state
+    again; that deadlocks the viewer thread.
 
     To avoid unnecessary locks when the simulation state is not required in the UI,
     :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>add_ui_callback_detached`
@@ -332,7 +337,8 @@ which demonstrates various types of UI elements including windows, side panels, 
     will **not** contain:
 
     - the mass and factorization matrices (``crb``, ``M``, ``qLD``, ``qH``, ``qDeriv``, ``qLU``);
-    - the sparse constraint Jacobian blocks (``efc_J_*``, ``efc_Y_*``, ``efc_AR_*``).
+    - the sparse constraint Jacobian blocks (``efc_J``, ``efc_Y``, ``efc_AR`` and their index
+      arrays).
 
     If you require those in a UI callback, either call an appropriate method on the passed
     :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData` instance
@@ -343,6 +349,9 @@ which demonstrates various types of UI elements including windows, side panels, 
     equality constraints) back to the user's ``data`` via the integration state. If your
     code relies on derived quantities such as previously-computed Jacobians, recompute them
     after each :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>sync_data` call.
+
+    Each sync also applies the mouse perturbation, which unconditionally zeroes
+    ``data.xfrc_applied``. Set your own external forces after the sync, not before it.
 
 
 .. _model_parameter_sync:

--- a/docs/guide/source/webassembly.rst
+++ b/docs/guide/source/webassembly.rst
@@ -50,7 +50,7 @@ Building MuJoCo
 =============================
 
 Use either the ``mujoco/`` submodule (already initialized in the MuJoCo-rs
-repository) or a fresh clone of the official MuJoCo ``3.11.0`` release as the
+repository) or a fresh clone of the official MuJoCo |MUJOCO_VERSION| release as the
 source directory.  The official unmodified tag is sufficient for WASM --- the
 submodule patches are only required for native/C++ features.
 
@@ -58,7 +58,7 @@ To clone the official release:
 
 ::
 
-    git clone https://github.com/google-deepmind/mujoco.git --branch 3.11.0 --depth 1
+    git clone https://github.com/google-deepmind/mujoco.git --branch 3.12.0 --depth 1
 
 Then build (replace ``mujoco`` with the path to whichever source you chose):
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ## MuJoCo version
 //!
-//! MuJoCo-rs relies on MuJoCo [3.11.0](https://github.com/google-deepmind/mujoco/releases/tag/3.11.0).
+//! MuJoCo-rs relies on MuJoCo [3.12.0](https://github.com/google-deepmind/mujoco/releases/tag/3.12.0).
 //!
 //! ## Documentation
 //! A more guided documentation can be obtained [here](https://mujoco-rs.readthedocs.io/en/v6.0.x/).

--- a/src/mujoco_c.rs
+++ b/src/mujoco_c.rs
@@ -43,7 +43,7 @@ impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
     }
 }
 impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
-pub const mjVERSION_HEADER: u32 = 3011000;
+pub const mjVERSION_HEADER: u32 = 3012000;
 pub const mjMINVAL: f64 = 0.000000000000001;
 pub const mjPI: f64 = 3.141592653589793;
 pub const mjMAXVAL: f64 = 10000000000.0;
@@ -306,7 +306,8 @@ pub enum mjtDyn {
     mjDYN_FILTEREXACT = 3,
     mjDYN_MUSCLE = 4,
     mjDYN_DCMOTOR = 5,
-    mjDYN_USER = 6,
+    mjDYN_PID = 6,
+    mjDYN_USER = 7,
 }
 #[repr(u32)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq,  Copy)]
@@ -316,7 +317,8 @@ pub enum mjtGain {
     mjGAIN_MUSCLE = 2,
     mjGAIN_DCMOTOR = 3,
     mjGAIN_SO3 = 4,
-    mjGAIN_USER = 5,
+    mjGAIN_PID = 5,
+    mjGAIN_USER = 6,
 }
 #[repr(u32)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq,  Copy)]
@@ -333,6 +335,15 @@ pub enum mjtBias {
 pub enum mjtCtrlChart {
     mjCHART_EXPMAP = 1,
     mjCHART_QUAT = 2,
+}
+#[repr(u32)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq,  Copy)]
+pub enum mjtCtrlInput {
+    mjINPUT_POS = 1,
+    mjINPUT_VEL = 2,
+    mjINPUT_FF = 4,
+    mjINPUT_VOLTAGE = 8,
+    mjINPUT_NONE = 16,
 }
 #[repr(u32)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq,  Copy)]
@@ -1087,6 +1098,7 @@ pub struct mjModel_ {
     pub light_dir0: *mut mjtNum,
     pub light_attenuation: *mut f32,
     pub light_cutoff: *mut f32,
+    pub light_softness: *mut f32,
     pub light_exponent: *mut f32,
     pub light_ambient: *mut f32,
     pub light_diffuse: *mut f32,
@@ -1187,6 +1199,7 @@ pub struct mjModel_ {
     pub mesh_texcoordadr: *mut ::std::os::raw::c_int,
     pub mesh_texcoordnum: *mut ::std::os::raw::c_int,
     pub mesh_graphadr: *mut ::std::os::raw::c_int,
+    pub mesh_extrema: *mut ::std::os::raw::c_int,
     pub mesh_vert: *mut f32,
     pub mesh_normal: *mut f32,
     pub mesh_texcoord: *mut f32,
@@ -1683,9 +1696,6 @@ pub struct mjData_ {
     pub efm_K_colind: *mut ::std::os::raw::c_int,
     pub efm_K_val: *mut mjtNum,
     pub efm_dofid: *mut ::std::os::raw::c_int,
-    pub efm_L_rownnz: *mut ::std::os::raw::c_int,
-    pub efm_L_rowadr: *mut ::std::os::raw::c_int,
-    pub efm_L_colind: *mut ::std::os::raw::c_int,
     pub efm_L: *mut mjtNum,
     pub efc_b: *mut mjtNum,
     pub iefc_aref: *mut mjtNum,
@@ -2084,6 +2094,7 @@ pub struct mjsLight_ {
     pub(crate) range: f32,
     pub(crate) attenuation: [f32; 3usize],
     pub(crate) cutoff: f32,
+    pub(crate) softness: f32,
     pub(crate) exponent: f32,
     pub(crate) ambient: [f32; 3usize],
     pub(crate) diffuse: [f32; 3usize],
@@ -2323,6 +2334,8 @@ pub struct mjsActuator_ {
     pub(crate) dynprm: [f64; 10usize],
     pub(crate) actdim: ::std::os::raw::c_int,
     pub(crate) ctrlspec: ::std::os::raw::c_int,
+    pub(crate) velrange: [f64; 2usize],
+    pub(crate) ffrange: [f64; 2usize],
     pub(crate) actearly: mjtBool,
     pub(crate) trntype: mjtTrn,
     pub(crate) gear: [f64; 6usize],
@@ -2662,6 +2675,7 @@ pub struct mjvLight_ {
     pub bulbradius: f32,
     pub intensity: f32,
     pub range: f32,
+    pub softness: f32,
 }
 pub type mjvLight = mjvLight_;
 #[repr(C)]
@@ -2771,6 +2785,7 @@ pub struct mjResource_ {
     pub vfs: *mut mjVFS,
     pub timestamp: [::std::os::raw::c_char; 512usize],
     pub provider: *const mjpResourceProvider,
+    pub args: *const ::std::os::raw::c_char,
 }
 pub type mjResource = mjResource_;
 pub type mjfOpenResource =
@@ -4509,6 +4524,13 @@ unsafe extern "C" {
     pub fn mjv_averageCamera(cam1: *const mjvGLCamera, cam2: *const mjvGLCamera) -> mjvGLCamera;
 }
 unsafe extern "C" {
+    pub fn mjv_camera2GLCamera(
+        model: *const mjModel,
+        data: *const mjData,
+        mjv_camera: *const mjvCamera,
+    ) -> mjvGLCamera;
+}
+unsafe extern "C" {
     pub fn mjv_select(
         m: *const mjModel,
         d: *const mjData,
@@ -5807,6 +5829,19 @@ unsafe extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
+    pub fn mjs_setToPID(
+        actuator: *mut mjsActuator,
+        kp: f64,
+        kv: *mut f64,
+        dampratio: *mut f64,
+        ki: *mut f64,
+        imax: *mut f64,
+        slewmax: *mut f64,
+        inheritrange: f64,
+        ctrlspec: ::std::os::raw::c_int,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
     pub fn mjs_setToDamper(actuator: *mut mjsActuator, kv: f64) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
@@ -5851,7 +5886,7 @@ unsafe extern "C" {
         controller: *mut [f64; 6usize],
         thermal: *mut [f64; 6usize],
         lugre: *mut [f64; 5usize],
-        input_mode: ::std::os::raw::c_int,
+        ctrlspec: ::std::os::raw::c_int,
     ) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -606,7 +606,8 @@ impl ViewerSharedState {
     /// The viewer's passive copy will therefore **not** contain:
     ///
     /// - mass and factorization matrices (``crb``, ``M``, ``qLD``, ``qH``, ``qDeriv``, ``qLU``);
-    /// - the sparse constraint Jacobian blocks (``efc_J_*``, ``efc_Y_*``, ``efc_AR_*``).
+    /// - the sparse constraint Jacobian blocks (``efc_J``, ``efc_Y``, ``efc_AR`` and their
+    ///   index arrays).
     ///
     /// In UI callbacks these fields will be absent unless
     /// [`ViewerSharedState::sync_data_full`] is used or they are recomputed explicitly
@@ -908,7 +909,8 @@ impl MjViewer {
     /// The viewer's passive copy will therefore **not** contain:
     ///
     /// - mass and factorization matrices (``crb``, ``M``, ``qLD``, ``qH``, ``qDeriv``, ``qLU``);
-    /// - the sparse constraint Jacobian blocks (``efc_J_*``, ``efc_Y_*``, ``efc_AR_*``).
+    /// - the sparse constraint Jacobian blocks (``efc_J``, ``efc_Y``, ``efc_AR`` and their
+    ///   index arrays).
     ///
     /// In UI callbacks these fields will be absent unless
     /// [`MjViewer::sync_data_full`] is used or they are recomputed explicitly

--- a/src/wrappers/mj_data.rs
+++ b/src/wrappers/mj_data.rs
@@ -1580,10 +1580,9 @@ impl<M: Deref<Target = MjModel>> MjData<M> {
         [ffi] nl: i32; "number of limit constraints.";
         [ffi] nefc: i32; "number of constraints.";
         [ffi] nJ: i32; "number of non-zeros in constraint Jacobian.";
-        [ffi] efm_active: i32; "implicit effective metric M+K: 0 inactive, 1 active, 2 active + preconditioner exact.";
         [ffi] nefmK: i32; "number of non-zeros in effective-stiffness CSR.";
-        [ffi] nefmdof: i32; "number of rows in effective-metric factor.";
-        [ffi] nefmL: i32; "number of non-zeros in the effective-metric factor.";
+        [ffi] nefmdof: i32; "number of 3x3 blocks in the effective-metric preconditioner.";
+        [ffi] nefmL: i32; "size of the effective-metric block storage (9*nefmdof).";
         [ffi] nY: i32; "number of non-zeros in constraint inverse inertia square root.";
         [ffi] nA: i32; "number of non-zeros in constraint inverse inertia matrix.";
         [ffi] nisland: i32; "number of detected constraint islands.";
@@ -1593,6 +1592,10 @@ impl<M: Deref<Target = MjModel>> MjData<M> {
         [ffi] nparent_awake: i32; "number of bodies with awake parents.";
         [ffi] nv_awake: i32; "number of awake dofs.";
         [ffi] signature: u64; "compilation signature.";
+    ]}
+
+    getter_setter! {get, [
+        [ffi] efm_active: bool; "whether the implicit effective metric M+K is active.";
     ]}
 
     getter_setter! {get, [
@@ -1864,11 +1867,8 @@ impl<M: Deref<Target = MjModel>> MjData<M> {
         (mut = unsafe) efm_K_rowadr: &[i32; "effective-stiffness CSR row addresses"; model.ffi().nv],
         (mut = unsafe) efm_K_colind: &[i32; "effective-stiffness CSR column indices"; ffi().nefmK],
         efm_K_val: &[MjtNum; "effective-stiffness CSR values"; ffi().nefmK],
-        (mut = unsafe) efm_dofid: &[i32; "factor row -> dof address"; ffi().nefmdof],
-        (mut = unsafe) efm_L_rownnz: &[i32; "factor row nonzeros"; ffi().nefmdof],
-        (mut = unsafe) efm_L_rowadr: &[i32; "factor row addresses"; ffi().nefmdof],
-        (mut = unsafe) efm_L_colind: &[i32; "factor column indices"; ffi().nefmL],
-        efm_L: &[MjtNum; "Cholesky factor of diag(M)+K, covered dofs"; ffi().nefmL],
+        (mut = unsafe) efm_dofid: &[i32; "block k -> dof address of its vertex triple"; ffi().nefmdof],
+        efm_L: &[MjtNum; "factored 3x3 diagonal blocks of M+K"; ffi().nefmL],
         efc_b: &[MjtNum; "linear cost term: J*qacc_smooth - aref"; ffi().nefc],
         iefc_aref: &[MjtNum; "reference pseudo-acceleration"; ffi().nefc],
         iefc_state: &[MjtConstraintState [force]; "constraint state"; ffi().nefc],
@@ -1934,8 +1934,9 @@ info_with_view!(Data, body,
      subtree_angmom: MjtNum,
      cacc: MjtNum,
      cfrc_int: MjtNum,
-     cfrc_ext: MjtNum],
-    [[body_] awake: MjtSleepState [force]],
+     cfrc_ext: MjtNum,
+     [body_] awake: MjtSleepState [force]],
+    [],
     [], M: Deref<Target = MjModel>);
 
 info_with_view!(Data, camera,

--- a/src/wrappers/mj_data.rs
+++ b/src/wrappers/mj_data.rs
@@ -102,7 +102,7 @@ impl<M: Deref<Target = MjModel>> MjData<M> {
     /// # Notes
     /// This method only validates model-signature compatibility.
     /// **Not all model parameters are safe (for correct simulation) to change at runtime.**
-    /// See [here](https://mujoco.readthedocs.io/en/3.11.0/programming/simulation.html#mjmodel-changes)
+    /// See [here](https://mujoco.readthedocs.io/en/3.12.0/programming/simulation.html#mjmodel-changes)
     /// to see what parameters can be changed.
     /// 
     /// If `M` implements [`DerefMut`], prefer
@@ -1633,7 +1633,7 @@ impl<M: DerefMut<Target = MjModel>> MjData<M> {
     /// (e.g., timestep, gravity) without having to rebuild the simulation.
     ///
     /// **Not all model parameters are safe to change at runtime.**
-    /// See [MuJoCo's documentation](https://mujoco.readthedocs.io/en/3.11.0/programming/simulation.html#mjmodel-changes)
+    /// See [MuJoCo's documentation](https://mujoco.readthedocs.io/en/3.12.0/programming/simulation.html#mjmodel-changes)
     /// for a list of parameters that are safe to change.
     ///
     /// Only available when the inner model type `M` implements

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -1011,6 +1011,7 @@ impl MjsLight {
         intensity: f32;                "intensity, in candelas.";
         range: f32;                    "range of effectiveness.";
         cutoff: f32;                   "OpenGL cutoff.";
+        softness: f32;                 "spotlight edge softness.";
         exponent: f32;                 "OpenGL exponent.";
     ]);
 
@@ -1090,6 +1091,8 @@ impl MjsActuator {
             lengthrange: &[f64; 2];                     "transmission length range.";
             damping: &[f64; mjNPOLY as usize + 1];      "damping coefficient.";
             ctrlrange: &[f64; 2];                       "control range.";
+            velrange: &[f64; 2];                        "range of the velocity-setpoint input (pid).";
+            ffrange: &[f64; 2];                         "range of the feedforward input (pid).";
             forcerange: &[f64; 2];                      "force range.";
             actrange: &[f64; 2];                        "activation range.";
         ]
@@ -3095,9 +3098,9 @@ mod tests {
   <worldbody>
     <body>
       <geom size=\"0.01\"/>
-      <site pos=\"0 0 0\"/>
-      <camera pos=\"0 0 0\"/>
-      <light pos=\"0 0 0\" dir=\"0 0 -1\"/>
+      <site/>
+      <camera/>
+      <light/>
     </body>
   </worldbody>
 </mujoco>

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -1,9 +1,9 @@
 //! Definitions related to model editing.
 use std::ffi::{c_char, c_int, CStr, CString};
-use std::marker::PhantomData;
-use std::ptr::{self, NonNull};
-use std::path::Path;
 use crate::error::MjEditError;
+use std::ptr::{self, NonNull};
+use std::marker::PhantomData;
+use std::path::Path;
 
 #[macro_use]
 mod utility;
@@ -1231,8 +1231,9 @@ impl IntVelocityConfig {
 pub struct DcMotorConfig {
     /// Electrical resistance.
     pub resistance: f64,
-    /// Input mode selector.
-    pub input_mode: i32,
+    /// Input signature: a bitmask of
+    /// [`MjtCtrlInput`](crate::wrappers::mj_model::MjtCtrlInput) values.
+    pub ctrlspec: i32,
     /// Torque and back-EMF constants `[Kt, Ke]`.
     pub motorconst: Option<[f64; 2]>,
     /// Nominal ratings `[voltage, stall_torque, no_load_speed]`.
@@ -1255,7 +1256,7 @@ impl DcMotorConfig {
     getter_setter! {
         with, [
             resistance: f64;       "the electrical resistance.";
-            input_mode: i32;       "the input mode selector.";
+            ctrlspec: i32;         "the input signature bitmask ([`MjtCtrlInput`](crate::wrappers::mj_model::MjtCtrlInput)).";
             motorconst: [f64; 2];  "the torque and back-EMF constants [Kt, Ke].";
             nominal: [f64; 3];     "the nominal ratings [voltage, stall_torque, no_load_speed].";
             saturation: [f64; 3];  "the saturation [tau_max, i_max, di_dt_max].";
@@ -1264,6 +1265,72 @@ impl DcMotorConfig {
             controller: [f64; 6];  "the controller [kp, ki, kd, slewmax, Imax, v_max].";
             thermal: [f64; 6];     "the thermal [R_th, C, tau_th, alpha, T0, T_ambient].";
             lugre: [f64; 5];       "the LuGre friction [stiffness, damping, coulomb, static, stribeck].";
+        ]
+    }
+}
+
+/// Configuration for [`MjsActuator::set_to_pid`].
+///
+/// Each optional field defaults to `None`, disabling the corresponding feature.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct PidConfig {
+    /// Proportional (position) gain.
+    pub kp: f64,
+    /// Velocity feedback gain. Mutually exclusive with `dampratio`.
+    pub kv: Option<f64>,
+    /// Damping ratio. Mutually exclusive with `kv`.
+    pub dampratio: Option<f64>,
+    /// Integral gain on the position error.
+    pub ki: Option<f64>,
+    /// Anti-windup limit on the integral state.
+    pub imax: Option<f64>,
+    /// Slew rate limit of the position setpoint.
+    pub slewmax: Option<f64>,
+    /// Automatic range-inheritance factor for the position-setpoint range (0 disables it).
+    pub inheritrange: f64,
+    /// Input signature: a bitmask of
+    /// [`MjtCtrlInput`](crate::wrappers::mj_model::MjtCtrlInput) values.
+    pub ctrlspec: i32,
+}
+
+impl PidConfig {
+    getter_setter! {
+        with, [
+            kp: f64;            "the proportional (position) gain.";
+            kv: f64;            "the velocity feedback gain (mutually exclusive with dampratio).";
+            dampratio: f64;     "the damping ratio (mutually exclusive with kv).";
+            ki: f64;            "the integral gain on the position error.";
+            imax: f64;          "the anti-windup limit on the integral state.";
+            slewmax: f64;       "the position-setpoint slew rate limit.";
+            inheritrange: f64;  "the automatic range-inheritance factor.";
+            ctrlspec: i32;      "the input signature bitmask ([`MjtCtrlInput`](crate::wrappers::mj_model::MjtCtrlInput)).";
+        ]
+    }
+}
+
+/// Configuration for [`MjsActuator::set_to_orientation`].
+///
+/// Each optional field defaults to `None`, disabling the corresponding feature.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct OrientationConfig {
+    /// Proportional gain, in torque per radian of geodesic error.
+    pub kp: f64,
+    /// Damping, per force output. Mutually exclusive with `dampratio`.
+    pub kv: Option<f64>,
+    /// Damping ratio. Mutually exclusive with `kv`.
+    pub dampratio: Option<f64>,
+    /// Chart of the commanded orientation
+    /// ([`MjtCtrlChart`](crate::wrappers::mj_model::MjtCtrlChart)).
+    pub ctrlspec: i32,
+}
+
+impl OrientationConfig {
+    getter_setter! {
+        with, [
+            kp: f64;         "the proportional gain, in torque per radian of geodesic error.";
+            kv: f64;         "the velocity feedback gain (mutually exclusive with dampratio).";
+            dampratio: f64;  "the damping ratio (mutually exclusive with kv).";
+            ctrlspec: i32;   "the chart of the commanded orientation ([`MjtCtrlChart`](crate::wrappers::mj_model::MjtCtrlChart)).";
         ]
     }
 }
@@ -1368,7 +1435,7 @@ impl MjsActuator {
     /// value is out of its allowed range.
     pub fn set_to_dc_motor(&mut self, config: DcMotorConfig) -> Result<(), MjEditError> {
         let DcMotorConfig {
-            resistance, input_mode,
+            resistance, ctrlspec,
             mut motorconst, mut nominal, mut saturation, mut inductance,
             mut cogging, mut controller, mut thermal, mut lugre
         } = config;
@@ -1383,8 +1450,58 @@ impl MjsActuator {
             controller.as_mut().map_or(ptr::null_mut(), |x| x),
             thermal.as_mut().map_or(ptr::null_mut(), |x| x),
             lugre.as_mut().map_or(ptr::null_mut(), |x| x),
-            input_mode
+            ctrlspec
         ) };
+        actuator_set_result(c_err_msg)
+    }
+
+    /// Configure the actuator to be a PID controller on a single force output. The force is
+    /// `kp * (u_pos - length) + kv * (u_vel - velocity) + ki * integral + ff`.
+    /// # Errors
+    /// Returns [`MjEditError::InvalidParameter`] when `kv` and `dampratio` are both set, when
+    /// `kv`, `dampratio` or `slewmax` is negative, or when `inheritrange` is set together with a
+    /// position-setpoint range.
+    pub fn set_to_pid(&mut self, config: PidConfig) -> Result<(), MjEditError> {
+        let PidConfig {
+            kp, mut kv, mut dampratio, mut ki,
+            mut imax, mut slewmax, inheritrange, ctrlspec
+        } = config;
+
+        let c_err_msg = unsafe {
+            mjs_setToPID(
+                self,
+                kp,
+                kv.as_mut().map_or(ptr::null_mut(), |x| x),
+                dampratio.as_mut().map_or(ptr::null_mut(), |x| x),
+                ki.as_mut().map_or(ptr::null_mut(), |x| x),
+                imax.as_mut().map_or(ptr::null_mut(), |x| x),
+                slewmax.as_mut().map_or(ptr::null_mut(), |x| x),
+                inheritrange, ctrlspec
+            )
+        };
+        actuator_set_result(c_err_msg)
+    }
+
+    /// Configure the actuator to be an orientation servo: a geodesic PD controller on a ball
+    /// joint or a site with a reference site. The three force outputs carry the torque
+    /// `kp * log(q^-1 * q_target) - kv * omega`, in the frame of the transmission target.
+    /// # Errors
+    /// Returns [`MjEditError::InvalidParameter`] when `kv` and `dampratio` are both set, or when
+    /// `kv` or `dampratio` is negative.
+    pub fn set_to_orientation(&mut self, config: OrientationConfig) -> Result<(), MjEditError> {
+        let OrientationConfig {
+            kp, mut kv, mut dampratio, ctrlspec
+        } = config;
+
+        let c_err_msg = unsafe {
+            mjs_setToOrientation(
+                self,
+                kp,
+                kv.as_mut().map_or(ptr::null_mut(), |x| x),
+                dampratio.as_mut().map_or(ptr::null_mut(), |x| x),
+                ctrlspec
+            )
+        };
         actuator_set_result(c_err_msg)
     }
 }

--- a/src/wrappers/mj_model.rs
+++ b/src/wrappers/mj_model.rs
@@ -120,6 +120,10 @@ pub type MjtBias = mjtBias;
 /// Orientation input charts of so3 actuators. These values are used in `m->actuator_ctrlspec`.
 pub type MjtCtrlChart = mjtCtrlChart;
 
+/// Input signature bits of servo-family (`pid`, `dcmotor`) actuators. These values are OR-ed into
+/// `m->actuator_ctrlspec`.
+pub type MjtCtrlInput = mjtCtrlInput;
+
 /// MuJoCo object types. These are used, for example, in the support functions `mj_name2id` and
 /// `mj_id2name` to convert between object names and integer ids.
 pub type MjtObj = mjtObj;

--- a/src/wrappers/mj_model.rs
+++ b/src/wrappers/mj_model.rs
@@ -161,7 +161,7 @@ pub type MjtRayDataField = mjtRayDataField;
 /// Camera output type bitflags.
 pub type MjtCamOutBit = mjtCamOutBit;
 
-// SAFETY: All MuJoCo C enums below are `#[repr(u32)]` (or `#[repr(u8)]`) and each
+// SAFETY: All MuJoCo C enums below are fieldless with an explicit integer repr, and each
 // has a variant with discriminant 0, so the all-zeros bit pattern is a valid value.
 // This lets `info_with_view!`'s `zero()` method use the safe `Zeroable::zeroed()`
 // instead of `unsafe { std::mem::zeroed() }`, providing a compile-time guarantee
@@ -183,6 +183,22 @@ unsafe impl bytemuck::Zeroable for mjtDataType {}
 unsafe impl bytemuck::Zeroable for mjtStage {}
 unsafe impl bytemuck::Zeroable for mjtTexture {}
 unsafe impl bytemuck::Zeroable for mjtColorSpace {}
+unsafe impl bytemuck::Zeroable for mjtAlignFree {}
+unsafe impl bytemuck::Zeroable for mjtBuiltin {}
+unsafe impl bytemuck::Zeroable for mjtConflict {}
+unsafe impl bytemuck::Zeroable for mjtConstraint {}
+unsafe impl bytemuck::Zeroable for mjtConstraintState {}
+unsafe impl bytemuck::Zeroable for mjtDepthMap {}
+unsafe impl bytemuck::Zeroable for mjtFlexSelf {}
+unsafe impl bytemuck::Zeroable for mjtInertiaFromGeom {}
+unsafe impl bytemuck::Zeroable for mjtLimited {}
+unsafe impl bytemuck::Zeroable for mjtLogLevel {}
+unsafe impl bytemuck::Zeroable for mjtLogTopic {}
+unsafe impl bytemuck::Zeroable for mjtMark {}
+unsafe impl bytemuck::Zeroable for mjtSleepPolicy {}
+unsafe impl bytemuck::Zeroable for mjtSleepState {}
+unsafe impl bytemuck::Zeroable for mjtStereo {}
+unsafe impl bytemuck::Zeroable for mjtWrap {}
 
 /*******************************************/
 
@@ -428,7 +444,7 @@ impl MjModel {
         [mode: 1, bodyid: 1, targetbodyid: 1, r#type: 1, texid: 1, castshadow: 1,
         bulbradius: 1, intensity: 1, range: 1,
         active: 1, pos: 3, dir: 3, poscom0: 3, pos0: 3,
-        dir0: 3, attenuation: 3, cutoff: 1, exponent: 1, ambient: 3,
+        dir0: 3, attenuation: 3, cutoff: 1, softness: 1, exponent: 1, ambient: 3,
         diffuse: 3, specular: 3],
         [],
         []
@@ -446,7 +462,7 @@ impl MjModel {
     info_method! { Model, mesh,
         [vertadr: 1, vertnum: 1,
         texcoordadr: 1, faceadr: 1,
-        facenum: 1, graphadr: 1,
+        facenum: 1, graphadr: 1, extrema: 27,
         normaladr: 1, normalnum: 1, texcoordnum: 1,
         bvhadr: 1, bvhnum: 1, octadr: 1, octnum: 1,
         pathadr: 1, polynum: 1, polyadr: 1,
@@ -973,7 +989,7 @@ impl MjModel {
         qpos_spring: &[MjtNum; "reference pose for springs"; ffi().nq],
         (mut = unsafe) body_parentid: &[i32; "id of body's parent"; ffi().nbody],
         (mut = unsafe) body_rootid: &[i32; "ancestor that is direct child of world"; ffi().nbody],
-        (mut = unsafe) body_weldid: &[i32; "top ancestor with no dofs to this body"; ffi().nbody],
+        (mut = unsafe) body_weldid: &[i32; "top dof-less ancestor; mocap: own root"; ffi().nbody],
         (mut = unsafe) body_mocapid: &[i32; "id of mocap data; -1: none"; ffi().nbody],
         (mut = unsafe) body_jntnum: &[i32; "number of joints for this body"; ffi().nbody],
         (mut = unsafe) body_jntadr: &[i32; "start addr of joints; -1: no joints"; ffi().nbody],
@@ -1112,6 +1128,7 @@ impl MjModel {
         light_dir0: &[[MjtNum; 3] [force]; "global direction in qpos0"; ffi().nlight],
         light_attenuation: &[[f32; 3] [force]; "OpenGL attenuation (quadratic model)"; ffi().nlight],
         light_cutoff: &[f32; "OpenGL cutoff"; ffi().nlight],
+        light_softness: &[f32; "spotlight edge softness"; ffi().nlight],
         light_exponent: &[f32; "OpenGL exponent"; ffi().nlight],
         light_ambient: &[[f32; 3] [force]; "ambient rgb (alpha=1)"; ffi().nlight],
         light_diffuse: &[[f32; 3] [force]; "diffuse rgb (alpha=1)"; ffi().nlight],
@@ -1212,6 +1229,7 @@ impl MjModel {
         (mut = unsafe) mesh_texcoordadr: &[i32; "texcoord data address; -1: no texcoord"; ffi().nmesh],
         (mut = unsafe) mesh_texcoordnum: &[i32; "number of texcoord"; ffi().nmesh],
         (mut = unsafe) mesh_graphadr: &[i32; "graph data address; -1: no graph"; ffi().nmesh],
+        (mut = unsafe) mesh_extrema: &[[i32; 27] [force]; "extremum vertices in 3x3x3 directions"; ffi().nmesh],
         mesh_vert: &[[f32; 3] [force]; "vertex positions for all meshes"; ffi().nmeshvert],
         mesh_normal: &[[f32; 3] [force]; "normals for all meshes"; ffi().nmeshnormal],
         mesh_texcoord: &[[f32; 2] [force]; "vertex texcoords for all meshes"; ffi().nmeshtexcoord],
@@ -1333,11 +1351,11 @@ impl MjModel {
         (mut = unsafe) wrap_prm: &[MjtNum; "divisor, joint coef, or site id"; ffi().nwrap],
         (mut = unsafe) actuator_trntype: &[MjtTrn [force]; "transmission type"; ffi().nactuator],
         (mut = unsafe) actuator_dyntype: &[MjtDyn [force]; "dynamics type"; ffi().nactuator],
-        actuator_gaintype: &[MjtGain [force]; "gain type"; ffi().nactuator],
+        (mut = unsafe) actuator_gaintype: &[MjtGain [force]; "gain type"; ffi().nactuator],
         actuator_biastype: &[MjtBias [force]; "bias type"; ffi().nactuator],
         (mut = unsafe) actuator_ctrladr: &[i32; "address of first control"; ffi().nactuator],
         (mut = unsafe) actuator_ctrlnum: &[i32; "number of controls"; ffi().nactuator],
-        actuator_ctrlspec: &[i32; "input signature, scoped by gaintype"; ffi().nactuator],
+        (mut = unsafe) actuator_ctrlspec: &[i32; "input signature, scoped by gaintype"; ffi().nactuator],
         (mut = unsafe) actuator_outadr: &[i32; "address of first force output"; ffi().nactuator],
         (mut = unsafe) actuator_outnum: &[i32; "number of force outputs, from trntype"; ffi().nactuator],
         (mut = unsafe) actuator_trnid: &[[i32; 2] [force]; "transmission id: joint, tendon, site"; ffi().nactuator],
@@ -1425,7 +1443,7 @@ impl MjModel {
         (mut = unsafe) name_pluginadr: &[i32; "plugin instance name pointers"; ffi().nplugin],
         (mut = unsafe) names: &[c_char; "names of all objects, 0-terminated"; ffi().nnames],
         (mut = unsafe) names_map: &[i32; "internal hash map of names"; ffi().nnames_map],
-        (mut = unsafe) paths: &[c_char; "paths to assets, 0-terminated"; ffi().npaths],
+        paths: &[c_char; "paths to assets, 0-terminated"; ffi().npaths],
         (mut = unsafe) B_rownnz: &[i32; "body-dof: non-zeros in each row"; ffi().nbody],
         (mut = unsafe) B_rowadr: &[i32; "body-dof: row addresses"; ffi().nbody],
         (mut = unsafe) B_colind: &[i32; "body-dof: column indices"; ffi().nB],
@@ -1492,11 +1510,11 @@ info_with_view!(Model, actuator,
 	 [actuator_] armature: MjtNum,
 	 [actuator_] cranklength: MjtNum, [actuator_] acc0: MjtNum,
 	 [actuator_] length0: MjtNum, [actuator_] lengthrange: MjtNum,
-	 [actuator_] ctrlspec: i32, [actuator_] user: MjtNum,
-	 [actuator_] gaintype: MjtGain [force], [actuator_] biastype: MjtBias [force],
+	 [actuator_] user: MjtNum, [actuator_] biastype: MjtBias [force],
 	 [actuator_] plugin: i32],
 	[[actuator_] trntype: MjtTrn [force], [actuator_] dyntype: MjtDyn [force],
-	 [actuator_] ctrladr: i32, [actuator_] ctrlnum: i32,
+	 [actuator_] ctrladr: i32, [actuator_] ctrlnum: i32, [actuator_] ctrlspec: i32,
+	 [actuator_] gaintype: MjtGain [force],
 	 [actuator_] outadr: i32, [actuator_] outnum: i32,
 	 [actuator_] trnid: i32, [actuator_] actadr: i32,
 	 [actuator_] actnum: i32, [actuator_] history: i32,
@@ -1623,6 +1641,7 @@ info_with_view!(Model, light,
 	 [light_] dir0: MjtNum,
 	 [light_] attenuation: f32,
 	 [light_] cutoff: f32,
+	 [light_] softness: f32,
 	 [light_] exponent: f32,
 	 [light_] ambient: f32,
 	 [light_] diffuse: f32,
@@ -1655,6 +1674,7 @@ info_with_view!(Model, mesh,
 	 [mesh_] faceadr: i32,
 	 [mesh_] facenum: i32,
 	 [mesh_] graphadr: i32,
+	 [mesh_] extrema: i32,
 	 [mesh_] normaladr: i32,
 	 [mesh_] normalnum: i32,
 	 [mesh_] texcoordnum: i32,
@@ -2016,15 +2036,34 @@ mod tests {
 
         /* Test write */
         let mut view_mut = actuator_model_info.view_mut(&mut model);
-        view_mut.gaintype[0] = MjtGain::mjGAIN_AFFINE;
+        view_mut.biastype[0] = MjtBias::mjBIAS_USER;
         view_mut.delay[0] = 3.0;
 
-        assert_eq!(view_mut.gaintype[0], MjtGain::mjGAIN_AFFINE);
+        assert_eq!(view_mut.biastype[0], MjtBias::mjBIAS_USER);
         assert_eq!(view_mut.delay[0], 3.0);
         view_mut.zero();
 
         assert_eq!(view_mut.delay[0], 0.0);
-        assert_eq!(view_mut.gaintype[0], MjtGain::mjGAIN_FIXED);
+        assert_eq!(view_mut.biastype[0], MjtBias::mjBIAS_NONE);
+    }
+
+    /// `light_softness` must expose the per-light `softness`, not one of the arrays that bracket
+    /// it in `mjModel` (`light_cutoff` before it, `light_exponent` after it).
+    #[test]
+    fn test_light_softness() {
+        const XML: &str = stringify!(
+            <mujoco>
+                <worldbody>
+                    <light name="spot1" type="spot" cutoff="45" softness="0.25" exponent="2"/>
+                    <light name="spot2" type="spot" cutoff="60" softness="0.75" exponent="3"/>
+                </worldbody>
+            </mujoco>
+        );
+        let model = MjModel::from_xml_string(XML).unwrap();
+        assert_eq!(model.light_softness(), [0.25, 0.75]);
+
+        let info = model.light("spot2").unwrap();
+        assert_eq!(info.view(&model).softness[0], 0.75);
     }
 
     #[test]
@@ -3425,9 +3464,9 @@ mod tests {
 
         // Mutable enum roundtrip via view
         let mut slider_view_mut = slider_info.view_mut(&mut model);
-        slider_view_mut.gaintype[0] = MjtGain::mjGAIN_AFFINE;
+        slider_view_mut.biastype[0] = MjtBias::mjBIAS_NONE;
         let slider_view2 = slider_info.view(&model);
-        assert_eq!(slider_view2.gaintype[0], MjtGain::mjGAIN_AFFINE);
+        assert_eq!(slider_view2.biastype[0], MjtBias::mjBIAS_NONE);
     }
 
     /// Verifies mutable model-array roundtrip via info views.

--- a/src/wrappers/mj_rendering.rs
+++ b/src/wrappers/mj_rendering.rs
@@ -302,7 +302,7 @@ impl MjrContext {
 /// Array slices.
 impl MjrContext {
     array_slice_dyn! {
-        (mut = unsafe) textureType: as_ptr as_mut_ptr &[MjtTexture [force]; "type of texture"; ffi().ntexture],
+        textureType: as_ptr as_mut_ptr &[MjtTexture [force]; "type of texture"; ffi().ntexture],
         (mut = unsafe) skinvertVBO: &[u32; "skin vertex position VBOs"; ffi().nskin],
         (mut = unsafe) skinnormalVBO: &[u32; "skin vertex normal VBOs"; ffi().nskin],
         (mut = unsafe) skintexcoordVBO: &[u32; "skin vertex texture coordinate VBOs"; ffi().nskin],
@@ -321,7 +321,9 @@ impl MjrContext {
         [ffi] offWidth: i32; "width of offscreen buffer.";
         [ffi] offHeight: i32; "height of offscreen buffer.";
         [ffi] offSamples: i32; "number of offscreen buffer multisamples.";
-        [ffi] fontScale: i32; "font scale.";
+        // The zeroed state that mjr_defaultContext leaves has no mjtFontScale variant, but only
+        // Drop can reach it: new() and ffi_mut() are unsafe and change_font() takes the enum.
+        [ffi] fontScale: MjtFontScale [force]; "font scale.";
         [ffi] offFBO: u32; "offscreen framebuffer object.";
         [ffi] offFBO_r: u32; "offscreen framebuffer for resolving multisamples.";
         [ffi] offColor: u32; "offscreen color buffer.";
@@ -346,14 +348,17 @@ impl MjrContext {
         [ffi] nskin: i32; "number of skins.";
         [ffi] charHeight: i32; "character heights: normal and shadow.";
         [ffi] charHeightBig: i32; "character heights: big.";
-        [ffi] glInitialized: i32; "is OpenGL initialized.";
-        [ffi] windowAvailable: i32; "is default/window framebuffer available.";
         [ffi] windowSamples: i32; "number of samples for default/window framebuffer.";
-        [ffi] windowStereo: i32; "is stereo available for default/window framebuffer.";
-        [ffi] windowDoublebuffer: i32; "is default/window framebuffer double buffered.";
         [ffi] currentBuffer: i32; "currently active framebuffer: mjFB_WINDOW or mjFB_OFFSCREEN.";
         [ffi] readPixelFormat: i32; "default color pixel format for mjr_readPixels.";
-        [ffi] readDepthMap: i32; "depth mapping: mjDEPTH_ZERONEAR or mjDEPTH_ZEROFAR.";
+        [ffi] readDepthMap: MjtDepthMap [force]; "depth mapping.";
+    ]}
+
+    getter_setter! {get, [
+        [ffi] glInitialized: bool; "whether OpenGL is initialized.";
+        [ffi] windowAvailable: bool; "whether the default/window framebuffer is available.";
+        [ffi] windowStereo: bool; "whether stereo is available for the default/window framebuffer.";
+        [ffi] windowDoublebuffer: bool; "whether the default/window framebuffer is double buffered.";
     ]}
 
     getter_setter! {get, [


### PR DESCRIPTION
Roll MuJoCo bindings up to version MuJoCo 3.12.0. Some extra wrappers and types were also created to mirror the new changes of MuJoCo 3.12.0. More PRs will follow to address the rest of missing wrappers.