### PR TITLE
Upgrade viewer's UI for joint and actuator controls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,11 @@ name = "model_parameters"
 path = "examples/simulation/model_parameters.rs"
 
 [[example]]
+name = "actuator_inputs"
+path = "examples/visualization/viewer/actuator_inputs.rs"
+required-features = ["viewer-ui"]
+
+[[example]]
 name = "cpp_viewer"
 path = "examples/visualization/viewer/cpp_viewer.rs"
 required-features = ["cpp-viewer"]

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -116,8 +116,7 @@ update of MuJoCo alone can increase the major version.
   The |mj_data| accessors ``actuator_length``, ``moment_rownnz``, ``moment_rowadr``,
   ``actuator_velocity`` and ``actuator_force`` are now sized by ``nout``. The per-actuator views
   are affected the same way: they now use dynamic ranges based on ``actuator_ctrladr`` and
-  ``actuator_outadr``. The viewer labels the sliders of a multi-control actuator
-  ``<name>[<index>]``. For single-input single-output actuators ``nactuator == nu == nout`` and
+  ``actuator_outadr``. For single-input single-output actuators ``nactuator == nu == nout`` and
   behavior is unchanged.
 - |mj_data| ``read_ctrl``/``try_read_ctrl`` and ``init_ctrl_history`` now bound the actuator index
   by ``nactuator`` instead of ``nu``, because the control history is stored per actuator.
@@ -201,8 +200,26 @@ update of MuJoCo alone can increase the major version.
   actuator in the "Actuator" window. A ball joint and a free joint show all their position
   components in one horizontal row, named ``x``, ``y``, ``z`` and ``qw``, ``qx``, ``qy``, ``qz``.
   The window listed a slide joint and a hinge joint only before.
+- Each component of the "Joint" window now writes ``qpos``, so the window moves the model. The
+  window was read-only before. A limited joint gets the joint limit as its slider range. Without
+  a limit, a slide joint spans -1 to 1 and a hinge joint spans -pi to pi, as in MuJoCo's own
+  viewer. A quaternion component spans -1 to 1, and the window normalizes the quaternion after an
+  edit. A free joint holds no natural range, so each of its components takes a numeric input
+  instead of a slider.
+- A limited ball joint now shows its rotation angle against the limit, because MuJoCo limits the
+  angle of a ball joint and not one quaternion component. Every component of a ball joint reported
+  "no limit" before, even when the joint was limited.
+- The "Actuator" window now holds one collapsible section for each actuator, with one slider for
+  each control input of the actuator. A multi-input actuator labels each slider with the input
+  name that MuJoCo reports for the actuator type, for example ``pos``, ``vel`` and ``ff`` for a
+  ``pid`` actuator. An actuator without control inputs shows "no inputs". The window showed one
+  flat slider for each control before, labelled ``<name>[<index>]``.
+- A defined ``ctrlrange`` now sets the range of an actuator slider, even when MuJoCo does not
+  clamp the control to it. The slider spanned -1 to 1 unless ``actuator_ctrllimited`` was set
+  before.
 - A press on the scene now takes the selection away from every viewer window, so no window keeps a
   highlighted title bar while the pointer works in the scene.
+
 *New accessors for 3.11.0 fields*
 
 - |mj_model|:
@@ -324,10 +341,18 @@ update of MuJoCo alone can increase the major version.
 
 *New accessors for 3.12.0 fields*
 
-- |mj_model|: ``light_softness`` :sup:`new` and ``mesh_extrema`` :sup:`new` array accessors, with
-  matching ``softness`` and ``extrema`` fields in the light and mesh info views. Mutating
-  ``mesh_extrema`` needs ``unsafe``, in the array accessor and through the mesh view, because
-  MuJoCo uses its values as unchecked vertex indices.
+- |mj_model|:
+
+  - ``light_softness`` :sup:`new` and ``mesh_extrema`` :sup:`new` array accessors, with
+    matching ``softness`` and ``extrema`` fields in the light and mesh info views. Mutating
+    ``mesh_extrema`` needs ``unsafe``, in the array accessor and through the mesh view, because
+    MuJoCo uses its values as unchecked vertex indices.
+  - :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>actuator_input_name`
+    :sup:`new`, wrapping ``mj_actuatorInputName``, gives the name of one control input of an
+    actuator, for example ``pos`` for a ``pid`` actuator or ``rx`` for an ``orientation``
+    actuator on the exponential-map chart. It returns ``None`` when the actuator type defines
+    no input names.
+
 - |mjs_light|: ``softness`` :sup:`new`.
 - |mjs_actuator|: ``velrange`` :sup:`new` and ``ffrange`` :sup:`new`.
 - Added ``MjtCtrlInput`` :sup:`new` as an alias for the new ``mjtCtrlInput`` enum, whose values
@@ -359,9 +384,14 @@ update of MuJoCo alone can increase the major version.
   controls of the :ref:`mj_rust_viewer` for every input flavour: actuator types that define no
   input names, the named multi-input control blocks of a ``pid``, a ``dcmotor`` and an
   ``orientation`` actuator, an actuator without a name, and an actuator without control inputs.
+  The model also holds a limited ball joint, an unlimited ball joint and a free joint, for the
+  sliders of the "Joint" window.
 
 .. rubric:: Bug fixes
 
+- The viewer no longer clamps ``ctrl`` to the range of its slider. While the "Actuator" window
+  was open, it wrote the clamped control back on every frame, so a program that set a control
+  outside the slider range lost that value.
 - Closed an out-of-bounds read reachable from safe code in
   :docs-rs:`~~mujoco_rs::wrappers::mj_visualization::<type>MjvCamera::<method>frame` for a tracking
   camera: MuJoCo indexes ``subtree_com`` by ``trackbodyid`` after testing only that it is not

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -198,6 +198,13 @@ update of MuJoCo alone can increase the major version.
   the left screen-edge, so the panel no longer needs the keyboard. The ``X`` key still toggles
   it. The panel now slides with an animation when it opens or closes.
 
+*The viewer "Joint" window shows a ball joint and a free joint*
+
+- The "Joint" window of the viewer now lists every joint, and each joint is a collapsible section
+  like an actuator in the "Actuator" window. A ball joint and a free joint show all their position
+  components in one horizontal row, named ``x``, ``y``, ``z`` and ``qw``, ``qx``, ``qy``, ``qz``.
+  The window listed a slide joint and a hinge joint only before.
+
 *New accessors for 3.11.0 fields*
 
 - |mj_model|:
@@ -347,6 +354,13 @@ update of MuJoCo alone can increase the major version.
   MuJoCo fills ``paths`` during the compile step and never reads it back, and it only compares
   ``textureType`` against ``mjtTexture`` variants, so a write can at worst give a wrong asset
   path or wrong rendering, never a memory fault.
+
+.. rubric:: New examples
+
+- :gh-example:`Actuator inputs <visualization/viewer/actuator_inputs.rs>` --- shows the actuator
+  controls of the :ref:`mj_rust_viewer` for every input flavour: actuator types that define no
+  input names, the named multi-input control blocks of a ``pid``, a ``dcmotor`` and an
+  ``orientation`` actuator, an actuator without a name, and an actuator without control inputs.
 
 .. rubric:: Bug fixes
 

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -192,19 +192,17 @@ update of MuJoCo alone can increase the major version.
 
 .. rubric:: New features and improvements
 
-*Viewer-UI side-panel is now natively collapsible*
+*Viewer improvements*
 
 - The viewer's UI side-panel now also opens and closes by a drag of its inner edge to and from
   the left screen-edge, so the panel no longer needs the keyboard. The ``X`` key still toggles
   it. The panel now slides with an animation when it opens or closes.
-
-*The viewer "Joint" window shows a ball joint and a free joint*
-
-- The "Joint" window of the viewer now lists every joint, and each joint is a collapsible section
-  like an actuator in the "Actuator" window. A ball joint and a free joint show all their position
+- The "Joint" window now lists every joint, and each joint is a collapsible section like an
+  actuator in the "Actuator" window. A ball joint and a free joint show all their position
   components in one horizontal row, named ``x``, ``y``, ``z`` and ``qw``, ``qx``, ``qy``, ``qz``.
   The window listed a slide joint and a hinge joint only before.
-
+- A press on the scene now takes the selection away from every viewer window, so no window keeps a
+  highlighted title bar while the pointer works in the scene.
 *New accessors for 3.11.0 fields*
 
 - |mj_model|:

--- a/examples/visualization/viewer/actuator_inputs.rs
+++ b/examples/visualization/viewer/actuator_inputs.rs
@@ -1,0 +1,98 @@
+//! Example of the actuator controls in the viewer UI.
+//! The model holds one actuator of every input flavour: actuators whose type defines no input
+//! names (motor, position), actuators whose control block holds several named inputs (pid,
+//! dcmotor, orientation), an actuator without a name, an actuator without control inputs, and
+//! control ranges that differ between the inputs of one actuator.
+//!
+//! Open the "Actuator" window in the viewer. Each actuator holds one slider for each of its
+//! control inputs, labelled with the input name that MuJoCo reports for the actuator type.
+use std::time::Duration;
+
+use mujoco_rs::viewer::MjViewer;
+use mujoco_rs::prelude::*;
+
+
+const EXAMPLE_MODEL: &str = stringify! {
+<mujoco model="actuator_inputs">
+  <option integrator="implicitfast"/>
+  <statistic center=".25 0 .3" extent="4"/>
+
+  <default>
+    <geom type="capsule" size=".035" rgba=".7 .7 .75 1"/>
+    <joint damping=".2"/>
+  </default>
+
+  <worldbody>
+    <light pos="0 -.6 3" dir="0 .2 -1" diffuse=".8 .8 .8"/>
+    <geom name="floor" type="plane" size="0 0 .05" rgba=".3 .35 .4 1"/>
+
+    <body name="slider" pos="-1.8 0 .4">
+      <joint name="slide" type="slide" axis="1 0 0" range="-.3 .3"/>
+      <geom type="box" size=".05 .05 .05" rgba=".9 .3 .2 1"/>
+    </body>
+
+    <body name="pid_arm" pos="-1 0 .4">
+      <joint name="pid_hinge" type="hinge" axis="0 1 0"/>
+      <geom fromto="0 0 0 0 0 -.25" rgba=".2 .8 .4 1"/>
+    </body>
+
+    <body name="pid_ff_arm" pos="-.3 0 .4">
+      <joint name="pid_ff_hinge" type="hinge" axis="0 1 0"/>
+      <geom fromto="0 0 0 0 0 -.25" rgba=".2 .6 .8 1"/>
+    </body>
+
+    <body name="dcmotor_arm" pos=".4 0 .4">
+      <joint name="dcmotor_hinge" type="hinge" axis="0 1 0"/>
+      <geom fromto="0 0 0 0 0 -.25" rgba=".9 .7 .2 1"/>
+    </body>
+
+    <body name="dcmotor_passive_arm" pos="1.1 0 .4">
+      <joint name="dcmotor_passive_hinge" type="hinge" axis="0 1 0"/>
+      <geom fromto="0 0 0 0 0 -.25" rgba=".6 .4 .8 1"/>
+    </body>
+
+    <body name="expmap_box" pos="1.8 0 .4">
+      <joint name="expmap_ball" type="ball"/>
+      <geom type="box" size=".09 .06 .04" rgba=".8 .5 .3 1"/>
+    </body>
+
+    <body name="quat_box" pos="2.3 0 .4">
+      <joint name="quat_ball" type="ball"/>
+      <geom type="box" size=".09 .06 .04" rgba=".4 .5 .9 1"/>
+    </body>
+  </worldbody>
+
+  <actuator>
+    <motor name="motor_limited" joint="slide" gear="20" ctrlrange="-3 3"/>
+    <motor joint="slide" gear="20"/>
+    <position name="position_servo" joint="pid_hinge" kp="8" ctrlrange="-1.2 1.2"/>
+    <pid name="pid_pos_vel_ff" joint="pid_hinge" kp="8" kv=".5"
+         input="pos vel ff" posrange="-1.2 1.2" velrange="-6 6" ffrange="-2 2"/>
+    <pid name="pid_ff_only" joint="pid_ff_hinge" kp="8" input="ff" ffrange="-4 4"/>
+    <dcmotor name="dcmotor_all" joint="dcmotor_hinge" motorconst="1.0" resistance="1.0"
+             input="pos vel ff voltage" controller="10 0 5" ctrlrange="-5 5"/>
+    <dcmotor name="dcmotor_passive" joint="dcmotor_passive_hinge" motorconst="1.0" resistance="1.0"
+             input="none"/>
+    <orientation name="orientation_expmap" joint="expmap_ball" kp="3" dampratio="1" ctrlrange="-3.1416 3.1416"/>
+    <orientation name="orientation_quat" joint="quat_ball" input="quat" kp="3" dampratio="1" ctrlrange="-1 1"/>
+  </actuator>
+</mujoco>
+};
+
+fn main() {
+    let model = MjModel::from_xml_string(EXAMPLE_MODEL).expect("could not load the model");
+    let mut data = MjData::new(&model);
+    let mut viewer = MjViewer::builder()
+        .max_user_geoms(0)
+        .build_passive(&model).unwrap();
+
+    let timestep = model.opt().timestep;
+    while viewer.running() {
+        data.step();
+        viewer.sync_data(&mut data);
+        viewer.render().unwrap();
+
+        // Sleep for approximately timestep of seconds.
+        std::thread::sleep(Duration::from_secs_f64(timestep));
+    }
+}

--- a/examples/visualization/viewer/actuator_inputs.rs
+++ b/examples/visualization/viewer/actuator_inputs.rs
@@ -1,11 +1,16 @@
-//! Example of the actuator controls in the viewer UI.
+//! Example of the actuator and joint controls in the viewer UI.
 //! The model holds one actuator of every input flavour: actuators whose type defines no input
 //! names (motor, position), actuators whose control block holds several named inputs (pid,
 //! dcmotor, orientation), an actuator without a name, an actuator without control inputs, and
-//! control ranges that differ between the inputs of one actuator.
+//! control ranges that differ between the inputs of one actuator. It also holds a limited ball
+//! joint, an unlimited ball joint and a free joint.
 //!
 //! Open the "Actuator" window in the viewer. Each actuator holds one slider for each of its
 //! control inputs, labelled with the input name that MuJoCo reports for the actuator type.
+//!
+//! Open the "Joint" window in the viewer. Each slider writes one position component of the
+//! joint, and a free joint takes a numeric input for each component. A limited ball joint also
+//! shows its rotation angle against the limit.
 use std::time::Duration;
 
 use mujoco_rs::viewer::MjViewer;
@@ -59,6 +64,16 @@ const EXAMPLE_MODEL: &str = stringify! {
     <body name="quat_box" pos="2.3 0 .4">
       <joint name="quat_ball" type="ball"/>
       <geom type="box" size=".09 .06 .04" rgba=".4 .5 .9 1"/>
+    </body>
+
+    <body name="limited_ball_box" pos="2.8 0 .4">
+      <joint name="limited_ball" type="ball" limited="true" range="0 60"/>
+      <geom type="box" size=".09 .06 .04" rgba=".5 .8 .5 1"/>
+    </body>
+
+    <body name="free_box" pos="3.3 0 .4">
+      <freejoint name="free"/>
+      <geom type="box" size=".06 .06 .06" rgba=".8 .8 .4 1"/>
     </body>
   </worldbody>
 

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -1478,8 +1478,13 @@ impl MjViewer {
                     let is_pressed = state == ElementState::Pressed;
                     
                     #[cfg(feature = "viewer-ui")]
-                    if self.ui.covered() && is_pressed {
-                        continue;
+                    if is_pressed {
+                        if self.ui.covered() {
+                            continue;
+                        }
+
+                        // A press on the scene takes the selection away from the UI windows.
+                        self.ui.deselect_windows();
                     }
 
                     let index = match button {

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -1466,7 +1466,7 @@ impl MjViewer {
 
                 // if the UI has an active input focus, ignore all keyboard events
                 if let WindowEvent::KeyboardInput { .. } = &window_event
-                    && self.ui.focused()
+                    && self.ui.is_focused()
                 {
                     continue;
                 }
@@ -1479,12 +1479,15 @@ impl MjViewer {
                     
                     #[cfg(feature = "viewer-ui")]
                     if is_pressed {
-                        if self.ui.covered() {
-                            continue;
+                        // A press outside the UI windows (scene or side panel) takes the
+                        // selection away from them.
+                        if !self.ui.is_window_covered() {
+                            self.ui.deselect_windows();
                         }
 
-                        // A press on the scene takes the selection away from the UI windows.
-                        self.ui.deselect_windows();
+                        if self.ui.is_covered() {
+                            continue;
+                        }
                     }
 
                     let index = match button {
@@ -1507,7 +1510,7 @@ impl MjViewer {
                     // of a (popup) window. This might seem like an ad-hoc solution, but is at the time the
                     // shortest and most efficient one.
                     #[cfg(feature = "viewer-ui")]
-                    if self.ui.dragged() {
+                    if self.ui.is_dragged() {
                         continue;
                     }
 
@@ -1677,7 +1680,7 @@ impl MjViewer {
                 // Zoom in/out
                 WindowEvent::MouseWheel {delta, ..} => {
                     #[cfg(feature = "viewer-ui")]
-                    if self.ui.covered() {
+                    if self.ui.is_covered() {
                         continue;
                     }
 

--- a/src/viewer/ui.rs
+++ b/src/viewer/ui.rs
@@ -1623,6 +1623,7 @@ impl ViewerUI {
 
             egui::Window::new("Group")
                 .open(&mut self.group_window)
+                .resizable(false)
                 .show(ui, |ui|
             {
                 egui::Grid::new("group_grid").show(ui, |ui| {

--- a/src/viewer/ui.rs
+++ b/src/viewer/ui.rs
@@ -3,6 +3,7 @@
 use std::collections::VecDeque;
 use std::ops::RangeInclusive;
 use std::sync::{Arc, Mutex};
+use std::f64::consts::PI;
 use std::ffi::CString;
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -17,6 +18,7 @@ use egui_winit;
 
 use crate::wrappers::mj_model::{MjModel, MjtObj, MjtJoint, MjtDisableBit, MjtEnableBit};
 use crate::wrappers::mj_visualization::{MjvOption, MjvCamera, MjtCamera, MjvScene};
+use crate::wrappers::fun::{mju_normalize_3, mju_normalize_4, mju_quat_2_vel};
 use crate::viewer::{ViewerSharedState, ViewerStatusBit, MjViewerError};
 use crate::wrappers::mj_primitive::MjtNum;
 use crate::{cast_mut_info, set_flag};
@@ -35,6 +37,7 @@ const BUTTON_ROUNDING: f32 = 50.0;
 const TOGGLE_LABEL_HEIGHT_EXTRA_SPACE: f32 = 20.0;
 const SIDE_PANEL_PAD: f32 = 10.0;
 const MAX_SPAN_WIDTH: f32 = 350.0;
+const JOINT_ANGLE_BAR_WIDTH: f32 = 120.0;
 
 /* Precision and Tolerances */
 const RANGE_PRECISION_TOLERANCE: f32 = 1e-4;
@@ -206,11 +209,14 @@ const ENABLE_FLAGS: &[(&str, MjtEnableBit)] = &[
 ];
 const _: () = assert!(ENABLE_FLAGS.len() == crate::mujoco_c::mjtEnableBit::mjNENABLE as usize);
 
-/// Names of the position components of a free joint, in `qpos` order.
-const FREE_JOINT_COMPONENTS: [&str; 7] = ["x", "y", "z", "qw", "qx", "qy", "qz"];
+/// Names of the translation components of a free joint, in `qpos` order.
+const FREE_JOINT_TRANSLATION_COMPONENTS: [&str; 3] = ["x", "y", "z"];
 
-/// Names of the position components of a ball joint, in `qpos` order.
-const BALL_JOINT_COMPONENTS: [&str; 4] = ["qw", "qx", "qy", "qz"];
+/// Names of the components of a joint quaternion, in `qpos` order.
+const JOINT_QUAT_COMPONENTS: [&str; 4] = ["qw", "qx", "qy", "qz"];
+
+/// Value change per point of pointer travel in the numeric input of a joint component.
+const JOINT_INPUT_DRAG_SPEED: f64 = 0.01;
 
 /// Type alias for a user-provided UI callback function.
 pub(crate) type UiCallback = Box<dyn FnMut(&mut egui::Ui, &Arc<Mutex<ViewerSharedState>>)>;
@@ -220,7 +226,7 @@ struct ActuatorInputDisplayInfo {
     /// Name of the input, or the input index when the actuator type defines no input names and
     /// the actuator has more than one input. [`None`] when the input needs no label.
     label: Option<Cow<'static, str>>,
-    /// Range of the slider: the control range when the control is limited, else -1 to 1.
+    /// Range of the slider: the control range when the model defines one, else -1 to 1.
     range: RangeInclusive<MjtNum>,
 }
 
@@ -238,8 +244,17 @@ struct ActuatorDisplayInfo {
 struct JointComponentDisplayInfo {
     /// Name of the component. [`None`] when the joint holds one component, which needs no label.
     label: Option<&'static str>,
-    /// Range of the component, or [`None`] when the component has no limit.
+    /// Range of the slider of the component, or [`None`] when the component has no natural range
+    /// and takes a numeric input instead.
     range: Option<RangeInclusive<MjtNum>>,
+}
+
+/// Cached display information about the position components of a joint that form a quaternion.
+struct JointQuatDisplayInfo {
+    /// Offset of the quaternion inside the position block of the joint.
+    offset: usize,
+    /// Maximum rotation angle in radians, or [`None`] when the joint has no limit.
+    angle_limit: Option<MjtNum>,
 }
 
 /// Cached display information about one joint.
@@ -250,6 +265,8 @@ struct JointDisplayInfo {
     qpos_start: usize,
     /// Display information of each position component of the joint, in `qpos` order.
     components: Box<[JointComponentDisplayInfo]>,
+    /// The quaternion of a ball or a free joint, [`None`] for a slide or a hinge joint.
+    quat: Option<JointQuatDisplayInfo>,
 }
 
 /// Viewer user interface context.
@@ -338,7 +355,6 @@ impl ViewerUI {
         }).collect();
 
         self.actuator_info = (0..model.nactuator() as usize).map(|idx_actuator| {
-            let input_limited = model.actuator_ctrllimited();
             let input_limits = model.actuator_ctrlrange();
             let ctrl_start = model.actuator_ctrladr()[idx_actuator] as usize;
             let num_inputs = model.actuator_ctrlnum()[idx_actuator] as usize;
@@ -355,12 +371,11 @@ impl ViewerUI {
                         .map(Cow::Borrowed)
                         .or_else(|| (num_inputs > 1).then(|| Cow::Owned(idx_in.to_string())));
 
-                    // The limit arrays hold one entry for each control, not for each actuator.
-                    let idx_ctrl = ctrl_start + idx_in;
-                    let range = if input_limited[idx_ctrl] {
-                        let [low, high] = input_limits[idx_ctrl];
-                        low..=high
-                    } else { -1.0..=1.0 };
+                    // The range array holds one entry for each control, not for each actuator.
+                    // A defined range sets the slider range, even when MuJoCo does not clamp the
+                    // control to it.
+                    let [low, high] = input_limits[ctrl_start + idx_in];
+                    let range = if low < high { low..=high } else { -1.0..=1.0 };
 
                     ActuatorInputDisplayInfo { label, range }
                 }).collect();
@@ -374,25 +389,49 @@ impl ViewerUI {
                 .unwrap_or_else(|| format!("Joint {idx_joint}"));
 
             let qpos_start = model.jnt_qposadr()[idx_joint] as usize;
+            let limits = model.jnt_range()[idx_joint];
 
-            // The limit of a ball or a free joint applies to the rotation angle, not to a single
-            // position component, so a named component shows no range.
-            let named_component = |label| JointComponentDisplayInfo { label: Some(label), range: None };
-            let components = match model.jnt_type()[idx_joint] {
-                MjtJoint::mjJNT_FREE => FREE_JOINT_COMPONENTS.map(named_component).into(),
-                MjtJoint::mjJNT_BALL => BALL_JOINT_COMPONENTS.map(named_component).into(),
+            // The limit of a ball joint applies to the rotation angle, and MuJoCo takes the
+            // maximum of the range as that limit. A zero limit carries no scale for the bar.
+            let angle_limit = model.jnt_limited()[idx_joint]
+                .then(|| limits[0].max(limits[1]))
+                .filter(|limit| *limit > 0.0);
 
-                // A slide or a hinge joint holds one position component, which the limit applies to.
-                _ => {
-                    let range = model.jnt_limited()[idx_joint].then(|| {
-                        let [low, high] = model.jnt_range()[idx_joint];
-                        low..=high
+            let (components, quat) = match model.jnt_type()[idx_joint] {
+                // A free joint holds no limit and no natural range, so each of its components
+                // takes a numeric input.
+                MjtJoint::mjJNT_FREE => {
+                    let components = FREE_JOINT_TRANSLATION_COMPONENTS.into_iter()
+                        .chain(JOINT_QUAT_COMPONENTS)
+                        .map(|label| JointComponentDisplayInfo { label: Some(label), range: None })
+                        .collect();
+
+                    (components, Some(JointQuatDisplayInfo { offset: 3, angle_limit }))
+                }
+
+                // A quaternion component always lies inside the unit sphere.
+                MjtJoint::mjJNT_BALL => {
+                    let components = JOINT_QUAT_COMPONENTS.map(|label| {
+                        JointComponentDisplayInfo { label: Some(label), range: Some(-1.0..=1.0) }
                     });
-                    [JointComponentDisplayInfo { label: None, range }].into()
+
+                    (components.into(), Some(JointQuatDisplayInfo { offset: 0, angle_limit }))
+                }
+
+                // A slide or a hinge joint holds one position component, which the limit applies
+                // to. Without a limit the slider spans the same range as MuJoCo's own viewer.
+                joint_type => {
+                    let range = if model.jnt_limited()[idx_joint] {
+                        limits[0]..=limits[1]
+                    } else if joint_type == MjtJoint::mjJNT_SLIDE {
+                        -1.0..=1.0
+                    } else { -PI..=PI };
+
+                    ([JointComponentDisplayInfo { label: None, range: Some(range) }].into(), None)
                 }
             };
 
-            JointDisplayInfo { name, qpos_start, components }
+            JointDisplayInfo { name, qpos_start, components, quat }
         }).collect();
 
         self.equality_names = (0..model.neq()).map(|i| {
@@ -1463,6 +1502,11 @@ impl ViewerUI {
                 for ActuatorDisplayInfo { name, ctrl_start, inputs } in &self.actuator_info {
                     let actuator_ctrl = &mut ctrl_mut[*ctrl_start..*ctrl_start + inputs.len()];
                     ui.collapsing(RichText::new(name).font(MAIN_FONT), |ui| {
+                        if inputs.is_empty() {
+                            ui.label(RichText::new("no inputs").font(MAIN_FONT));
+                            return;
+                        }
+
                         ui.horizontal(|ui| {
                             for (input, ctrl) in inputs.iter().zip(actuator_ctrl) {
                                 if let Some(label) = &input.label {
@@ -1470,6 +1514,7 @@ impl ViewerUI {
                                 }
                                 ui.add(
                                     egui::Slider::new(ctrl, input.range.clone())
+                                    .clamping(egui::SliderClamping::Never)
                                     .update_while_editing(false)
                                 );
                             }
@@ -1490,30 +1535,67 @@ impl ViewerUI {
                 .open(&mut self.joint_window)
                 .show(ui, |ui|
             {
-                let lock = shared_viewer_state.lock_unpoison();
-                let qpos = lock.data_passive.qpos();
-                for JointDisplayInfo { name, qpos_start, components } in &self.joint_info {
-                    let joint_qpos = &qpos[*qpos_start..*qpos_start + components.len()];
+                let mut lock = shared_viewer_state.lock_unpoison();
+                let qpos = lock.data_passive.qpos_mut();
+                for JointDisplayInfo { name, qpos_start, components, quat } in &self.joint_info {
+                    let joint_qpos = &mut qpos[*qpos_start..*qpos_start + components.len()];
                     ui.collapsing(RichText::new(name).font(MAIN_FONT), |ui| {
+                        let mut edited = false;
                         ui.horizontal(|ui| {
-                            for (component, value) in components.iter().zip(joint_qpos) {
+                            for (component, value) in components.iter().zip(joint_qpos.iter_mut()) {
                                 if let Some(label) = component.label {
                                     ui.label(RichText::new(label).font(MAIN_FONT));
                                 }
 
-                                let mut value = *value;
-                                ui.add_enabled(false, egui::DragValue::new(&mut value));
+                                // A slider must not clamp: the simulation reaches values outside
+                                // the range, for example a hinge that turns past pi.
+                                edited |= match &component.range {
+                                    Some(range) => ui.add(
+                                        egui::Slider::new(value, range.clone())
+                                        .clamping(egui::SliderClamping::Never)
+                                        .update_while_editing(false)
+                                    ),
 
-                                if let Some(range) = &component.range {
-                                    let (low, high) = (*range.start(), *range.end());
-                                    let value_scaled = ((value - low) / (high - low)).clamp(0.0, 1.0);
-                                    ui.add(egui::ProgressBar::new(value_scaled as f32));
-                                }
-                                else {
-                                    ui.label("no limit");
-                                }
+                                    None => ui.add(
+                                        egui::DragValue::new(value)
+                                        .speed(JOINT_INPUT_DRAG_SPEED)
+                                        .update_while_editing(false)
+                                    )
+                                }.changed();
                             }
                         });
+
+                        // Only a ball or a free joint holds a quaternion.
+                        if let Some(JointQuatDisplayInfo { offset, angle_limit }) = quat
+                            && let Some(joint_quat) = joint_qpos[*offset..].first_chunk_mut::<4>()
+                        {
+                            // A slider moves one component alone, which takes the quaternion off
+                            // the unit sphere.
+                            if edited {
+                                mju_normalize_4(joint_quat);
+                            }
+
+                            // The limit of a ball joint applies to the rotation angle, so the
+                            // angle needs a row of its own.
+                            if let Some(limit) = angle_limit {
+                                let mut angle_axis = [0.0; 3];
+                                mju_quat_2_vel(&mut angle_axis, joint_quat, 1.0);
+                                let mut angle = mju_normalize_3(&mut angle_axis);
+
+                                ui.horizontal(|ui| {
+                                    ui.label(RichText::new("angle").font(MAIN_FONT));
+                                    ui.add_enabled(
+                                        false,
+                                        egui::DragValue::new(&mut angle).suffix(" rad")
+                                    );
+                                    let angle_scaled = (angle / limit).clamp(0.0, 1.0);
+                                    ui.add(
+                                        egui::ProgressBar::new(angle_scaled as f32)
+                                        .desired_width(JOINT_ANGLE_BAR_WIDTH)
+                                    );
+                                });
+                            }
+                        }
                     });
                 }
             });

--- a/src/viewer/ui.rs
+++ b/src/viewer/ui.rs
@@ -1,8 +1,10 @@
 //! Implementation of the interface for use in the viewer.
 
 use std::collections::VecDeque;
+use std::ops::RangeInclusive;
 use std::sync::{Arc, Mutex};
 use std::ffi::CString;
+use std::borrow::Cow;
 use std::fmt::Debug;
 
 use glutin::display::{Display, GlDisplay};
@@ -204,8 +206,51 @@ const ENABLE_FLAGS: &[(&str, MjtEnableBit)] = &[
 ];
 const _: () = assert!(ENABLE_FLAGS.len() == crate::mujoco_c::mjtEnableBit::mjNENABLE as usize);
 
+/// Names of the position components of a free joint, in `qpos` order.
+const FREE_JOINT_COMPONENTS: [&str; 7] = ["x", "y", "z", "qw", "qx", "qy", "qz"];
+
+/// Names of the position components of a ball joint, in `qpos` order.
+const BALL_JOINT_COMPONENTS: [&str; 4] = ["qw", "qx", "qy", "qz"];
+
 /// Type alias for a user-provided UI callback function.
 pub(crate) type UiCallback = Box<dyn FnMut(&mut egui::Ui, &Arc<Mutex<ViewerSharedState>>)>;
+
+/// Cached display information about one input (one control) of an actuator.
+struct ActuatorInputDisplayInfo {
+    /// Name of the input, or the input index when the actuator type defines no input names and
+    /// the actuator has more than one input. [`None`] when the input needs no label.
+    label: Option<Cow<'static, str>>,
+    /// Range of the slider: the control range when the control is limited, else -1 to 1.
+    range: RangeInclusive<MjtNum>,
+}
+
+/// Cached display information about one actuator.
+struct ActuatorDisplayInfo {
+    /// Name of the actuator, or a generated name when the model defines none.
+    name: String,
+    /// Address of the first control of the actuator inside `ctrl`.
+    ctrl_start: usize,
+    /// Display information of each input of the actuator, in control order.
+    inputs: Box<[ActuatorInputDisplayInfo]>,
+}
+
+/// Cached display information about one position component (one `qpos` entry) of a joint.
+struct JointComponentDisplayInfo {
+    /// Name of the component. [`None`] when the joint holds one component, which needs no label.
+    label: Option<&'static str>,
+    /// Range of the component, or [`None`] when the component has no limit.
+    range: Option<RangeInclusive<MjtNum>>,
+}
+
+/// Cached display information about one joint.
+struct JointDisplayInfo {
+    /// Name of the joint, or a generated name when the model defines none.
+    name: String,
+    /// Address of the first position component of the joint inside `qpos`.
+    qpos_start: usize,
+    /// Display information of each position component of the joint, in `qpos` order.
+    components: Box<[JointComponentDisplayInfo]>,
+}
 
 /// Viewer user interface context.
 pub(crate) struct ViewerUI {
@@ -215,8 +260,8 @@ pub(crate) struct ViewerUI {
     gl: Arc<egui_glow::glow::Context>,
     events: VecDeque<UiEvent>,
     camera_names: Vec<String>,
-    actuator_display_info: Vec<(String, bool, [MjtNum; 2])>,
-    joint_display_info: Vec<(String, bool, [MjtNum; 2], usize)>,
+    actuator_info: Vec<ActuatorDisplayInfo>,
+    joint_info: Vec<JointDisplayInfo>,
     equality_names: Vec<String>,
     user_ui_callbacks: Vec<UiCallback>,
 
@@ -265,8 +310,8 @@ impl ViewerUI {
         let mut viewer_ui = Self {
             egui_ctx, state, painter, gl, events: VecDeque::new(),
             camera_names: Vec::new(),
-            actuator_display_info: Vec::new(),
-            joint_display_info: Vec::new(),
+            actuator_info: Vec::new(),
+            joint_info: Vec::new(),
             equality_names: Vec::new(),
             user_ui_callbacks: Vec::new(),
             actuator_window: false,
@@ -292,42 +337,62 @@ impl ViewerUI {
             } else { format!("Camera {i}") }
         }).collect();
 
-        self.actuator_display_info = (0..model.nu()).map(|i| {
-            let idx = i as usize;
-            // Map the control index to its owning actuator: MIMO actuators own
-            // actuator_ctrlnum() consecutive controls starting at actuator_ctrladr(),
-            // so control and actuator indices no longer coincide.
-            let (act, sub) = (0..model.nactuator() as usize).find_map(|a| {
-                let start = model.actuator_ctrladr()[a] as usize;
-                (start..start + model.actuator_ctrlnum()[a] as usize)
-                    .contains(&idx)
-                    .then_some((a, idx - start))
-            }).unwrap_or((idx, 0));
-            let base = if let Some(name) = model.id_to_name(MjtObj::mjOBJ_ACTUATOR, act) {
-                name.to_string()
-            } else { format!("Actuator {act}") };
-            let name = if model.actuator_ctrlnum()[act] > 1 {
-                format!("{base}[{sub}]")
-            } else { base };
-            let limited = model.actuator_ctrllimited()[idx];
-            let range   = model.actuator_ctrlrange()[idx];
-            (name, limited, range)
+        self.actuator_info = (0..model.nactuator() as usize).map(|idx_actuator| {
+            let input_limited = model.actuator_ctrllimited();
+            let input_limits = model.actuator_ctrlrange();
+            let ctrl_start = model.actuator_ctrladr()[idx_actuator] as usize;
+            let num_inputs = model.actuator_ctrlnum()[idx_actuator] as usize;
+
+            let name = model.id_to_name(MjtObj::mjOBJ_ACTUATOR, idx_actuator)
+                .map(|name| name.to_string())
+                .unwrap_or_else(|| format!("Actuator {idx_actuator}"));
+
+            let inputs = (0..num_inputs)
+                .map(|idx_in| {
+                    // Most actuator types define no input names. An actuator with more than one
+                    // input then shows the input index, an actuator with one input shows no label.
+                    let label = model.actuator_input_name(idx_actuator, idx_in)
+                        .map(Cow::Borrowed)
+                        .or_else(|| (num_inputs > 1).then(|| Cow::Owned(idx_in.to_string())));
+
+                    // The limit arrays hold one entry for each control, not for each actuator.
+                    let idx_ctrl = ctrl_start + idx_in;
+                    let range = if input_limited[idx_ctrl] {
+                        let [low, high] = input_limits[idx_ctrl];
+                        low..=high
+                    } else { -1.0..=1.0 };
+
+                    ActuatorInputDisplayInfo { label, range }
+                }).collect();
+
+            ActuatorDisplayInfo { name, ctrl_start, inputs }
         }).collect();
 
-        self.joint_display_info = (0..model.njnt()).filter_map(|i| {
-            let idx = i as usize;
-            match model.jnt_type()[idx] {
-                MjtJoint::mjJNT_SLIDE | MjtJoint::mjJNT_HINGE => {
-                    let name = if let Some(name) = model.id_to_name(MjtObj::mjOBJ_JOINT, idx) {
-                        name.to_string()
-                    } else { format!("Joint {i}") };
-                    let limited  = model.jnt_limited()[idx];
-                    let range    = model.jnt_range()[idx];
-                    let qpos_adr = model.jnt_qposadr()[idx] as usize;
-                    Some((name, limited, range, qpos_adr))
+        self.joint_info = (0..model.njnt() as usize).map(|idx_joint| {
+            let name = model.id_to_name(MjtObj::mjOBJ_JOINT, idx_joint)
+                .map(|name| name.to_string())
+                .unwrap_or_else(|| format!("Joint {idx_joint}"));
+
+            let qpos_start = model.jnt_qposadr()[idx_joint] as usize;
+
+            // The limit of a ball or a free joint applies to the rotation angle, not to a single
+            // position component, so a named component shows no range.
+            let named_component = |label| JointComponentDisplayInfo { label: Some(label), range: None };
+            let components = match model.jnt_type()[idx_joint] {
+                MjtJoint::mjJNT_FREE => FREE_JOINT_COMPONENTS.map(named_component).into(),
+                MjtJoint::mjJNT_BALL => BALL_JOINT_COMPONENTS.map(named_component).into(),
+
+                // A slide or a hinge joint holds one position component, which the limit applies to.
+                _ => {
+                    let range = model.jnt_limited()[idx_joint].then(|| {
+                        let [low, high] = model.jnt_range()[idx_joint];
+                        low..=high
+                    });
+                    [JointComponentDisplayInfo { label: None, range }].into()
                 }
-                _ => None
-            }
+            };
+
+            JointDisplayInfo { name, qpos_start, components }
         }).collect();
 
         self.equality_names = (0..model.neq()).map(|i| {
@@ -1384,32 +1449,33 @@ impl ViewerUI {
             // Controls window
             egui::Window::new("Actuator")
                 .scroll(true)
+                .drag_to_scroll(egui::scroll_area::DragScroll::Always)
                 .open(&mut self.actuator_window)
                 .show(ui, |ui|
             {
                 let mut lock = shared_viewer_state.lock_unpoison();
                 let ctrl_mut = lock.data_passive.ctrl_mut();
-                egui::Grid::new("ctrl_grid").show(ui, |ui| {
-                    debug_assert_eq!(
-                        self.actuator_display_info.len(), ctrl_mut.len(),
-                        "actuator names don't match num of actuators in model. This is a bug!"
-                    );
-                    for ((name, limited, range), ctrl) in self.actuator_display_info.iter()
-                        .zip(ctrl_mut.iter_mut())
-                    {
-                        ui.label(RichText::new(name).font(MAIN_FONT));
-
-                        let range_inc = if *limited {
-                            range[0]..=range[1]
-                        } else { -1.0..=1.0 };
-
-                        ui.add(
-                            egui::Slider::new(ctrl, range_inc)
-                            .update_while_editing(false)
-                        );
-                        ui.end_row();
-                    }
-                });
+                debug_assert_eq!(
+                    self.actuator_info.iter().map(|info| info.inputs.len()).sum::<usize>(),
+                    ctrl_mut.len(),
+                    "actuator inputs don't match num of controls in model. This is a bug!"
+                );
+                for ActuatorDisplayInfo { name, ctrl_start, inputs } in &self.actuator_info {
+                    let actuator_ctrl = &mut ctrl_mut[*ctrl_start..*ctrl_start + inputs.len()];
+                    ui.collapsing(RichText::new(name).font(MAIN_FONT), |ui| {
+                        ui.horizontal(|ui| {
+                            for (input, ctrl) in inputs.iter().zip(actuator_ctrl) {
+                                if let Some(label) = &input.label {
+                                    ui.label(RichText::new(&**label).font(MAIN_FONT));
+                                }
+                                ui.add(
+                                    egui::Slider::new(ctrl, input.range.clone())
+                                    .update_while_editing(false)
+                                );
+                            }
+                        });
+                    });
+                }
 
                 // Clear all actuator controls by setting them to 0
                 if ui.button(RichText::new("Clear").font(MAIN_FONT)).clicked() {
@@ -1420,35 +1486,42 @@ impl ViewerUI {
             // Joints window
             egui::Window::new("Joint")
                 .scroll(true)
+                .drag_to_scroll(egui::scroll_area::DragScroll::Always)
                 .open(&mut self.joint_window)
                 .show(ui, |ui|
             {
-                egui::Grid::new("joint_grid").show(ui, |ui| {
-                    let lock = shared_viewer_state.lock_unpoison();
-                    let qpos = lock.data_passive.qpos();
-                    for (name, limited, range, qpos_adr) in &self.joint_display_info
-                    {
-                        ui.label(RichText::new(name).font(MAIN_FONT));
-                        let mut value = qpos[*qpos_adr];
-                        ui.add_enabled(false, egui::DragValue::new(&mut value));
+                let lock = shared_viewer_state.lock_unpoison();
+                let qpos = lock.data_passive.qpos();
+                for JointDisplayInfo { name, qpos_start, components } in &self.joint_info {
+                    let joint_qpos = &qpos[*qpos_start..*qpos_start + components.len()];
+                    ui.collapsing(RichText::new(name).font(MAIN_FONT), |ui| {
+                        ui.horizontal(|ui| {
+                            for (component, value) in components.iter().zip(joint_qpos) {
+                                if let Some(label) = component.label {
+                                    ui.label(RichText::new(label).font(MAIN_FONT));
+                                }
 
-                        if *limited {
-                            let [low, high] = *range;
-                            let value_scaled = ((value - low) / (high - low)).clamp(0.0, 1.0);
-                            ui.add(egui::ProgressBar::new(value_scaled as f32));
-                        }
-                        else {
-                            ui.label("no limit");
-                        }
+                                let mut value = *value;
+                                ui.add_enabled(false, egui::DragValue::new(&mut value));
 
-                        ui.end_row();
-                    }
-                });
+                                if let Some(range) = &component.range {
+                                    let (low, high) = (*range.start(), *range.end());
+                                    let value_scaled = ((value - low) / (high - low)).clamp(0.0, 1.0);
+                                    ui.add(egui::ProgressBar::new(value_scaled as f32));
+                                }
+                                else {
+                                    ui.label("no limit");
+                                }
+                            }
+                        });
+                    });
+                }
             });
 
             // Equalities window
             egui::Window::new("Equality")
                 .scroll(true)
+                .drag_to_scroll(egui::scroll_area::DragScroll::Always)
                 .open(&mut self.equality_window)
                 .show(ui, |ui|
             {

--- a/src/viewer/ui.rs
+++ b/src/viewer/ui.rs
@@ -1734,17 +1734,27 @@ impl ViewerUI {
     }
 
     /// Checks whether the UI is focused (e.g., typing).
-    pub(crate) fn focused(&self) -> bool {
+    pub(crate) fn is_focused(&self) -> bool {
         self.egui_ctx.memory(|ui| ui.focused().is_some())
     }
 
     /// Checks whether the mouse is over the UI.
-    pub(crate) fn covered(&self) -> bool {
+    pub(crate) fn is_covered(&self) -> bool {
         self.egui_ctx.is_pointer_over_egui()
     }
 
+    /// Checks whether the mouse is over one of UI's windows (side panels do not count).
+    pub(crate) fn is_window_covered(&self) -> bool {
+        let Some(position) = self.egui_ctx.pointer_interact_pos() else {
+            return false;
+        };
+
+        // The side panels share the background layer with the scene; windows and popups do not.
+        self.egui_ctx.layer_id_at(position).is_some_and(|layer| layer.order != Order::Background)
+    }
+
     /// Checks whether the UI is currently being dragged.
-    pub(crate) fn dragged(&self) -> bool {
+    pub(crate) fn is_dragged(&self) -> bool {
         self.egui_ctx.dragged_id().is_some()
     }
 

--- a/src/viewer/ui.rs
+++ b/src/viewer/ui.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 use glutin::display::{Display, GlDisplay};
 use egui_winit::winit::event::WindowEvent;
 use egui_glow::glow::{self, HasContext};
-use egui::{FontId, RichText, Id};
+use egui::{FontId, RichText, LayerId, Order, Id};
 use egui_winit::winit::window::Window;
 use egui_winit::egui;
 use egui_winit;
@@ -1664,6 +1664,12 @@ impl ViewerUI {
     /// Checks whether the UI is currently being dragged.
     pub(crate) fn dragged(&self) -> bool {
         self.egui_ctx.dragged_id().is_some()
+    }
+
+    /// Takes the selection away from every UI window.
+    pub(crate) fn deselect_windows(&self) {
+        let scene_layer = LayerId::new(Order::Middle, Id::new("mujoco_scene"));
+        self.egui_ctx.memory_mut(|memory| memory.areas_mut().move_to_top(scene_layer));
     }
 
     /// Prepares OpenGL for drawing 2D overlays.

--- a/src/wrappers/mj_model.rs
+++ b/src/wrappers/mj_model.rs
@@ -869,6 +869,21 @@ impl MjModel {
         ) as u32 })
     }
 
+    /// Determine the name for the actuator input. For example, an orientation servo will return
+    /// "rx" for `input_idx = 0` when its actuator_ctrlspec is not quaternion.
+    /// Wraps [`mj_actuatorInputName`].
+    /// # Returns
+    /// [`Some`] with a static string when the actuator type defines a name for the input.
+    /// [`None`] when the type defines no input names, or when `id` or `input_idx` is out of range.
+    pub fn actuator_input_name(&self, id: usize, input_idx: usize) -> Option<&'static str> {
+        // SAFETY: id and input_idx are checked inside the function. When c_ptr is not null, it is
+        // always an ASCII static C string constant.
+        unsafe {
+            let c_ptr = mj_actuatorInputName(self.ffi(), id as i32, input_idx as i32);
+            (!c_ptr.is_null()).then(|| CStr::from_ptr(c_ptr).to_str().unwrap())
+        }
+    }
+
     /* FFI */
     /// Returns a reference to the wrapped FFI struct.
     pub fn ffi(&self) -> &mjModel {

--- a/src/wrappers/mj_model.rs
+++ b/src/wrappers/mj_model.rs
@@ -869,17 +869,20 @@ impl MjModel {
         ) as u32 })
     }
 
-    /// Determine the name for the actuator input. For example, an orientation servo will return
-    /// "rx" for `input_idx = 0` when its actuator_ctrlspec is not quaternion.
+    /// Returns the name that the type of actuator `id` gives to its control input `input`, an
+    /// index into the control block of the actuator. For example, an orientation servo on the
+    /// exponential-map chart names its first input `"rx"`.
     /// Wraps [`mj_actuatorInputName`].
     /// # Returns
-    /// [`Some`] with a static string when the actuator type defines a name for the input.
-    /// [`None`] when the type defines no input names, or when `id` or `input_idx` is out of range.
-    pub fn actuator_input_name(&self, id: usize, input_idx: usize) -> Option<&'static str> {
-        // SAFETY: id and input_idx are checked inside the function. When c_ptr is not null, it is
-        // always an ASCII static C string constant.
+    /// [`None`] when the actuator type defines no input names, or when `id` or `input` is out of
+    /// range.
+    /// # Panics
+    /// Panics if the reported name is not valid UTF-8.
+    pub fn actuator_input_name(&self, id: usize, input: usize) -> Option<&'static str> {
+        // SAFETY: id and input are checked inside the function. When c_ptr is not null, it is
+        // always an ASCII static C string constant, so the UTF-8 check cannot fail.
         unsafe {
-            let c_ptr = mj_actuatorInputName(self.ffi(), id as i32, input_idx as i32);
+            let c_ptr = mj_actuatorInputName(self.ffi(), id as i32, input as i32);
             (!c_ptr.is_null()).then(|| CStr::from_ptr(c_ptr).to_str().unwrap())
         }
     }


### PR DESCRIPTION
Upgrades the viewer's UI such that the actuator and joint windows are grouped by actuator and joint. This is done via collapsibles, which contain multiple controls per actuator input and per joint DOFs.