### PR TITLE
Fix model-editing soundness around C code

### DIFF
--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -23,7 +23,6 @@ Changelog
 
 
 This page contains the summary of changes made throughout different releases of the MuJoCo-rs crate.
-Only the last 5 major/minor versions are shown in detail.
 
 Versioning
 =================

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -19,6 +19,7 @@ Changelog
 .. |mjr_context| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext`
 .. |mjs_light| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsLight`
 .. |mjs_actuator| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsActuator`
+.. |mjs_plugin| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsPlugin`
 
 
 This page contains the summary of changes made throughout different releases of the MuJoCo-rs crate.

--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -7,22 +7,22 @@ Changelog
 .. |mj_data| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData`
 .. |mj_model| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel`
 .. |mj_spec| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec`
-.. |mjs_body| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsBody`
-.. |mjs_frame| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsFrame`
+.. |mjs_body| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsBody`
+.. |mjs_frame| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsFrame`
 .. |mj_geomview| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjGeomDataView`
 .. |mj_geomviewmut| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjGeomDataViewMut`
 .. |mjv_scene| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_visualization::<struct>MjvScene`
 .. |mj_vfs| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_auxiliary::<struct>MjVfs`
-.. |mjs_tendon| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsTendon`
-.. |mjs_wrap| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsWrap`
+.. |mjs_tendon| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsTendon`
+.. |mjs_wrap| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsWrap`
 .. |mjv_camera| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_visualization::<type>MjvCamera`
 .. |mjr_context| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext`
-.. |mjs_light| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsLight`
-.. |mjs_actuator| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator`
+.. |mjs_light| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsLight`
+.. |mjs_actuator| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsActuator`
 
 
 This page contains the summary of changes made throughout different releases of the MuJoCo-rs crate.
-Ony the last 5 major/minor versions are shown in detail.
+Only the last 5 major/minor versions are shown in detail.
 
 Versioning
 =================

--- a/docs/guide/source/changelog/3.0.x.rst.inc
+++ b/docs/guide/source/changelog/3.0.x.rst.inc
@@ -290,7 +290,7 @@ gained new variants. See `Error handling`_ below for the full method list.
   (tri-state: ``FALSE`` / ``TRUE`` / ``AUTO``) instead of ``bool``, matching the
   C ``mjtLimited`` semantics.
 
-- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTexture::<method>set_data`
+- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTexture::<method>set_data`
   now requires ``T: bytemuck::NoUninit``.
 
 *New* ``unsafe`` *requirements*
@@ -576,16 +576,16 @@ The six new enums (all ``#[non_exhaustive]``) have the following variants:
   types (the fields existed in MuJoCo 3.3.7 but were not previously accessible
   via per-object view types).
 - ``MjsMaterial``:
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsMaterial::<method>set_texture` /
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsMaterial::<method>with_texture`
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsMaterial::<method>set_texture` /
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsMaterial::<method>with_texture`
   set a texture name by
   :docs-rs:`~mujoco_rs::wrappers::mj_model::<type>MjtTextureRole`, correctly targeting the
   pre-sized slot the MuJoCo renderer reads (e.g. ``mjTEXROLE_RGB``).
   The existing ``set_textures`` / ``append_textures`` methods are retained but
   should generally be avoided for role-indexed vectors.
 - ``MjsTexture``:
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTexture::<method>set_cubefile` /
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTexture::<method>with_cubefile`
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTexture::<method>set_cubefile` /
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTexture::<method>with_cubefile`
   set a cube-map face file by
   :docs-rs:`~mujoco_rs::wrappers::mj_model::<enum>MjtCubeFace`.
   The existing ``set_cubefiles`` / ``append_cubefiles`` methods are retained.

--- a/docs/guide/source/changelog/4.0.x.rst.inc
+++ b/docs/guide/source/changelog/4.0.x.rst.inc
@@ -28,7 +28,7 @@
 
 *Model-editing wrappers now expose polynomial stiffness and damping coefficients*
 
-- :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsJoint`:
+- :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsJoint`:
   ``stiffness`` and ``damping`` now expose coefficient arrays
   instead of scalar ``f64`` values.
 - |mjs_tendon|:
@@ -63,7 +63,7 @@
 - Updated FFI bindings and wrappers to match MuJoCo 3.8.0 headers.
 - |mj_model| now exposes the new joint, dof, tendon, and actuator coefficient
   arrays and actuator-linkage fields added in newer MuJoCo releases.
-  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator` now exposes its
+  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsActuator` now exposes its
   ``damping`` coefficient array and ``armature`` field.
 - :docs-rs:`~mujoco_rs::wrappers::mj_model::<type>MjtLRMode` is now exported for
   typed access to ``MjLROpt.mode``.

--- a/docs/guide/source/changelog/5.0.x.rst.inc
+++ b/docs/guide/source/changelog/5.0.x.rst.inc
@@ -61,22 +61,22 @@
 
 *MjsTuple::set_objtype now takes ``&[MjtObj]`` and is fallible*
 
-- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTuple::<method>set_objtype` now accepts
+- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTuple::<method>set_objtype` now accepts
   ``&[MjtObj]`` instead of ``&[i32]`` and is a **safe** ``fn`` returning ``Result<(), MjEditError>``
   instead of ``()``. Out-of-range object types are rejected with ``MjEditError::InvalidParameter``.
   See the migration guide.
 
 *MjsSensor::set_objtype / set_reftype are now fallible*
 
-- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsSensor::<method>set_objtype` and
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsSensor::<method>set_reftype` now return
+- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsSensor::<method>set_objtype` and
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsSensor::<method>set_reftype` now return
   ``Result<(), MjEditError>`` instead of ``()``, rejecting out-of-range object types with
   ``MjEditError::InvalidParameter``. The builder counterparts ``with_objtype`` / ``with_reftype``
   keep their signature but **panic** on a rejected value. See the migration guide.
 
 *MjsNumeric::set_size is now fallible*
 
-- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsNumeric::<method>set_size` now returns
+- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsNumeric::<method>set_size` now returns
   ``Result<(), MjEditError>`` instead of ``()``, rejecting a negative size with
   ``MjEditError::InvalidParameter`` (a negative size triggers an out-of-bounds write in the model
   compiler). See the migration guide.
@@ -202,8 +202,8 @@ New error variants in pre-existing enums:
 
 *Fallible tendon wrap accessors*
 
-- Added :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTendon::<method>try_wrap` and
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTendon::<method>try_wrap_mut`, the fallible
+- Added :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTendon::<method>try_wrap` and
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTendon::<method>try_wrap_mut`, the fallible
   counterparts of ``wrap`` / ``wrap_mut``. They return
   ``Result<&MjsWrap, MjEditError>`` and yield ``MjEditError::IndexOutOfBounds`` for an out-of-range
   index instead of panicking. A new
@@ -268,8 +268,8 @@ runtime.
 
   - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>timer`
     for CTIMER values.
-  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsBody::<method>child` and
-    :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsBody::<method>child_mut`
+  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>child` and
+    :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>child_mut`
     for named child lookup.
   - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>id`
     for retrieving optional element IDs.
@@ -280,7 +280,7 @@ runtime.
 - Added the missing frame-finding methods to |mj_spec|: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>frame`
   and :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>frame_mut`.
 
-- :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator` now exposes the full family of
+- :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsActuator` now exposes the full family of
   actuator-configuration helpers covering MuJoCo's ``mjs_setToX`` C API: ``set_to_motor``,
   ``set_to_position``, ``set_to_int_velocity``, ``set_to_velocity``, ``set_to_damper``,
   ``set_to_cylinder``, ``set_to_muscle``, ``set_to_adhesion``, and ``set_to_dc_motor``. Helpers

--- a/docs/guide/source/changelog/6.0.x.rst.inc
+++ b/docs/guide/source/changelog/6.0.x.rst.inc
@@ -188,6 +188,25 @@
   handle to a ``mujoco_c`` function needs an edit, see :ref:`migrate_6_0_0`. ``std::mem::swap`` on
   two handles used to exchange the contents of two elements; it now exchanges nothing.
 
+|mj_spec| *is no longer* ``Send``
+
+- A model that attaches another model keeps the child specification shared between a spec and every
+  clone of it, behind a reference count that MuJoCo does not synchronize.
+
+|mjs_wrap| *lost* ``side_site_mut``
+
+- Two wraps, that name one site, each handed out a mutable reference to it.
+  The shared :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsWrap::<method>side_site` is not removed.
+  Mutable references to sites are available through
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>site_mut`, see
+  :ref:`migrate_6_0_0`.
+
+|mjs_plugin| *no longer stands for the plugin that an element embeds*
+
+- The ``plugin`` and ``plugin_mut`` accessors of a body, geom, mesh, actuator and sensor now hand
+  out :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsPluginReference` :sup:`new`.
+  See :ref:`migrate_6_0_0`.
+
 .. rubric:: New dependencies
 
 - Added `log <https://docs.rs/log/0.4.34/log/>`__ as a mandatory dependency.
@@ -519,6 +538,10 @@
   carries no name of its own:
   :docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>name` reports the wrapped
   object's name.
+- Closed a heap over-read reachable from safe code in
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>compile`. It now rejects a
+  texture whose ``nchannel``, ``width`` or ``height`` is negative, and one whose
+  ``nchannel * width * height`` product does not fit in an ``i32``.
 
 *Utility functions*
 

--- a/docs/guide/source/changelog/6.0.x.rst.inc
+++ b/docs/guide/source/changelog/6.0.x.rst.inc
@@ -38,8 +38,7 @@
 *MuJoCo FFI upgraded to 3.12.0*
 
 - MuJoCo-rs now builds against MuJoCo 3.12.0 FFI, which rolls up the upstream 3.10.0,
-  3.11.0 and 3.12.0 releases. This is a breaking dependency-level change for consumers
-  tied to older MuJoCo C ABI details.
+  3.11.0 and 3.12.0 releases.
   This directly affects all the wrappers, separate changelog will not be provided.
   See MuJoCo's changelog for this release:
   https://mujoco.readthedocs.io/en/3.12.0/changelog.html
@@ -90,9 +89,8 @@
 
 *Relaxed* |mj_data| ``body_awake`` *view mutability*
 
-- The body views now hold ``awake`` as a :docs-rs:`~mujoco_rs::util::<struct>PointerViewMut`, which
-  matches the array accessor, already safe to mutate. Code that wrote through ``as_mut_slice`` must
-  drop the call and the surrounding ``unsafe``.
+- The body views now hold ``awake`` as a :docs-rs:`~mujoco_rs::util::<struct>PointerViewMut`. Code
+  that wrote through ``as_mut_slice`` must drop the call and the surrounding ``unsafe``.
 
 ``SpecItem::default`` *returns an* ``Option``
 
@@ -182,8 +180,7 @@
 
 - Every ``Mjs*`` element handle is now an opaque, zero-sized struct instead of an alias for the
   matching ``mujoco_c`` struct; |mjs_body| and
-  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsDefault` are examples. A handle still
-  travels only as ``&MjsX`` or ``&mut MjsX``, so wrapper code needs no change. It exposes its FFI
+  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsDefault` are examples. It exposes its FFI
   struct through ``ffi`` for reading and ``unsafe fn ffi_mut`` for writing, so code that hands a
   handle to a ``mujoco_c`` function needs an edit, see :ref:`migrate_6_0_0`. ``std::mem::swap`` on
   two handles used to exchange the contents of two elements; it now exchanges nothing.
@@ -195,8 +192,7 @@
 
 |mjs_wrap| *lost* ``side_site_mut``
 
-- Two wraps, that name one site, each handed out a mutable reference to it.
-  The shared :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsWrap::<method>side_site` is not removed.
+- The shared :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsWrap::<method>side_site` is not removed.
   Mutable references to sites are available through
   :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>site_mut`, see
   :ref:`migrate_6_0_0`.
@@ -251,9 +247,7 @@
 
 - :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>is_compatible_with_model`
   :sup:`new` reports whether another |mj_model| can take the place of this one in an |mj_data| or
-  in a cached ``Info``. It compares the structure of the two models: the per-element tables and
-  types that place each element inside a packed array and fix what its state means, plus every
-  size that no table already determines.
+  in a cached ``Info``.
 - :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>is_asset_compatible_with_model`
   :sup:`new` is the weaker test the asset-upload methods need: it compares the mesh, texture and
   heightfield memory alone.
@@ -264,10 +258,8 @@
   holds. Use them to decide whether a scene needs to be rebuilt before an update or a merge.
 - Every ``Info`` gained an ``update_layout`` method, for example
   :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjBodyDataInfo::<method>update_layout`
-  :sup:`new`. After a model swap an ``Info`` compares the whole cached layout on every view; call
-  ``update_layout`` once against the new |mj_data| or |mj_model| to make that test a pointer
-  comparison again. It reports the same error as a view method when the new model is not
-  compatible.
+  :sup:`new`. Call ``update_layout`` once against the new |mj_data| or |mj_model| after a model
+  swap. It reports the same error as a view method when the new model is not compatible.
 
 *Viewer improvements*
 
@@ -275,9 +267,8 @@
   the left screen-edge, so the panel no longer needs the keyboard. The ``X`` key still toggles
   it. The panel now slides with an animation when it opens or closes.
 - The "Joint" window now lists every joint, and each joint is a collapsible section like an
-  actuator in the "Actuator" window. A ball joint and a free joint show all their position
-  components in one horizontal row, named ``x``, ``y``, ``z`` and ``qw``, ``qx``, ``qy``, ``qz``.
-  The window listed a slide joint and a hinge joint only before.
+  actuator in the "Actuator" window. The window listed a slide joint and a hinge joint only
+  before.
 - Each component of the "Joint" window now writes ``qpos``, so the window moves the model. The
   window was read-only before. A limited joint gets the joint limit as its slider range. Without
   a limit, a slide joint spans -1 to 1 and a hinge joint spans -pi to pi, as in MuJoCo's own
@@ -509,12 +500,9 @@
   the scene was created for.
 - :docs-rs:`~~mujoco_rs::wrappers::mj_visualization::<struct>MjvScene::<method>create_geom` now
   writes every field that :docs-rs:`~mujoco_rs::mujoco_c::<fn>mjv_initGeom` leaves unwritten over
-  uninitialized memory: ``objtype`` becomes
-  :docs-rs:`~mujoco_rs::wrappers::mj_model::<type>MjtObj::<variant>mjOBJ_UNKNOWN`, ``objid``
-  becomes ``-1``, ``category`` becomes
-  :docs-rs:`~mujoco_rs::wrappers::mj_visualization::<type>MjtCatBit::<variant>mjCAT_DECOR`,
-  ``segid`` becomes the geom's own index, and ``label``, ``camdist`` and ``transparent`` are
-  cleared. A ``mjCAT_DECOR`` geom casts no shadow.
+  uninitialized memory. ``category`` becomes
+  :docs-rs:`~mujoco_rs::wrappers::mj_visualization::<type>MjtCatBit::<variant>mjCAT_DECOR`, and a
+  ``mjCAT_DECOR`` geom casts no shadow.
 - :docs-rs:`~~mujoco_rs::wrappers::mj_visualization::<struct>MjvScene::<method>new` now clears the
   geom, flex and skin buffers that :docs-rs:`~mujoco_rs::mujoco_c::<fn>mjv_makeScene` allocates but
   never writes. A read before the first render returned uninitialized memory; it now returns

--- a/docs/guide/source/changelog/6.0.x.rst.inc
+++ b/docs/guide/source/changelog/6.0.x.rst.inc
@@ -207,12 +207,23 @@
   out :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsPluginReference` :sup:`new`.
   See :ref:`migrate_6_0_0`.
 
+``delete`` *moved from* :docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecItem` *to*
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecObject`
+
+- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecObject::<method>delete` :sup:`new` stays
+  ``unsafe`` and is no longer deprecated. A default class and a tendon wrap are no ``SpecObject``,
+  so a deletion that MuJoCo cannot carry out is now a compile error instead of an error value.
+  See :ref:`migrate_6_0_0`.
+
 .. rubric:: New dependencies
 
 - Added `log <https://docs.rs/log/0.4.34/log/>`__ as a mandatory dependency.
 
 .. rubric:: Deprecations
 
+- Deprecated |mj_spec|'s
+  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>delete_element`. Call
+  ``SpecObject::delete`` on the element handle instead.
 - Deprecated |mj_model|'s
   :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>try_clone` --- its
   :docs-rs:`~~mujoco_rs::error::<enum>MjModelError::<variant>AllocationFailed` arm is
@@ -525,12 +536,9 @@
 
 - :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>id` now returns ``None``
   for a default class.
-- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>delete_element` now reports
-  :docs-rs:`~mujoco_rs::error::<enum>MjEditError::<variant>UnsupportedOperation` for a default
-  class of this spec, instead of
-  :docs-rs:`~mujoco_rs::error::<enum>MjEditError::<variant>DeleteFailed`, and no
-  longer panics on an element whose stored name is not valid UTF-8. It also reports
-  ``UnsupportedOperation`` for a frame and for a tendon wrap.
+- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecObject::<method>delete` now reports
+  :docs-rs:`~mujoco_rs::error::<enum>MjEditError::<variant>UnsupportedOperation` for a frame and
+  for the world body. MuJoCo reported success for both and left the specification corrupted.
 - Closed a crash reachable from safe code when naming a tendon wrap:
   :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>set_name` on a |mjs_wrap|
   now reports ``UnsupportedOperation`` and

--- a/docs/guide/source/changelog/6.0.x.rst.inc
+++ b/docs/guide/source/changelog/6.0.x.rst.inc
@@ -219,7 +219,7 @@
 
 |mjs_wrap| *lost* ``side_site_mut``
 
-- The shared :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsWrap::<method>side_site` is not removed.
+- The shared :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsWrap::<method>side_site` stays.
   Mutable references to sites are available through
   :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>site_mut`, see
   :ref:`migrate_6_0_0`.

--- a/docs/guide/source/changelog/6.0.x.rst.inc
+++ b/docs/guide/source/changelog/6.0.x.rst.inc
@@ -207,6 +207,10 @@
   struct through ``ffi`` for reading and ``unsafe fn ffi_mut`` for writing, so code that hands a
   handle to a ``mujoco_c`` function needs an edit, see :ref:`migrate_6_0_0`. ``std::mem::swap`` on
   two handles used to exchange the contents of two elements; it now exchanges nothing.
+- |mj_spec| lost ``with_compiler``, because a by-value builder cannot take an opaque handle. Reach
+  the compiler options through
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>compiler_mut`, see
+  :ref:`migrate_6_0_0`.
 
 |mj_spec| *is no longer* ``Send``
 
@@ -342,8 +346,8 @@
     :docs-rs:`~mujoco_rs::logging::<fn>install_logging_hook` :sup:`new` installs a hook for
     ``log`` routing.
     :docs-rs:`~mujoco_rs::logging::<fn>set_log_handler` :sup:`new` registers a user handler.
-  - MuJoCo-rs now reports its own events to the ``log`` crate as well, on the ``Info``, ``Warn``
-    and ``Error`` levels, with the emitting module path as the target.
+  - MuJoCo-rs now reports its own events to the ``log`` crate as well, on the ``Debug``, ``Info``,
+    ``Warn`` and ``Error`` levels, with the emitting module path as the target.
 
 *New compilation-warning accessors*
 
@@ -575,9 +579,10 @@
   :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_eye`,
   :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_mul_mat_mat`,
   :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_mul_mat_t_mat`,
-  :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_sqr_mat_td` and
-  :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_sym2dense`. They now panic on a
-  destination above ``i32::MAX`` elements. The other wrappers in the module are unchanged.
+  :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_sqr_mat_td`,
+  :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_sym2dense` and
+  :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_symmetrize`. They now panic on a
+  destination above ``i32::MAX`` elements.
 - Closed a heap buffer overflow reachable from safe code in
   :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsHfield::<method>set_userdata` and
   :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTexture::<method>set_data`. They now

--- a/docs/guide/source/changelog/6.0.x.rst.inc
+++ b/docs/guide/source/changelog/6.0.x.rst.inc
@@ -3,6 +3,17 @@
 
 .. rubric:: Breaking changes
 
+*The items deprecated in 3.0.0 are removed*
+
+- ``mujoco_rs::get_mujoco_version`` (:docs-rs:`~mujoco_rs::<fn>mujoco_version`), |mj_vfs|'s
+  ``add_from_file`` (:docs-rs:`~mujoco_rs::wrappers::mj_auxiliary::<struct>MjVfs::<method>add_file`
+  and :docs-rs:`~mujoco_rs::wrappers::mj_auxiliary::<struct>MjVfs::<method>add_file_from`),
+  ``MjRenderer::sync`` (:docs-rs:`~mujoco_rs::renderer::<struct>MjRenderer`), ``MjvFigure::new``
+  (:docs-rs:`~mujoco_rs::wrappers::mj_visualization::<type>MjvFigure`), |mj_data|'s ``contacts``
+  and ``get_state``, and ``MjsSkin::set_vertid`` and ``MjsSkin::set_vertweight``
+  (:docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsSkin`) are gone.
+  See :ref:`migrate_6_0_0`.
+
 *Minimum-supported Rust version (MSRV) raised to 1.95*
 
 - `egui <https://docs.rs/egui/0.36.1/egui/>`_ 0.36 requires Rust 1.95, so the MSRV rose from 1.88

--- a/docs/guide/source/changelog/6.0.x.rst.inc
+++ b/docs/guide/source/changelog/6.0.x.rst.inc
@@ -3,6 +3,18 @@
 
 .. rubric:: Breaking changes
 
+*Mutable body iteration is restricted to a tree walk*
+
+- Patched undefined-behavior cases by making
+  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec` no longer carry ``body_iter_mut``,
+  and :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>body_iter_mut` no
+  longer taking the ``recurse`` argument. This now makes them yield only their direct children.
+  Reach a body through
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>world_body_mut` and walk
+  down. Immutable iteration is unchanged, and
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>body_iter` keeps
+  ``recurse``. See :ref:`migrate_6_0_0`.
+
 *The items deprecated in 3.0.0 are removed*
 
 - ``mujoco_rs::get_mujoco_version`` (:docs-rs:`~mujoco_rs::<fn>mujoco_version`), |mj_vfs|'s
@@ -575,6 +587,10 @@
   passed a truncated capacity to MuJoCo and allocated a smaller scene than the caller asked for.
 
 .. rubric:: Other changes
+
+- The :gh-example:`Basic model editing <model_editing/model_editing.rs>` example now builds three
+  swinging pendulum chains instead of overlapping balls, and walks the finished body tree to shade
+  each link by its depth. The old model stood still and showed nothing.
 
 - Following the reworked FFI struct field-visibility rules, the fields of
   :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsOrientation` (``type_``, ``axisangle``,

--- a/docs/guide/source/changelog/6.0.x.rst.inc
+++ b/docs/guide/source/changelog/6.0.x.rst.inc
@@ -13,9 +13,9 @@
 - The :ref:`mj_rust_viewer` now builds against ``egui`` 0.36, which it re-exports as
   ``mujoco_rs::viewer::egui``. Custom UI code must be ported to the new ``egui`` API,
   see :ref:`migrate_6_0_0`. For the upstream changes, see egui's changelog:
-  https://github.com/emilk/egui/blob/main/CHANGELOG.md
+  https://github.com/emilk/egui/blob/0.36.1/CHANGELOG.md
 
-*UI callbacks receive a* `egui::Ui <https://docs.rs/egui/0.36.1/egui/struct.Ui.html>`_ *and the shared state*
+*UI callbacks receive an* `egui::Ui <https://docs.rs/egui/0.36.1/egui/struct.Ui.html>`_ *and the shared state*
 
 - The closure passed to
   :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>add_ui_callback` now receives
@@ -40,7 +40,7 @@
 - MuJoCo-rs now builds against MuJoCo 3.12.0 FFI, which rolls up the upstream 3.10.0,
   3.11.0 and 3.12.0 releases. This is a breaking dependency-level change for consumers
   tied to older MuJoCo C ABI details.
-  This directly affects all the wrappers, separate changelog will not be provided. 
+  This directly affects all the wrappers, separate changelog will not be provided.
   See MuJoCo's changelog for this release:
   https://mujoco.readthedocs.io/en/3.12.0/changelog.html
 
@@ -84,9 +84,9 @@
   :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>DcMotorConfig::<method>with_ctrlspec`,
   following the renamed :docs-rs:`~mujoco_rs::mujoco_c::<fn>mjs_setToDCMotor` parameter. The value
   is now a bitmask of :docs-rs:`~mujoco_rs::wrappers::mj_model::<type>MjtCtrlInput` values instead
-  of a single mode selector. MuJoCo 3.12.0 also moved the ``dcmotor`` controller gains from voltage space to torque
-  space, so the same ``controller`` array now gives a different force. The old velocity mode's
-  integrated-velocity term is gone.
+  of a single mode selector. MuJoCo 3.12.0 also moved the ``dcmotor`` controller gains from
+  voltage space to torque space, so the same ``controller`` array now gives a different force.
+  The old velocity mode's integrated-velocity term is gone.
 
 *Relaxed* |mj_data| ``body_awake`` *view mutability*
 
@@ -97,7 +97,7 @@
 ``SpecItem::default`` *returns an* ``Option``
 
 - :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>default` now returns
-  ``Option<&MjsDefault>`` (:docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsDefault`). Handle
+  ``Option<&MjsDefault>`` (:docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsDefault`). Handle
   the ``None`` case.
 
 *Changed* |mjr_context| ``set_buffer`` *parameter type*
@@ -127,8 +127,7 @@
 - The model-handle generic ``M`` is now bound by the ``unsafe`` marker traits
   :docs-rs:`~mujoco_rs::wrappers::mj_model::traits::<trait>ModelType` :sup:`new` and
   :docs-rs:`~mujoco_rs::wrappers::mj_model::traits::<trait>ModelTypeMut` :sup:`new`, instead of
-  ``Deref<Target = MjModel>`` and ``DerefMut<Target = MjModel>``. A handle whose ``deref`` returns
-  a different model each time can no longer reach the wrappers from safe code. Every standard
+  ``Deref<Target = MjModel>`` and ``DerefMut<Target = MjModel>``. Every standard
   handle implements the markers, so only code that spells the bound or defines its own handle
   needs an edit, see :ref:`migrate_6_0_0`.
 
@@ -137,17 +136,13 @@
 - :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>tex_type_mut`,
   :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>sensor_intprm_mut` and
   :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>flex_elemlayer_mut` are now
-  ``unsafe fn``, which every neighbouring field in each of the three tables already was. C sizes a
-  buffer or indexes an array from the values of all three without an upper-bound check, so a safe
-  write reached memory outside that buffer. Wrap the call in an ``unsafe`` block and uphold the C
-  invariant, see :ref:`migrate_6_0_0`.
+  ``unsafe fn``. Wrap the call in an ``unsafe`` block and uphold the C invariant,
+  see :ref:`migrate_6_0_0`.
 
 *Drawing an* ``MjvFigure`` *became* ``unsafe``
 
 - :docs-rs:`~~mujoco_rs::wrappers::mj_visualization::<type>MjvFigure::<method>draw` is now an
-  ``unsafe fn``. ``linepnt`` is a public field and C reads ``linedata`` up to that count without
-  an upper-bound check, so an oversized entry read past the row. Checking it would scan every
-  line on a per-frame path, so the bound is a caller precondition, see :ref:`migrate_6_0_0`.
+  ``unsafe fn``. The ``linepnt`` bound is a caller precondition, see :ref:`migrate_6_0_0`.
 
 *Sixteen* |mj_data| *arena accessors became* ``unsafe``
 
@@ -170,9 +165,8 @@
   :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>efc_j_rowsuper`,
   :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>efc_j_colind`
 
-  MuJoCo allocates each of these arrays in the ``mjData`` arena and never zeroes it, so a read
-  taken before the pipeline stage that computes the array returns uninitialized memory. Run that
-  stage first, see :ref:`migrate_6_0_0`.
+  A read taken before the pipeline stage that computes the array returns uninitialized memory.
+  Run that stage first, see :ref:`migrate_6_0_0`.
 
 *Two model view fields moved to the read-only list*
 
@@ -180,9 +174,19 @@
   ``type`` on :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjTextureModelViewMut` are now
   :docs-rs:`~mujoco_rs::util::<struct>PointerViewUnsafeMut`, matching the array accessors
   :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>sensor_intprm_mut` and
-  :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>tex_type_mut`. MuJoCo reads
-  both values as unchecked sizes, so writing one needs ``as_mut_slice`` and explicit ``unsafe``,
-  see :ref:`migrate_6_0_0`. ``zero`` no longer touches either field.
+  :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>tex_type_mut`. Writing one
+  now needs ``as_mut_slice`` and explicit ``unsafe``, see :ref:`migrate_6_0_0`. ``zero`` no longer
+  touches either field.
+
+*Element handles are opaque types*
+
+- Every ``Mjs*`` element handle is now an opaque, zero-sized struct instead of an alias for the
+  matching ``mujoco_c`` struct; |mjs_body| and
+  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsDefault` are examples. A handle still
+  travels only as ``&MjsX`` or ``&mut MjsX``, so wrapper code needs no change. It exposes its FFI
+  struct through ``ffi`` for reading and ``unsafe fn ffi_mut`` for writing, so code that hands a
+  handle to a ``mujoco_c`` function needs an edit, see :ref:`migrate_6_0_0`. ``std::mem::swap`` on
+  two handles used to exchange the contents of two elements; it now exchanges nothing.
 
 .. rubric:: New dependencies
 
@@ -201,14 +205,14 @@
 
 - Deprecated |mj_spec|'s
   :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>try_new`,
-  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsBody::<method>try_add_frame` on |mjs_body|
+  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>try_add_frame` on |mjs_body|
   and |mjs_frame|, and every
   macro-generated ``try_add_*`` element constructor on |mj_spec|, |mjs_body| and |mjs_frame| ---
   their :docs-rs:`~~mujoco_rs::error::<enum>MjEditError::<variant>AllocationFailed` arm is
   unreachable. Use ``new`` and the
   panicking ``add_*`` methods instead.
   :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>try_add_default` and
-  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsBody::<method>try_add_flexcomp` keep their
+  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>try_add_flexcomp` keep their
   ``Result``: MuJoCo does report a duplicate class name and a failed flex build.
 
 .. rubric:: New features and improvements
@@ -337,10 +341,11 @@
 
 - |mjs_body|:
 
-  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsBody::<method>add_flexcomp` :sup:`new` (and the
+  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>add_flexcomp` :sup:`new` (and the
     fallible ``try_add_flexcomp``), wrapping :docs-rs:`~mujoco_rs::mujoco_c::<fn>mjs_makeFlex` to
     procedurally create a flex with auto-generated bodies, joints, and optional equality constraints
-    (the programmatic equivalent of the ``flexcomp`` element). The generation is configured through the new
+    (the programmatic equivalent of the ``flexcomp`` element). The generation is configured
+    through the new
     :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjFlexcompConfig` :sup:`new` builder.
 
 *New type aliases*
@@ -362,11 +367,11 @@
 
 - |mjs_actuator|:
 
-  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator::<method>set_to_pid` :sup:`new`,
+  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsActuator::<method>set_to_pid` :sup:`new`,
     wrapping :docs-rs:`~mujoco_rs::mujoco_c::<fn>mjs_setToPID`, makes the actuator a PID controller
     on a single force output. The controller is configured through the new
     :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>PidConfig` :sup:`new` builder.
-  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator::<method>set_to_orientation`
+  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsActuator::<method>set_to_orientation`
     :sup:`new`, wrapping :docs-rs:`~mujoco_rs::mujoco_c::<fn>mjs_setToOrientation`, makes the
     actuator a geodesic PD orientation servo on a ball joint or a site. It is configured through the
     new
@@ -397,8 +402,6 @@
   rejects a history payload whose ring-buffer cursor falls outside ``0..nsample``, and leaves the
   history buffer unchanged. It reports the new
   :docs-rs:`~~mujoco_rs::error::<enum>MjDataError::<variant>InvalidHistoryCursor` :sup:`new`.
-  MuJoCo reads the buffer at ``(cursor + 1 + logical) % nsample``, and C's ``%`` keeps the sign of
-  its left operand, so a cursor below zero produced a negative index.
 - The matrix helpers of :docs-rs:`mujoco_rs::wrappers::fun::utility` now reject a dimension above
   ``i32::MAX`` and a size product that overflows, instead of passing a wrapped size to MuJoCo.
 - A view of a |mj_data| field that MuJoCo allocates in the arena is now empty until the stage that
@@ -408,8 +411,7 @@
 *Viewer*
 
 - The viewer runs a forward step on the data it builds for a new model, so the first frame after
-  a model load or swap no longer draws every geom collapsed at the origin. A fresh |mj_data| has a
-  zeroed ``geom_xpos``, which the scene update copies verbatim.
+  a model load or swap no longer draws every geom collapsed at the origin.
 - The viewer no longer clamps ``ctrl`` to the range of its slider. While the "Actuator" window
   was open, it wrote the clamped control back on every frame, so a program that set a control
   outside the slider range lost that value.
@@ -419,15 +421,10 @@
   through :docs-rs:`~~mujoco_rs::viewer::<struct>MjViewer::<method>sync_data`. The click is dropped
   while the scene still follows the previous model.
 - The viewer's side panel and its windows can no longer panic, or write to the wrong actuator,
-  joint or equality, when a model swap through ``sync_data`` arrives in the same frame. Each
-  section now draws and writes only while the viewer still holds the model that the frame's
-  widgets belong to, and the next frame rebuilds it against the new model.
+  joint or equality, when a model swap through ``sync_data`` arrives in the same frame.
 - A model swap no longer discards the change that a program makes to the new model's ``opt``,
   ``vis`` or ``stat`` before the next
-  :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>sync_model`. The viewer
-  measured such a change against the parameters of the model it held before the swap, so it read
-  the difference between the two models as its own edit and wrote that back over the program's
-  value.
+  :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>sync_model`.
 - The viewer no longer applies a pending camera tracking selection to a body of the previous model
   after a model swap. A selection that the "Track" dialog left open held a body id that addresses
   a different body in the new model, so the camera followed that one instead.
@@ -440,16 +437,15 @@
   :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>copy_to`,
   :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>copy_visual_to`,
   :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>copy_state_from_data` and in
-  every ``Info`` view method. All of them compared the model signature alone, which pins the
-  element tree but no ``mjData`` buffer size, so a model with a larger ``nuserdata``, ``na`` or
-  ``nout`` passed the test. The ``MjData`` methods now test
+  every ``Info`` view method. All of them compared the model signature alone. The ``MjData``
+  methods now test
   ``MjModel::is_compatible_with_model``, which also compares the per-element address tables; an
   ``Info`` view method compares the model layout it cached.
 - The viewer and the renderer no longer test the signature either. ``MjViewer::sync_data`` and
   ``MjViewer::sync_model`` test model compatibility, so a model that needs different buffers
   triggers a reload rather than a copy into the wrong sizes. The viewer's asset-upload methods
-  test the mesh, texture and heightfield memory alone, which is all a copy that overrides an asset
-  reads, so they accept a model whose ``mjData`` sizes differ.
+  test the mesh, texture and heightfield memory alone, so they accept a model whose ``mjData``
+  sizes differ.
 
 *Ray casting*
 
@@ -459,8 +455,7 @@
   direction.
 - ``multi_ray`` and
   :docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjData::<method>try_multi_ray` no longer report
-  geom ``0`` for such a direction. MuJoCo leaves the id unwritten, so the returned id was the
-  initial value of the buffer; it is now ``None``.
+  geom ``0`` for such a direction; the returned id is now ``None``.
 
 *Visualization*
 
@@ -489,30 +484,23 @@
   becomes ``-1``, ``category`` becomes
   :docs-rs:`~mujoco_rs::wrappers::mj_visualization::<type>MjtCatBit::<variant>mjCAT_DECOR`,
   ``segid`` becomes the geom's own index, and ``label``, ``camdist`` and ``transparent`` are
-  cleared. The renderer uses ``objid`` as an unchecked index into the skin and flex arrays, and it
-  casts no shadow for a ``mjCAT_DECOR`` geom.
+  cleared. A ``mjCAT_DECOR`` geom casts no shadow.
 - :docs-rs:`~~mujoco_rs::wrappers::mj_visualization::<struct>MjvScene::<method>new` now clears the
   geom, flex and skin buffers that :docs-rs:`~mujoco_rs::mujoco_c::<fn>mjv_makeScene` allocates but
-  never writes. The scene's slice accessors are safe, so a read before the first render returned
-  uninitialized memory; it now returns zeros.
+  never writes. A read before the first render returned uninitialized memory; it now returns
+  zeros.
 - :docs-rs:`~~mujoco_rs::wrappers::mj_visualization::<type>MjvFigure::<method>set_at` now treats a
-  negative ``linepnt`` entry as an empty plot. The count is public, and casting a negative value to
-  ``usize`` made the range test pass, so the call wrote outside the plot's data range.
+  negative ``linepnt`` entry as an empty plot, instead of writing outside the plot's data range.
 - :docs-rs:`~mujoco_rs::vis_common::<fn>sync_geoms` now panics when the two scenes were created for
-  models that are not compatible. A copied geom keeps its ``objid``, which the renderer uses as an
-  unchecked index into the destination scene's flex and skin arrays.
+  models that are not compatible.
 
 *Rendering*
 
 - :docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>read_pixels` no longer
-  wraps when the pixel count, or the ``rgb`` byte count that is three times it, overflows
-  ``usize`` on a 32-bit target, which let a short ``rgb`` or ``depth`` buffer pass the size
-  check; it reports
-  :docs-rs:`~mujoco_rs::error::<enum>MjrContextError::<variant>InvalidViewport` instead.
+  wraps when the pixel count or the ``rgb`` byte count overflows ``usize`` on a 32-bit target; it
+  reports :docs-rs:`~mujoco_rs::error::<enum>MjrContextError::<variant>InvalidViewport` instead.
 - :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>new` no longer truncates its
-  ``width``, ``height`` and ``max_user_geom`` arguments, which turned a value above ``u32::MAX``
-  into a small valid one, so the renderer used a size or a geom capacity the caller never asked
-  for. The three arguments now saturate at ``u32::MAX``.
+  ``width``, ``height`` and ``max_user_geom`` arguments; they now saturate at ``u32::MAX``.
 
 *Model editing*
 
@@ -524,8 +512,7 @@
   :docs-rs:`~mujoco_rs::error::<enum>MjEditError::<variant>DeleteFailed`, and no
   longer panics on an element whose stored name is not valid UTF-8. It also reports
   ``UnsupportedOperation`` for a frame and for a tendon wrap.
-- Closed a crash reachable from safe code when naming a tendon wrap. ``mjCWrap`` leaves its element
-  type at ``mjOBJ_UNKNOWN``, which makes MuJoCo's duplicate-name check index a null list, so
+- Closed a crash reachable from safe code when naming a tendon wrap:
   :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>set_name` on a |mjs_wrap|
   now reports ``UnsupportedOperation`` and
   :docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>with_name` panics. A wrap
@@ -536,9 +523,8 @@
 *Utility functions*
 
 - Closed a division by zero and a non-terminating loop reachable from safe code in
-  :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_halton`: MuJoCo divides by ``base`` without
-  checking it, so ``base = 0`` divided by zero and ``base = 1`` never returned. The wrapper now
-  panics unless ``base`` is 2 or more.
+  :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_halton`: the wrapper now panics unless
+  ``base`` is 2 or more.
 - Closed a heap buffer overflow reachable from safe code in
   :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_zero`,
   :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_copy`,
@@ -548,17 +534,12 @@
   :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_mul_mat_mat`,
   :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_mul_mat_t_mat`,
   :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_sqr_mat_td` and
-  :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_sym2dense`. Each of them reaches a C
-  ``memset`` whose byte count comes from a signed ``int``, so a destination above ``i32::MAX``
-  elements truncated to a negative count and cleared far past the buffer. They now panic on such a
-  destination. The other wrappers in the module take the length in a loop counter, where a
-  truncated count only shortens the work, and they are unchanged.
+  :docs-rs:`~~mujoco_rs::wrappers::fun::utility::<fn>mju_sym2dense`. They now panic on a
+  destination above ``i32::MAX`` elements. The other wrappers in the module are unchanged.
 - Closed a heap buffer overflow reachable from safe code in
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsHfield::<method>set_userdata` and
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTexture::<method>set_data`. Both give the
-  slice length to C++ as a signed ``int``, and a slice above ``i32::MAX`` elements truncated to a
-  negative count, which C++ turned into an out-of-range pointer or an enormous allocation. They now
-  panic on such a slice.
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsHfield::<method>set_userdata` and
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTexture::<method>set_data`. They now
+  panic on a slice above ``i32::MAX`` elements.
 - :docs-rs:`~~mujoco_rs::wrappers::mj_visualization::<struct>MjvScene::<method>new` now checks
   ``max_geom`` in a release build as well. The check was a ``debug_assert!``, so a release build
   passed a truncated capacity to MuJoCo and allocated a smaller scene than the caller asked for.

--- a/docs/guide/source/installation.rst
+++ b/docs/guide/source/installation.rst
@@ -234,7 +234,7 @@ To build statically linkable libraries, perform the following steps:
 
        git submodule update --init --recursive
        cd ./mujoco/
-       cmake -B build -S . -DBUILD_SHARED_LIBS:BOOL=OFF -DMUJOCO_HARDEN:BOOL=OFF -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=OFF -DMUJOCO_BUILD_EXAMPLES:BOOL=OFF
+       cmake -B build -S . -DBUILD_SHARED_LIBS:BOOL=OFF -DMUJOCO_HARDEN:BOOL=OFF -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=OFF -DMUJOCO_BUILD_EXAMPLES:BOOL=OFF -DMUJOCO_BUILD_TESTS:BOOL=OFF
        cmake --build build --parallel --target glfw libmujoco_simulate --config=Release
 
    This was tested with the ``gcc`` compiler.
@@ -259,7 +259,7 @@ To build statically linkable libraries, perform the following steps:
         compiler flags.
 
 4. Set the environment variable ``MUJOCO_STATIC_LINK_DIR`` to the **absolute** path of the ``lib/`` subdirectory
-   inside ``mujoco/build/`` (on some distributions, e.g. Fedora/RHEL/Arch, the directory may be ``lib64/``).
+   inside ``mujoco/build/`` (on some distributions, e.g. Fedora/RHEL, the directory may be ``lib64/``).
    Bash example:
 
    ::

--- a/docs/guide/source/migration.rst
+++ b/docs/guide/source/migration.rst
@@ -11,10 +11,10 @@ Migration guide
 .. |mjv_scene| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_visualization::<struct>MjvScene`
 .. |mjv_camera| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_visualization::<type>MjvCamera`
 .. |mjr_context| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext`
-.. |mjs_joint| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsJoint`
-.. |mjs_body| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsBody`
-.. |mjs_frame| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsFrame`
-.. |mjs_tendon| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsTendon`
+.. |mjs_joint| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsJoint`
+.. |mjs_body| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsBody`
+.. |mjs_frame| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsFrame`
+.. |mjs_tendon| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsTendon`
 
 
 This page documents the migration steps for upgrading between major versions of MuJoCo-rs.

--- a/docs/guide/source/migration/3.0.x.rst.inc
+++ b/docs/guide/source/migration/3.0.x.rst.inc
@@ -482,7 +482,7 @@ Type changes
   Replace ``data.runge_kutta(n)`` with ``data.runge_kutta(n as u32)`` at call sites.
   The function also now panics if ``n < 1`` (previously passed negative or zero values
   silently to MuJoCo C).
-- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTexture::<method>set_data`
+- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTexture::<method>set_data`
   now requires ``T: bytemuck::NoUninit`` (add ``bytemuck`` to your dependencies if you
   call this method with a custom type, and derive or implement ``NoUninit`` for it).
 - ``MjTendonDataInfo``: ``J_rownnz``, ``J_rowadr``, and ``J_colind`` are no longer
@@ -987,8 +987,8 @@ Callers must ensure the model and data remain alive and at a stable address.
 ``MjsTendon::wrap`` / ``wrap_mut`` no longer return ``Option``
 --------------------------------------------------------------
 
-:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTendon::<method>wrap` and
-:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsTendon::<method>wrap_mut` now return
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTendon::<method>wrap` and
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsTendon::<method>wrap_mut` now return
 ``&MjsWrap`` / ``&mut MjsWrap`` instead of ``Option<&MjsWrap>`` / ``Option<&mut MjsWrap>``, and
 panic when the index is out of bounds. Drop the ``.unwrap()`` and make sure the index is
 ``< wrap_num()``, or use the new fallible ``try_wrap`` / ``try_wrap_mut``.

--- a/docs/guide/source/migration/6.0.x.rst.inc
+++ b/docs/guide/source/migration/6.0.x.rst.inc
@@ -614,6 +614,21 @@ zero-sized type that stands at the address of that struct, so code that stays in
 API needs no edit, with one exception: ``MjSpec::with_compiler`` is gone, because a by-value
 builder cannot take an opaque handle.
 
+.. code-block:: rust
+
+    use mujoco_rs::prelude::*;
+
+    fn build() -> MjSpec {
+        let mut spec = MjSpec::new();
+
+        // Before
+        // let spec = spec.with_compiler(compiler);
+
+        // After
+        spec.compiler_mut().set_degree(false);
+        spec
+    }
+
 Two things change. Naming the FFI struct where the handle belongs no longer compiles, and passing
 a handle straight to a ``mujoco_c`` function no longer coerces. Call ``ffi`` for the FFI struct,
 and ``unsafe fn ffi_mut`` for writing.
@@ -636,21 +651,6 @@ and ``unsafe fn ffi_mut`` for writing.
 
 ``std::mem::swap`` on two handles used to exchange the contents of two elements. It now
 exchanges nothing.
-
-.. code-block:: rust
-
-    use mujoco_rs::prelude::*;
-
-    fn build() -> MjSpec {
-        let mut spec = MjSpec::new();
-
-        // Before
-        // let spec = spec.with_compiler(compiler);
-
-        // After
-        spec.compiler_mut().set_degree(false);
-        spec
-    }
 
 ``MjSpec`` is no longer ``Send``
 -------------------------------------------

--- a/docs/guide/source/migration/6.0.x.rst.inc
+++ b/docs/guide/source/migration/6.0.x.rst.inc
@@ -454,7 +454,7 @@ the lock.
     });
 
 Port the widgets themselves against egui's changelog:
-https://github.com/emilk/egui/blob/main/CHANGELOG.md
+https://github.com/emilk/egui/blob/0.36.1/CHANGELOG.md
 
 
 Model handles are bound by ``ModelType``
@@ -535,3 +535,32 @@ kind, and it bounds neither, so both now sit in the read-only list of their view
         // SAFETY: the caller keeps the kind consistent with the texture's own width and height.
         unsafe { info.view_mut(model).r#type.as_mut_slice()[0] = MjtTexture::mjTEXTURE_CUBE };
     }
+
+Element handles are opaque types
+-------------------------------------------
+An ``Mjs*`` element handle is no longer an alias for its ``mujoco_c`` struct. It is an opaque,
+zero-sized type that stands at the address of that struct, so every wrapper method keeps its
+signature and code that stays inside the wrapper API needs no edit.
+
+Two things change. Naming the FFI struct where the handle belongs no longer compiles, and passing
+a handle straight to a ``mujoco_c`` function no longer coerces. Call ``ffi`` for the FFI struct,
+and ``unsafe fn ffi_mut`` for writing.
+
+.. code-block:: rust
+
+    use mujoco_rs::prelude::*;
+    use mujoco_rs::mujoco_c::mjs_sensorDim;
+
+    fn dimension(spec: &MjSpec) -> i32 {
+        let sensor = spec.sensor("s").unwrap();
+
+        // Before
+        // unsafe { mjs_sensorDim(sensor) }
+
+        // After
+        // SAFETY: the borrow of the sensor keeps it alive for the call.
+        unsafe { mjs_sensorDim(sensor.ffi()) }
+    }
+
+``std::mem::swap`` on two handles used to exchange the contents of two elements. It now
+exchanges nothing.

--- a/docs/guide/source/migration/6.0.x.rst.inc
+++ b/docs/guide/source/migration/6.0.x.rst.inc
@@ -564,3 +564,68 @@ and ``unsafe fn ffi_mut`` for writing.
 
 ``std::mem::swap`` on two handles used to exchange the contents of two elements. It now
 exchanges nothing.
+
+``MjSpec`` is no longer ``Send``
+-------------------------------------------
+A model that attaches another model, through ``<asset><model file=.../></asset>``, keeps the child
+specification shared between a spec and every clone of it, behind a reference count that MuJoCo
+does not synchronise. Keep the specification on one thread and move the compiled |mj_model|, which
+stays ``Send`` and ``Sync``.
+
+.. code-block:: rust
+
+    use mujoco_rs::prelude::*;
+
+    fn build(path: &str) -> MjModel {
+        let mut spec = MjSpec::from_xml(path).unwrap();
+
+        // Before
+        // std::thread::spawn(move || spec.compile().unwrap()).join().unwrap()
+
+        // After
+        let model = spec.compile().unwrap();
+        std::thread::spawn(move || model).join().unwrap()
+    }
+
+``MjsWrap::side_site_mut`` is removed
+-------------------------------------------
+Two wraps that name one site each handed out a ``&mut MjsSite`` for the same site. Read the name
+through the shared ``side_site`` and take the mutable borrow from the specification.
+
+.. code-block:: rust
+
+    use mujoco_rs::prelude::*;
+
+    fn widen(spec: &mut MjSpec) {
+        // Before
+        // let site = spec.tendon_mut("t").unwrap().wrap_mut(0).side_site_mut().unwrap();
+        // site.with_size([0.1, 0.1, 0.1]);
+
+        // After
+        let name = spec.tendon("t").unwrap().wrap(0).side_site().unwrap().name().to_owned();
+        spec.site_mut(&name).unwrap().with_size([0.1, 0.1, 0.1]);
+    }
+
+``MjsPlugin`` no longer stands for the plugin that an element embeds
+----------------------------------------------------------------------
+A body, geom, mesh, actuator and sensor embed a reference that names a plugin instance and carries
+no element of its own. The ``plugin`` and ``plugin_mut`` accessors return ``MjsPluginReference``,
+which keeps the instance name, the plugin name and the active flag, and which implements no
+``SpecItem`` method. Reach the instance itself through ``MjSpec::plugin``.
+
+.. code-block:: rust
+
+    use mujoco_rs::wrappers::mj_editing::MjsPluginReference;
+    use mujoco_rs::prelude::*;
+
+    fn configure(spec: &mut MjSpec) {
+        let geom = spec.world_body_mut().add_geom();
+
+        // Before
+        // let plugin: &mut MjsPlugin = geom.plugin_mut();
+
+        // After
+        let plugin: &mut MjsPluginReference = geom.plugin_mut();
+        plugin.set_name("instance");
+        plugin.set_active(true);
+    }

--- a/docs/guide/source/migration/6.0.x.rst.inc
+++ b/docs/guide/source/migration/6.0.x.rst.inc
@@ -629,3 +629,22 @@ which keeps the instance name, the plugin name and the active flag, and which im
         plugin.set_name("instance");
         plugin.set_active(true);
     }
+
+``delete`` moved from ``SpecItem`` to ``SpecObject``
+----------------------------------------------------------------------
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecObject::<method>delete` keeps the shape of
+the removed ``SpecItem::delete``, so a call through the element handle needs no edit. Import
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecObject`, which ``mujoco_rs::prelude`` also
+exports. The method is no longer deprecated, and its safety contract is the one the guide states:
+delete each element at most once, and do not touch an element that the deletion of a body took out
+of the specification.
+
+``MjSpec::delete_element`` is deprecated. Delete through the handle instead.
+
+.. code-block:: rust
+
+    use mujoco_rs::prelude::*;
+
+    fn prune(spec: &mut MjSpec) {
+        unsafe { spec.geom_mut("g0").unwrap().delete() }.unwrap();
+    }

--- a/docs/guide/source/migration/6.0.x.rst.inc
+++ b/docs/guide/source/migration/6.0.x.rst.inc
@@ -22,6 +22,39 @@ Minimum Rust version
 This release needs Rust **1.95**, up from 1.88. Run ``rustup update stable`` before you build.
 
 
+Items deprecated in 3.0.0 are removed
+---------------------------------------------------------
+Each one has carried a deprecation warning since 3.0.0. Switch to the replacement.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Before
+     - After
+   * - ``mujoco_rs::get_mujoco_version()``
+     - ``mujoco_rs::mujoco_version()``
+   * - ``vfs.add_from_file(Some(dir), file)``
+     - ``vfs.add_file_from(dir, file)``
+   * - ``vfs.add_from_file(None, file)``
+     - ``vfs.add_file(file)``
+   * - ``renderer.sync(&mut data)``
+     - ``renderer.sync_data(&mut data)?; renderer.render()?``
+   * - ``MjvFigure::new()``
+     - ``MjvFigure::new_boxed()``
+   * - ``data.contacts()``
+     - ``data.contact()``
+   * - ``data.get_state(spec)``
+     - ``data.state(spec)``
+   * - ``skin.set_vertid(&ids)``
+     - ``skin.append_vertid(&ids)``
+   * - ``skin.set_vertweight(&weights)``
+     - ``skin.append_vertweight(&weights)``
+
+``MjRenderer::sync`` unwrapped both failures; ``sync_data`` and
+:docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>render` return a ``Result`` each.
+
+
 Redundant dimension parameters removed
 ---------------------------------------------------------
 Four utility wrappers took a dimension that the slices they already take fix. Drop the argument;

--- a/docs/guide/source/migration/6.0.x.rst.inc
+++ b/docs/guide/source/migration/6.0.x.rst.inc
@@ -22,6 +22,45 @@ Minimum Rust version
 This release needs Rust **1.95**, up from 1.88. Run ``rustup update stable`` before you build.
 
 
+Mutable body iteration
+---------------------------------------------------------
+
+|mj_spec| lost ``body_iter_mut``, and |mjs_body|'s ``body_iter_mut`` lost its ``recurse``
+argument. Every item a mutable iterator yields borrows its parent for the same lifetime, so all of
+them stay live together. A body owns a subtree, so both forms could hand out a body and that
+body's own descendant at once, and writing through the second handle broke the uniqueness that
+``&mut`` promises. Walk the tree instead: a child borrows its parent, so the two are never live
+together.
+
+.. code-block:: rust
+
+    // Before
+    for body in spec.body_iter_mut() {
+        body.set_gravcomp(1.0);
+    }
+
+    // After: the world body is the root of the walk.
+    fn walk(body: &mut MjsBody) {
+        body.set_gravcomp(1.0);
+        for child in body.body_iter_mut() {
+            walk(child);
+        }
+    }
+    walk(spec.world_body_mut());
+
+.. code-block:: rust
+
+    // Before
+    for body in world.body_iter_mut(true) { /* ... */ }
+
+    // After: `body_iter_mut` yields the direct children, so recurse by hand.
+    for body in world.body_iter_mut() { /* ... */ }
+
+Read-only iteration is unchanged. ``MjSpec::body_iter`` still walks every body flat, and
+``MjsBody::body_iter`` still takes ``recurse``, so a loop that only reads needs no edit beyond
+dropping ``_mut``.
+
+
 Items deprecated in 3.0.0 are removed
 ---------------------------------------------------------
 Each one has carried a deprecation warning since 3.0.0. Switch to the replacement.

--- a/docs/guide/source/migration/6.0.x.rst.inc
+++ b/docs/guide/source/migration/6.0.x.rst.inc
@@ -39,7 +39,9 @@ together.
         body.set_gravcomp(1.0);
     }
 
-    // After: the world body is the root of the walk.
+    // After: the world body is the root of the walk. The prelude does not carry `MjsBody`.
+    // use mujoco_rs::wrappers::mj_editing::MjsBody;
+
     fn walk(body: &mut MjsBody) {
         body.set_gravcomp(1.0);
         for child in body.body_iter_mut() {
@@ -535,8 +537,10 @@ the same model, which the wrappers rely on but ``Deref`` alone does not give.
 
 ``&MjModel``, ``&mut MjModel``, ``Box<MjModel>``, ``Rc<MjModel>``, ``Arc<MjModel>``,
 ``Ref<MjModel>``, ``RefMut<MjModel>``, ``MutexGuard<MjModel>``, ``RwLockReadGuard<MjModel>`` and
-``RwLockWriteGuard<MjModel>`` implement the markers. Rename the bound in your own generic code, and
-claim the marker for a hand-written handle.
+``RwLockWriteGuard<MjModel>`` implement ``ModelType``. The five that deref mutably
+(``&mut MjModel``, ``Box<MjModel>``, ``RefMut<MjModel>``, ``MutexGuard<MjModel>`` and
+``RwLockWriteGuard<MjModel>``) also implement ``ModelTypeMut``. Rename the bound in your own
+generic code, and claim the marker for a hand-written handle.
 
 **Before:**
 
@@ -606,8 +610,9 @@ kind, and it bounds neither, so both now sit in the read-only list of their view
 Element handles are opaque types
 -------------------------------------------
 An ``Mjs*`` element handle is no longer an alias for its ``mujoco_c`` struct. It is an opaque,
-zero-sized type that stands at the address of that struct, so every wrapper method keeps its
-signature and code that stays inside the wrapper API needs no edit.
+zero-sized type that stands at the address of that struct, so code that stays inside the wrapper
+API needs no edit, with one exception: ``MjSpec::with_compiler`` is gone, because a by-value
+builder cannot take an opaque handle.
 
 Two things change. Naming the FFI struct where the handle belongs no longer compiles, and passing
 a handle straight to a ``mujoco_c`` function no longer coerces. Call ``ffi`` for the FFI struct,
@@ -631,6 +636,21 @@ and ``unsafe fn ffi_mut`` for writing.
 
 ``std::mem::swap`` on two handles used to exchange the contents of two elements. It now
 exchanges nothing.
+
+.. code-block:: rust
+
+    use mujoco_rs::prelude::*;
+
+    fn build() -> MjSpec {
+        let mut spec = MjSpec::new();
+
+        // Before
+        // let spec = spec.with_compiler(compiler);
+
+        // After
+        spec.compiler_mut().set_degree(false);
+        spec
+    }
 
 ``MjSpec`` is no longer ``Send``
 -------------------------------------------

--- a/docs/guide/source/migration/6.0.x.rst.inc
+++ b/docs/guide/source/migration/6.0.x.rst.inc
@@ -12,7 +12,7 @@ update your library path. See :ref:`installation` for details.
 
 The FFI bindings follow the upstream API. This page gives no entry for an accessor that only
 mirrors a renamed, a removed or a resized MuJoCo field, and none for a shifted enum discriminant.
-For these changes, see MuJoCo's changelog for this release (and prior changelogs since MuJoCo 3.10.0+):
+For these changes, see MuJoCo's changelog for this release:
 https://mujoco.readthedocs.io/en/3.12.0/changelog.html
 
 
@@ -52,8 +52,7 @@ The variant is renamed in :docs-rs:`~mujoco_rs::error::<enum>MjDataError`,
 :docs-rs:`~mujoco_rs::error::<enum>MjModelError`,
 :docs-rs:`~mujoco_rs::viewer::<enum>MjViewerError` and
 :docs-rs:`~mujoco_rs::renderer::<enum>RendererError`. It now also fires for two models that share
-a signature but need different buffer sizes, so a program that treated an equal signature as
-"safe to pair" must handle the error on that path too.
+a signature but need different buffer sizes.
 
 **Before:**
 
@@ -211,10 +210,8 @@ engine write more force outputs than the actuator owns.
 Unsafe mutation of three more ``MjModel`` tables
 ------------------------------------------------
 ``tex_type_mut``, ``sensor_intprm_mut`` and ``flex_elemlayer_mut`` are now ``unsafe fn``, for the
-same reason as ``actuator_gaintype_mut`` above. C sizes a buffer or indexes an array from the
-values of all three: a texture kind sets how many faces the upload reads, a sensor int parameter
-selects the object a sensor stage reads, and an element layer sets how many flex faces the scene
-builder emits.
+same reason as ``actuator_gaintype_mut`` above: C sizes a buffer or indexes an array from the
+value of each one.
 
 **Before:**
 
@@ -238,12 +235,10 @@ builder emits.
 
 Drawing an ``MjvFigure`` is ``unsafe``
 --------------------------------------
-``draw`` is now an ``unsafe fn``. ``linepnt`` is a public field, and C reads ``linedata[n][2*i]``
-for every ``i < linepnt[n]`` without an upper-bound check, so an entry above ``mjMAXLINEPNT``
-read past the row. Validating it would scan all ``mjMAXLINE`` entries on a per-frame path, so the
-bound is a caller precondition. ``push`` refuses to grow a plot that is already at capacity, so a
-figure filled only through the line-editing methods already satisfies it; a direct write to the
-public ``linepnt`` field is what needs the care.
+``draw`` is now an ``unsafe fn``. Every ``linepnt`` entry must stay within ``0..=mjMAXLINEPNT``,
+and the bound is a caller precondition. ``push`` refuses to grow a plot that is already at
+capacity, so a figure filled only through the line-editing methods already satisfies it; a direct
+write to the public ``linepnt`` field is what needs the care.
 
 **Before:**
 
@@ -589,8 +584,7 @@ stays ``Send`` and ``Sync``.
 
 ``MjsWrap::side_site_mut`` is removed
 -------------------------------------------
-Two wraps that name one site each handed out a ``&mut MjsSite`` for the same site. Read the name
-through the shared ``side_site`` and take the mutable borrow from the specification.
+Read the name through the shared ``side_site`` and take the mutable borrow from the specification.
 
 .. code-block:: rust
 
@@ -610,8 +604,7 @@ through the shared ``side_site`` and take the mutable borrow from the specificat
 ----------------------------------------------------------------------
 A body, geom, mesh, actuator and sensor embed a reference that names a plugin instance and carries
 no element of its own. The ``plugin`` and ``plugin_mut`` accessors return ``MjsPluginReference``,
-which keeps the instance name, the plugin name and the active flag, and which implements no
-``SpecItem`` method. Reach the instance itself through ``MjSpec::plugin``.
+which implements no ``SpecItem`` method. Reach the instance itself through ``MjSpec::plugin``.
 
 .. code-block:: rust
 
@@ -635,9 +628,7 @@ which keeps the instance name, the plugin name and the active flag, and which im
 :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecObject::<method>delete` keeps the shape of
 the removed ``SpecItem::delete``, so a call through the element handle needs no edit. Import
 :docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecObject`, which ``mujoco_rs::prelude`` also
-exports. The method is no longer deprecated, and its safety contract is the one the guide states:
-delete each element at most once, and do not touch an element that the deletion of a body took out
-of the specification.
+exports.
 
 ``MjSpec::delete_element`` is deprecated. Delete through the handle instead.
 

--- a/docs/guide/source/programming/logging.rst
+++ b/docs/guide/source/programming/logging.rst
@@ -29,6 +29,16 @@ We provide a hook for integrating the MuJoCo logging with the ``log`` crate.
 The hook can be installed by calling :docs-rs:`~mujoco_rs::logging::<fn>install_logging_hook` once
 at the start of the program.
 
+.. note::
+
+    Installing the hook, through either function, replaces MuJoCo's own handler, so the
+    ``logto_console``, ``logto_file`` and ``logfile`` fields of
+    :docs-rs:`~mujoco_rs::wrappers::mj_logging::<struct>MjLogConfig` no longer reach the output.
+    The install also writes every topic into the global topic bitmask once, so a bitmask that the
+    program set before the install is lost. The producer-side topic gate still reads that bitmask,
+    so a :docs-rs:`~mujoco_rs::wrappers::mj_logging::<fn>set_log_config` call after the install
+    still suppresses the topics it clears.
+
 .. attention::
 
     :docs-rs:`~mujoco_rs::logging::<fn>install_logging_hook` and

--- a/docs/guide/source/programming/logging.rst
+++ b/docs/guide/source/programming/logging.rst
@@ -106,11 +106,6 @@ that takes a regular Rust reference to the
 log.
 
 The user callback function can be registered via :docs-rs:`~mujoco_rs::logging::<fn>set_log_handler`.
-Note that the callback does **not** go to
-:docs-rs:`~mujoco_rs::mujoco_c::<fn>mju_setLogHandler` directly. MuJoCo-rs stores it in a global
-static inside MuJoCo-rs (not MuJoCo), and gives ``mju_setLogHandler`` its own handler.
-That handler is responsible for both calling the global user-set Rust logging handler
-and routing the message to the ``log`` crate when no user-set Rust logging handler is set.
 
 When setting a custom logging callback inside MuJoCo-rs, there is no need to call
 :docs-rs:`~mujoco_rs::logging::<fn>install_logging_hook` separately,
@@ -137,7 +132,7 @@ All ``log_`` function calls (and internal MuJoCo calls) will now be redirected t
 
     Setting a custom handler using only ``set_log_handler`` only redirects **MuJoCo** messages
     to the user handler.
-    
+
     Any message emitted using ``log::`` invocations bypass the handler. This also applies
     to the internal invocations of MuJoCo-rs as well. For a custom callback of that, `a custom
     logger <https://docs.rs/log/0.4.34/log/#implementing-a-logger>`__ can be defined. Such logger

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -301,6 +301,13 @@ To iterate over :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec` item
 ``[item_type]_iter`` for immutable iteration or ``[item_type]_iter_mut`` for mutable iteration,
 with ``[item_type]`` replaced by geom, body, etc.
 
+A body is the exception: |mj_spec| carries ``body_iter`` alone. Every item that a mutable iterator
+yields borrows the spec for the same lifetime, so all of them stay live together. A body owns a
+subtree, so a flat mutable body iterator would hand out a body and that body's own descendant at
+once. Reach a body through
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>world_body_mut` and walk down
+the tree.
+
 .. code-block:: rust
 
     // ...
@@ -311,6 +318,9 @@ with ``[item_type]`` replaced by geom, body, etc.
 
 Iteration over :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsBody` items can be used in a similar way.
 The only difference is an additional boolean parameter, which enables recursive iteration when ``true``.
+The mutable body iterator
+(:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>body_iter_mut`) takes no such
+parameter and yields the direct children only, for the reason above.
 
 .. code-block:: rust
 

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -206,11 +206,11 @@ changed sensor type or a changed actuator dynamics type breaks it; ``swap_model`
 
 Deleting elements
 ======================
-Most elements can be removed from a specification with
-:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>delete_element`,
-which takes the element's raw pointer obtained from
-:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>element_mut_pointer`.
-The world body and default classes cannot be removed; ``delete_element`` returns
+Most elements can be removed from a specification with the ``unsafe``
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecObject::<method>delete`, called on the
+handle of the element. A default class and a tendon wrap are no
+:docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>SpecObject`, so they carry no ``delete`` at all.
+The world body and a frame do carry it, and it returns
 :docs-rs:`~mujoco_rs::error::<enum>MjEditError::<variant>UnsupportedOperation` for them.
 
 .. code-block:: rust
@@ -219,23 +219,37 @@ The world body and default classes cannot be removed; ``delete_element`` returns
 
     fn main() {
         let mut spec = MjSpec::new();
-        let body = spec.world_body_mut().add_body().with_name("ball");
+        spec.world_body_mut().add_body().with_name("ball");
 
-        let body_ptr = body.element_mut_pointer();
-        // SAFETY: `body_ptr` refers to a live element of `spec` that has not been deleted.
-        unsafe { spec.delete_element(body_ptr).expect("failed to delete the body") };
+        unsafe { spec.body_mut("ball").unwrap().delete() }.expect("failed to delete the body");
     }
 
-Because ``delete_element`` takes ``&mut MjSpec``, the borrow checker already invalidates any
-references obtained earlier (such as ``body`` above) --- you cannot use a reference into the
-spec across the call. The method is ``unsafe`` only because the raw element pointer itself
-cannot be validated: in particular, the caller must not pass a pointer to an element that has
-already been deleted, which would make MuJoCo operate on freed memory.
+``delete`` is ``unsafe`` because MuJoCo cannot answer whether it already deleted an element. It
+keeps a deleted element allocated until the specification drops, so a second deletion of the same
+element frees it twice. The caller carries three obligations:
 
-.. note::
+- Delete each element at most once.
+- Do not delete an element that the deletion of a body already took out of the specification.
+- Do not use the handle of an element that the deletion of a body freed.
 
-    The older ``SpecItem::delete`` method is **deprecated since 5.0.0** and is unsound
-    (it relies on undefined behavior). Use ``delete_element`` instead.
+Deleting a body deletes its whole subtree, and it frees every keyframe, and every actuator, sensor,
+tendon, equality, pair and exclude that refers to the subtree. The last two obligations follow from
+that: an iterator collected before such a deletion still hands out the handles it took.
+
+The borrow checker covers the ordinary case, because a handle borrows the specification and a
+deletion needs it mutably. Look the next element up in each round, as the loop below does, and every
+handle the loop holds belongs to a live element.
+
+.. code-block:: rust
+
+    use mujoco_rs::prelude::*;
+
+    fn delete_every_geom(spec: &mut MjSpec) {
+        // SAFETY: the walk starts again after each deletion, so it reaches a live geom only.
+        while let Some(geom) = spec.geom_iter_mut().next() {
+            unsafe { geom.delete() }.unwrap();
+        }
+    }
 
 
 .. _model_editing_defaults:

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -109,7 +109,8 @@ We can now add our ball's body, geom and joint like so:
 
     In the above block, we used methods that have the ``with_`` prefix.
     These allow method chaining.
-    Alternatively, methods that have the ``set_`` prefix can be used. A plain field setter
+    Many fields also carry a ``set_`` method, but not all: an array field such as ``pos`` or
+    ``size`` offers ``with_pos`` and ``pos_mut`` only. A plain field setter
     (e.g. ``set_group``, ``set_mass``) returns nothing, while a validated setter returns a
     ``Result`` (``set_name`` fails on a duplicate name, ``set_default`` on an unknown class, and
     ``MjsNumeric::set_size`` on a negative size).
@@ -287,8 +288,9 @@ In Rust code, class assignment is done with
 MuJoCo copies the values of a class into an element when the element is **created**, so set the
 class on the parent body before you add its children. A call on an element that already exists
 only records the class name: the saved XML then carries ``class="..."``, but the next ``compile``
-keeps the old values. Some item-specific wrappers (for example frames) also expose explicit
-``childclass`` setters, with the same limitation.
+keeps the old values. A frame also exposes an explicit ``childclass`` setter
+(:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsFrame::<method>set_childclass`), with the
+same limitation.
 
 
 Iterators
@@ -356,7 +358,7 @@ The search is recursive, and it returns the body itself when its own name matche
 Every finder returns an ``Option`` that is ``None`` when no element with that name exists.
 
 After compilation, an element's numeric id in the resulting |mj_model| can be retrieved with
-:docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>SpecItem::<method>id`
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>id`
 (``None`` when the element has no id yet).
 
 

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -7,9 +7,9 @@ Model editing
 .. |mj_data| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_data::<struct>MjData`
 .. |mj_model| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel`
 .. |mj_spec| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec`
-.. |mjs_body| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsBody`
-.. |mjs_actuator| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsActuator`
-.. |mjs_flex| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsFlex`
+.. |mjs_body| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsBody`
+.. |mjs_actuator| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsActuator`
+.. |mjs_flex| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsFlex`
 
 The most general way to create an |mj_model| instance is by loading an XML file
 via :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>from_xml`.
@@ -281,7 +281,7 @@ Iterators
 ================
 Since MuJoCo-rs 1.5.0, it is possible to also iterate existing :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec`
 items (geoms, joints, etc.). Iterators exist on :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec`
-and :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsBody`.
+and :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsBody`.
 
 To iterate over :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjSpec` items, call
 ``[item_type]_iter`` for immutable iteration or ``[item_type]_iter_mut`` for mutable iteration,
@@ -295,7 +295,7 @@ with ``[item_type]`` replaced by geom, body, etc.
     }
     // ...
 
-Iteration over :docs-rs:`~mujoco_rs::wrappers::mj_editing::<type>MjsBody` items can be used in a similar way.
+Iteration over :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsBody` items can be used in a similar way.
 The only difference is an additional boolean parameter, which enables recursive iteration when ``true``.
 
 .. code-block:: rust
@@ -326,8 +326,8 @@ Existing elements can be looked up by name. |mj_spec| exposes a finder method (a
 :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>geom`, and
 :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>frame`. Within a body,
 a body of its subtree is found with
-:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsBody::<method>child` /
-:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsBody::<method>child_mut`.
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>child` /
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>child_mut`.
 The search is recursive, and it returns the body itself when its own name matches.
 Every finder returns an ``Option`` that is ``None`` when no element with that name exists.
 
@@ -391,8 +391,8 @@ Procedural flex generation
 A `flexcomp <https://mujoco.readthedocs.io/en/3.12.0/XMLreference.html#body-flexcomp>`_ procedurally
 generates a deformable |mjs_flex| together with its supporting bodies, joints, and optional
 equality constraints --- handy for cloth, ropes, and soft volumes. In MuJoCo-rs it is created with
-:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsBody::<method>add_flexcomp` (or the fallible
-:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<type>MjsBody::<method>try_add_flexcomp`).
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>add_flexcomp` (or the fallible
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>try_add_flexcomp`).
 
 The generation is configured through a ``Default``-able
 :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjFlexcompConfig`, using the same ``with_*``

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -38,6 +38,11 @@ After procedurally creating a specification with |mj_spec|, compile it with
 :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>compile`. The compiled model
 runs in the simulation, and the compiled specification can also be saved to an XML file.
 
+.. attention::
+
+    Model editing stays on one thread. MuJoCo's C++ implementation shares unsynchronized state
+    between a specification and its elements, so |mj_spec| is neither ``Send`` nor ``Sync``.
+
 
 Examples
 ================

--- a/docs/guide/source/programming/simulation/views.rst
+++ b/docs/guide/source/programming/simulation/views.rst
@@ -142,5 +142,6 @@ Each view call compares the layout of the info struct against the layout of the 
 :docs-rs:`~mujoco_rs::wrappers::mj_model::<struct>MjModel`.
 While both of them name the same model, that comparison is a single pointer check.
 Both models keep their own copy of the layout, so after a swap to a different model
-each call compares the entire layout instead. Look the element up again on the new model
-to get the pointer check back.
+each call compares the entire layout instead. Call
+:docs-rs:`~~mujoco_rs::wrappers::mj_data::<struct>MjJointDataInfo::<method>update_layout` once
+against the new ``MjData`` or ``MjModel`` to get the pointer check back.

--- a/docs/guide/source/programming/visualization/drawing.rst
+++ b/docs/guide/source/programming/visualization/drawing.rst
@@ -39,7 +39,8 @@ To draw custom geoms to a scene inside a viewer or a renderer, applications typi
 
 .. warning::
 
-        Both methods are ``unsafe``. The renderer reads the geom's ``matid``, ``texid`` and, on a
+        ``create_geom`` and ``try_create_geom`` are ``unsafe``; ``clear_geom`` is safe. The
+        renderer reads the geom's ``matid``, ``texid`` and, on a
         flex or a skin geom, ``objid`` as unchecked indices, so the caller must keep each one below
         the count of the model that the rendering context was created for. ``matid`` and ``texid``
         also accept ``-1`` for none, which is what the two methods write.

--- a/docs/guide/source/programming/visualization/viewer.rst
+++ b/docs/guide/source/programming/visualization/viewer.rst
@@ -199,7 +199,7 @@ Here's an adapted excerpt from the :gh-example:`example <visualization/viewer/ru
 on how to use the viewer in a multi-threaded way:
 
 .. code-block:: rust
-    :emphasize-lines: 12-13, 18-22, 30-34
+    :emphasize-lines: 1-2, 12-13, 18-22, 31-33
 
     let model = Arc::new(MjModel::from_xml_string(EXAMPLE_MODEL).expect("could not load the model"));
     let mut data = MjData::new(model.clone());
@@ -371,8 +371,10 @@ This requires the ``M`` bound inside |mj_data| to be
 :docs-rs:`~mujoco_rs::wrappers::mj_model::traits::<trait>ModelTypeMut` (e.g., ``Box<MjModel>``).
 
 :docs-rs:`~~mujoco_rs::viewer::<struct>ViewerSharedState::<method>sync_model` does all three in one
-call and also reloads the viewer's internal state when the model's ``signature()`` changed. It takes
-``&mut MjModel``, so the caller passes ``unsafe { data.model_mut() }``.
+call and also reloads the viewer's internal state when the incoming model is no longer compatible
+with the passive model
+(:docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>is_compatible_with_model`). It
+takes ``&mut MjModel``, so the caller passes ``unsafe { data.model_mut() }``.
 
 
 .. _viewer_asset_reupload:
@@ -403,8 +405,9 @@ Both :docs-rs:`~mujoco_rs::viewer::<struct>MjViewer` and
   UV texture coordinates, face-vertex indices, face-normal indices, face-texcoord indices,
   and convex hull graph data), so ``update_meshes_from`` issues several array copies.
 
-Both call paths require ``model`` to be compatible with the viewer's internal passive model
-(:docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>is_compatible_with_model`)
+Both call paths require ``model`` to be asset-compatible with the viewer's internal passive model
+(:docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>is_asset_compatible_with_model`,
+which tests the mesh, texture and heightfield memory only, not the full model layout)
 and return ``Result<(), MjViewerError>`` ---
 :docs-rs:`~~mujoco_rs::viewer::<enum>MjViewerError::<variant>IncompatibleModel` is returned when
 the two models are not compatible, and

--- a/examples/model_editing/model_editing.rs
+++ b/examples/model_editing/model_editing.rs
@@ -4,9 +4,17 @@
 //! This example uses the viewer in single-threaded fashion.
 use std::time::Duration;
 
+use mujoco_rs::wrappers::mj_editing::MjsBody;
 use mujoco_rs::viewer::MjViewer;
 use mujoco_rs::prelude::*;
 use env_logger::Env;
+
+/// Number of pendulum chains.
+const N_CHAINS: usize = 3;
+/// Number of links in one chain.
+const N_LINKS: usize = 4;
+/// Length of one link, in meters.
+const LINK_LENGTH: f64 = 0.15;
 
 
 fn main() {
@@ -47,36 +55,64 @@ fn create_model() -> MjModel {
     // Create a plane
     let plane_geom = world.add_geom()
         .with_type(MjtGeom::mjGEOM_PLANE)
-        .with_size([1.0, 1.0, 1.0]);
+        .with_size([2.0, 2.0, 1.0]);
 
     plane_geom.alt_mut().set_euler(&[2.0, 0.0, 0.0]);  // two degrees
     // or
     // plane_geom.alt_mut().type_ = MjtOrientation::mjORIENTATION_EULER;
     // plane_geom.alt_mut().euler = [2.0, 0.0, 0.0];
 
-    // Create a ball
-    let ball_body = world.add_body()
-        .with_gravcomp(1.0)  // compensate 100% of the body weight.
-        .with_name("ball");
+    // Each chain hangs from the world. A link is a child of the link above it, so one chain is a
+    // branch of the body tree. Every chain starts horizontal and swings down under gravity.
+    for chain in 0..N_CHAINS {
+        let mut parent = world.add_body()
+            .with_name(&format!("chain_{chain}"))
+            .with_pos([0.0, 0.3 * chain as f64 - 0.3, 1.0]);
 
-    ball_body.add_geom()
-        .with_type(MjtGeom::mjGEOM_SPHERE)
-        .with_size([0.020, 0.0, 0.0])
-        .with_rgba([1.0, 1.0, 0.0, 1.0]);  // make the ball yellow.
+        for link in 0..N_LINKS {
+            let child = parent.add_body()
+                .with_name(&format!("link_{chain}_{link}"))
+                .with_pos([LINK_LENGTH, 0.0, 0.0]);
 
-    ball_body.add_joint().with_type(MjtJoint::mjJNT_FREE);
+            child.add_joint()
+                .with_type(MjtJoint::mjJNT_HINGE)
+                .with_axis([0.0, 1.0, 0.0]);
 
-    // Iterate all the sub-bodies of the world body recursively.
-    for body in world.body_iter_mut(true) {  // body_iter(recurse: true)
-        log::info!("Sub-body of world: {}", body.name());
+            child.add_geom()
+                .with_type(MjtGeom::mjGEOM_CAPSULE)
+                .with_size([0.015, 0.0, 0.0])
+                .with_fromto([0.0, 0.0, 0.0, LINK_LENGTH, 0.0, 0.0]);
+
+            parent = child;
+        }
     }
 
-    // Iterate all bodies recursively through MjSpec.
-    // Also prints out the world body.
-    for body in spec.body_iter_mut() {
+    // A mutable walk down the body tree. The world body keeps its own geoms, so the plane keeps
+    // its default colour.
+    for chain in spec.world_body_mut().body_iter_mut() {
+        shade_by_depth(chain, 0);
+    }
+
+    // A read-only walk over every body of the spec, the world body included.
+    for body in spec.body_iter() {
         log::info!("Body: {}", body.name());
     }
 
     // Compile the model (required for saving)
     spec.compile().expect("failed to compile")
+}
+
+
+/// Colours the geoms of `body` and of its whole subtree by how deep each body sits in the tree.
+///
+/// A child borrows its parent, so the two are never live together and the walk has to recurse.
+fn shade_by_depth(body: &mut MjsBody, depth: usize) {
+    let shade = depth as f32 / N_LINKS as f32;
+    for geom in body.geom_iter_mut(false) {
+        *geom.rgba_mut() = [1.0, shade, 1.0 - shade, 1.0];
+    }
+
+    for child in body.body_iter_mut() {
+        shade_by_depth(child, depth + 1);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,12 +127,6 @@ pub fn mujoco_version() -> &'static str {
     unsafe { CStr::from_ptr(arr).to_str().unwrap() }
 }
 
-/// Returns the version string of the MuJoCo library.
-#[deprecated(since = "3.0.0", note = "use `mujoco_version` instead")]
-pub fn get_mujoco_version() -> &'static str {
-    mujoco_version()
-}
-
 #[cfg(test)]
 mod tests {
     use crate::mujoco_version;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -114,7 +114,9 @@ pub unsafe fn set_log_handler(handler: LoggingHandler) {
 /// # Notes
 /// A message with level [`MjtLogLevel::mjLOG_ERROR`] will exit the program with code 1.
 ///
-/// [`MjLogConfig`](crate::wrappers::mj_logging::MjLogConfig) has no effect when this logging hook is installed.
+/// This call replaces MuJoCo's own handler, so the `logto_console`, `logto_file` and `logfile`
+/// fields of [`MjLogConfig`](crate::wrappers::mj_logging::MjLogConfig) no longer reach the output.
+/// It also enables every topic once, so a topic bitmask set before the call is lost.
 pub unsafe fn install_logging_hook() {
     USER_LOG_HANDLER.store(ptr::null_mut(), Ordering::Release);
     // SAFETY: the caller holds every thread that could use MuJoCo.

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -55,8 +55,7 @@ type LoggingHandler = fn(&MjLogMessage);
 /// [`install_logging_hook`] routes to the [`log`] crate instead.
 ///
 /// The MuJoCo handler is [`logging_hook`], which builds the [`MjLogMessage`] reference and then
-/// calls this handler. A [`LoggingHandler`] is a plain function pointer, so it fits in a pointer
-/// and needs no allocation.
+/// calls this handler.
 static USER_LOG_HANDLER: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 
 /// Guards the [`mju_setLogHandler`] call, so that the program writes the MuJoCo globals at most
@@ -67,8 +66,7 @@ static LOGGING_HOOK_INSTALLED: Once = Once::new();
 ///
 /// The function installs the same MuJoCo hook as [`install_logging_hook`], but `handler` replaces
 /// the built-in [`log`] routing of that hook.
-/// 
-/// 
+///
 /// # Clearing a handler
 /// To clear the user handler and restore routing to [`log`],
 /// call [`install_logging_hook`].
@@ -98,7 +96,7 @@ pub unsafe fn set_log_handler(handler: LoggingHandler) {
 /// Wraps [`mju_setLogHandler`].
 ///
 /// Also clears the handler set by [`set_log_handler`].
-/// For  structured [`MjLogMessage`] calls use [`set_log_handler`] instead,
+/// For structured [`MjLogMessage`] calls use [`set_log_handler`] instead,
 /// which installs the same hook and redirects messages to the user handler instead of the `log` crate.
 /// The hook maps the message like this:
 ///
@@ -114,9 +112,7 @@ pub unsafe fn set_log_handler(handler: LoggingHandler) {
 /// before any thread that steps a simulation, loads a model, or emits a message.
 ///
 /// # Notes
-/// A message with level [`MjtLogLevel::mjLOG_ERROR`] will exit the program with code 1, just like the default MuJoCo
-/// handler does, to prevent undefined behaviors that would arise due to MuJoCo erroring system
-/// assumptions.
+/// A message with level [`MjtLogLevel::mjLOG_ERROR`] will exit the program with code 1.
 ///
 /// [`MjLogConfig`](crate::wrappers::mj_logging::MjLogConfig) has no effect when this logging hook is installed.
 pub unsafe fn install_logging_hook() {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,7 +13,9 @@ pub use crate::wrappers::mj_logging::{
     MjLogConfig, MjLogMessage, MjtLogLevel, MjtLogTopic,
     log_config, log_error, log_info, log_message, log_warning, set_log_config,
 };
-pub use crate::wrappers::mj_editing::{MjSpec, MjtConflict, MjFlexcompConfig, SpecItem};
+pub use crate::wrappers::mj_editing::{
+    MjSpec, MjtConflict, MjFlexcompConfig, SpecItem, SpecObject
+};
 pub use crate::logging::{install_logging_hook, set_log_handler};
 pub use crate::wrappers::mj_visualization::*;
 pub use crate::wrappers::mj_rendering::*;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -618,18 +618,6 @@ impl MjRenderer {
         Ok(())
     }
 
-    /// Update the scene with new data and render it.
-    ///
-    /// # Panics
-    /// Panics if syncing the data or performing the render step fails (e.g. the OpenGL
-    /// context cannot be made current). Use [`MjRenderer::sync_data`] + [`MjRenderer::render`]
-    /// instead.
-    #[deprecated(note = "replaced with sync_data + render", since = "3.0.0")]
-    pub fn sync<M: ModelType>(&mut self, data: &mut MjData<M>) {
-        self.sync_data(data).unwrap();
-        self.render().unwrap();
-    }
-
     /// Return a flattened RGB image of the scene.
     pub fn rgb_flat(&self) -> Option<&[u8]> {
         self.rgb.as_deref()

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -651,7 +651,7 @@ impl MjRenderer {
     /// # Returns
     /// On success, returns [`Ok`] variant containing the rendered RGB image.
     /// # Errors
-    /// - [`RendererError::DimensionMismatch`] if `WIDTH * HEIGHT` doesn't match the rendered pixel count .
+    /// - [`RendererError::DimensionMismatch`] if `WIDTH * HEIGHT` doesn't match the rendered pixel count.
     /// - [`RendererError::RgbDisabled`] if RGB rendering is disabled.
     pub fn try_rgb<const WIDTH: usize, const HEIGHT: usize>(&self) -> Result<&[[[u8; 3]; WIDTH]; HEIGHT], RendererError> {
         if let Some(flat) = self.rgb_flat() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -93,9 +93,8 @@ pub(crate) fn checked_c_len<T: TryFrom<usize>>(len: usize) -> T {
 
 /// Offsets a raw array pointer, keeping a null pointer null.
 ///
-/// MuJoCo leaves an arena pointer null until the stage that allocates the array, and every
-/// `PointerView` maps a null pointer to an empty slice. A plain `add` turns null into a non-null
-/// dangling address and so defeats that guard.
+/// A plain `add` turns null into a dangling address, which defeats the empty-slice guard that
+/// every `PointerView` applies to a null pointer.
 ///
 /// # Safety
 /// When `ptr` is not null, `ptr.add(offset)` must stay inside the same allocation.
@@ -936,10 +935,8 @@ macro_rules! array_slice_dyn {
             /// Touches the first and last element of every slice this block reaches through a safe
             /// accessor, on the read path and, where the setter is also safe, on the write path.
             ///
-            /// Exists for the sanitizers. A length that overruns its allocation faults here instead
-            /// of returning a plausible number. Each write restores the value it read, so no field
-            /// changes. Call this on a freshly built value, before any pipeline stage runs: a safe
-            /// accessor must be sound at that point.
+            /// Each write restores the value it read, so no field changes. Call this on a freshly
+            /// built value, before any pipeline stage runs.
             #[cfg(test)]
             pub(crate) fn $probe(&mut self) {
                 $(

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -358,9 +358,8 @@ impl ViewerSharedState {
     /// Performs a bidirectional three-way merge of model's `opt`, `vis`, and `stat` parameters
     /// between the viewer's passive model and the incoming model.
     ///
-    /// Detects model changes via signature comparison and reloads internal state if needed.
+    /// Reloads the internal state when `model` is no longer compatible with the passive model.
     pub fn sync_model(&mut self, model: &mut MjModel) {
-        // Check if model signature changed
         if !self.data_passive.model().is_compatible_with_model(model) {
             // Model changed: reload internal state.
             let max_user_geom = self.user_scene.maxgeom() as usize;

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -297,9 +297,8 @@ impl ViewerSharedState {
     /// Called on construction and whenever [`_sync_data`](Self::_sync_data) or
     /// [`sync_model`](Self::sync_model) detects a model change.
     fn reload_model(&mut self, model: &MjModel, max_user_geom: usize) {
-        // Build every model-dependent value before the first assignment. A panic part-way then
-        // leaves the previous generation whole, instead of a mix of two models that a later sync
-        // accepts because the sizes happen to agree again.
+        // Build every model-dependent value before the first assignment, so a panic part-way
+        // leaves the previous generation whole rather than a mix of two models.
         let mut data_passive = MjData::new(Box::new(model.clone()));
         // Compute kinematic state that the viewer uses (only the state exists on a new MjData).
         data_passive.forward();
@@ -753,7 +752,7 @@ impl ViewerSharedState {
 /// 
 /// With the `viewer-ui` feature, `X` toggles the side UI panel. The side panel also closes and
 /// opens by a drag of its inner edge to and from the screen edge.
-/// 
+///
 /// # Panics
 /// Panics when initialized outside the main thread.
 #[derive(Debug)]
@@ -887,7 +886,7 @@ impl MjViewer {
     /// that calls [`MjViewer::sync_data`] waits for the same [`Mutex`].
     ///
     /// # Model swaps
-    /// Callbacks runs inside [`MjViewer::render`]. A sync on another
+    /// Callbacks run inside [`MjViewer::render`]. A sync on another
     /// thread through [`ViewerSharedState::sync_data`] with `data`'s [`MjData::model`] being a different
     /// model than the model used to create the viewer, or through [`ViewerSharedState::sync_model`],
     /// can cause the contents of [`ViewerSharedState`]'s (the `state` parameter) to change when it isn't locked.
@@ -933,7 +932,7 @@ impl MjViewer {
 
     /// Syncs the state of viewer's internal [`MjData`] with `data`.
     /// This is a proxy to [`ViewerSharedState::sync_data`].
-    /// 
+    ///
     /// Any changes made to the internal [`MjData`] in between syncs
     /// get selectively merged back into `data` before the copy.
     /// Perturbations are applied to `data` **after** the sync, which
@@ -1833,9 +1832,8 @@ impl MjViewer {
         let mut lock = self.shared_state.lock_unpoison();
         let ViewerSharedState {data_passive, pert, model_reloaded, ..} = lock.deref_mut();
 
-        // For a reduced mutex contention, the mutex locks are skipped during part
-        // of the render thread. In the case of the model being reloaded, we defer
-        // all operations until synced again in update_scene.
+        // The render thread skips the mutex lock for part of its work, so a model reload defers
+        // every operation until the next sync in update_scene.
         if *model_reloaded {
             return;
         }
@@ -2100,8 +2098,7 @@ mod tests {
          <geom size=\"0.1\"/></body></worldbody></mujoco>";
 
     /// A reload replaces the passive model, so the merge shadow must describe the new one. A stale
-    /// shadow makes the next `sync_model` read the difference between the two models as a change
-    /// the viewer made, and write it over the caller's own edit.
+    /// shadow makes the next `sync_model` overwrite the caller's own edit.
     #[test]
     fn test_reload_refreshes_the_model_merge_shadow() {
         let mut model_hinge = MjModel::from_xml_string(MODEL_HINGE).unwrap();

--- a/src/viewer/ui.rs
+++ b/src/viewer/ui.rs
@@ -372,9 +372,8 @@ impl ViewerUI {
                         .map(Cow::Borrowed)
                         .or_else(|| (num_inputs > 1).then(|| Cow::Owned(idx_in.to_string())));
 
-                    // The range array holds one entry for each control, not for each actuator.
-                    // A defined range sets the slider range, even when MuJoCo does not clamp the
-                    // control to it.
+                    // The range array holds one entry per control, not per actuator. A defined
+                    // range sets the slider range even when MuJoCo does not clamp the control.
                     let [low, high] = input_limits[ctrl_start + idx_in];
                     let range = if low < high { low..=high } else { -1.0..=1.0 };
 

--- a/src/vis_common.rs
+++ b/src/vis_common.rs
@@ -27,8 +27,7 @@ use std::path::Path;
 /// (see [`MjvScene::is_compatible_with_scene`]).
 pub fn sync_geoms(src: &MjvScene, dst: &mut MjvScene) -> Result<(), MjSceneError> {
     // A copied mjvGeom keeps its objid, which the renderer uses as an unchecked index into the
-    // DESTINATION scene's flex and skin arrays; those are sized by the model the scene was built
-    // for, and are null when that model has none.
+    // DESTINATION scene's flex and skin arrays, sized by the model that scene was built for.
     assert!(
         src.is_compatible_with_scene(dst),
         "the two scenes were created for models that are not compatible"
@@ -157,8 +156,7 @@ mod tests {
     use crate::wrappers::mj_model::{MjModel, MjtGeom};
 
     /// A copied geom keeps its `objid`, which the renderer uses as an unchecked index into the
-    /// destination scene's flex and skin arrays, so the two scenes must belong to one model. The
-    /// pair below differs in the flex arrays alone: a model that holds no flex sizes them to zero.
+    /// destination scene's flex and skin arrays, so the two scenes must belong to one model.
     #[test]
     #[should_panic(expected = "models that are not compatible")]
     fn test_sync_geoms_cross_model_panics() {

--- a/src/wrappers/mj_auxiliary.rs
+++ b/src/wrappers/mj_auxiliary.rs
@@ -96,23 +96,6 @@ impl MjVfs {
         }
     }
 
-    /// Adds a file from disk to the virtual file system.
-    /// # Returns
-    /// `Ok(())` on success.
-    /// # Errors
-    /// - [`MjVfsError::AlreadyExists`] if a file with the same name already exists in the VFS.
-    /// - [`MjVfsError::LoadFailed`] if the file could not be loaded.
-    /// - [`MjVfsError::Unknown`] for unrecognized MuJoCo return codes.
-    /// # Panics
-    /// When `directory` or `filename` contain interior `\0` characters.
-    #[deprecated(since = "3.0.0", note = "use `add_file` or `add_file_from` instead")]
-    pub fn add_from_file(&mut self, directory: Option<&str>, filename: &str) -> Result<(), MjVfsError> {
-        match directory {
-            Some(d) => self.add_file_from(d, filename),
-            None => self.add_file(filename),
-        }
-    }
-
     /// Adds a file from disk to the virtual file system, searching in `directory`.
     /// # Returns
     /// `Ok(())` on success.
@@ -526,29 +509,6 @@ mod tests {
         // PathBuf, &Path
         vfs = MjVfs::new();
         vfs.add_file_from(PathBuf::from("./"), Path::new(FILE)).unwrap();
-        assert!(MjModel::from_xml_vfs(FILE, &vfs).is_ok());
-
-        fs::remove_file(FILE).expect("could not clean up temp file");
-    }
-
-    /// The deprecated `add_from_file` still delegates correctly.
-    #[test]
-    fn test_vfs_deprecated_add_from_file() {
-        const FILE: &str = "mujoco-rs-deprecated-add-from-file.xml";
-        fs::write(FILE, RAW_FILE_DATA).expect("could not write temp file");
-
-        let mut vfs;
-
-        // With directory (delegates to add_file_from)
-        vfs = MjVfs::new();
-        #[allow(deprecated)]
-        vfs.add_from_file(Some("./"), FILE).unwrap();
-        assert!(MjModel::from_xml_vfs(FILE, &vfs).is_ok());
-
-        // Without directory (delegates to add_file)
-        vfs = MjVfs::new();
-        #[allow(deprecated)]
-        vfs.add_from_file(None, FILE).unwrap();
         assert!(MjModel::from_xml_vfs(FILE, &vfs).is_ok());
 
         fs::remove_file(FILE).expect("could not clean up temp file");

--- a/src/wrappers/mj_data.rs
+++ b/src/wrappers/mj_data.rs
@@ -147,21 +147,6 @@ impl<M: ModelType> MjData<M> {
         Ok(std::mem::replace(&mut self.model, model))
     }
 
-    /// Returns a slice of detected contacts.
-    /// To obtain the contact force, call [`MjData::contact_force`].
-    #[deprecated(since = "3.0.0", note = "use contact() instead")]
-    pub fn contacts(&self) -> &[MjContact] {
-        let ffi = self.ffi();
-        let ptr = ffi.contact;
-        if ptr.is_null() {
-            &[]
-        } else {
-            // SAFETY: ptr is non-null (checked above), points to a valid array of `ncon`
-            // initialized mjContact values owned by MjData, and is valid for `'self`.
-            unsafe { std::slice::from_raw_parts(ptr, ffi.ncon as usize) }
-        }
-    }
-
     info_method! { Data, [model], body, [
         xfrc_applied: 6, xpos: 3, xquat: 4, xmat: 9, xipos: 3, ximat: 9, subtree_com: 3, cinert: 10,
         crb: 10, cvel: 6, subtree_linvel: 3, subtree_angmom: 3, cacc: 6, cfrc_int: 6, cfrc_ext: 6,
@@ -1480,13 +1465,6 @@ impl<M: ModelType> MjData<M> {
         let mut destination = vec![0.0; self.model.state_size(spec)].into_boxed_slice();
         Self::read_state_into(self, spec, &mut destination);
         destination
-    }
-
-    /// Same as [`MjData::read_state_into`], except it allocates
-    /// and returns new boxed data containing the state.
-    #[deprecated(since = "3.0.0", note = "use `state` instead")]
-    pub fn get_state(&self, spec: u32) -> Box<[MjtNum]> {
-        self.state(spec)
     }
 
     /// Sets the `state` to [`MjData`]. Wraps [`mj_setState`].

--- a/src/wrappers/mj_data.rs
+++ b/src/wrappers/mj_data.rs
@@ -2018,15 +2018,7 @@ impl<M: ModelType + Clone> MjData<M> {
     /// Fallible version of [`Clone::clone`].
     ///
     /// # Note
-    ///
-    /// <div class="warning">
-    ///
-    /// MuJoCo cannot report a failure here: `mj_copyData` raises `mjERROR` when an allocation
-    /// fails, and the default error handler exits the process, so this method never returns
-    /// `Err`. Prefer [`Clone::clone`]. This method may be undeprecated in the future if MuJoCo's
-    /// upstream C code is changed to report the failure recoverably.
-    ///
-    /// </div>
+    /// MuJoCo ends the process when the allocation fails, so this never returns `Err`.
     ///
     /// # Errors
     /// Returns [`MjDataError::AllocationFailed`] if MuJoCo fails to allocate

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -187,6 +187,9 @@ pub type MjsAuthored = mjsAuthored;
 ** Model Specification
 ***************************/
 /// Model specification. This wraps the FFI type [`mjSpec`] internally.
+///
+/// Model editing is single-threaded. MuJoCo's C++ implementation shares unsynchronized state
+/// between a specification and its elements, so this type is neither [`Send`] nor [`Sync`].
 pub struct MjSpec {
     /// The specification that MuJoCo owns.
     ffi: NonNull<mjSpec>,

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -30,7 +30,7 @@ use crate::mujoco_c::*;
 use crate::getter_setter;
 
 // Re-export with lowercase 'f' to fix method generation
-use crate::mujoco_c::{mjs_addHField as mjs_addHfield, mjsHField as mjsHfield, mjs_asHField as mjs_asHfield};
+use crate::mujoco_c::{mjs_addHField as mjs_addHfield, mjs_asHField as mjs_asHfield};
 use crate::util::{assert_mujoco_version, ERROR_BUF_LEN};
 
 /* Validation helpers */
@@ -137,7 +137,7 @@ impl MjsOrientation {
     }
 }
 
-mjs_opaque!(MjsCompiler, mjsCompiler,
+mjs_opaque!(MjsCompiler <= mjsCompiler,
     "Compiler options. An opaque handle for the FFI type [`mjsCompiler`], reached through \
 [`ffi`](Self::ffi).");
 
@@ -194,17 +194,6 @@ pub type MjsAuthored = mjsAuthored;
 #[derive(Debug)]
 pub struct MjSpec(NonNull<mjSpec>);
 
-// SAFETY: `MjSpec` owns its `mjSpec` exclusively, so moving it between threads transfers
-// sole ownership and cannot race.
-//
-// It is intentionally NOT `Sync`. `clone`/`try_clone` produce a faithful, independent copy, but
-// the C++ copy constructor behind `mj_copySpec` is not strictly `const` on the source: for every
-// actuator it calls `ForgetKeyframes`, which clears two `std::map` keyframe-resolution caches
-// (`act_`/`ctrl_`). Those maps are empty for a normally-built spec, yet `std::map::clear` rewrites
-// the tree header unconditionally, so two threads sharing a `&MjSpec` and cloning concurrently
-// would race on those writes (a data race, though no spec data is lost). Hence the type stays `!Sync`.
-unsafe impl Send for MjSpec {}
-
 impl MjSpec {
     /// Creates an empty [`MjSpec`].
     ///
@@ -240,9 +229,9 @@ impl MjSpec {
 
     /// Creates a deep copy of this [`MjSpec`].
     ///
-    /// Internally calls `mj_copySpec`, which invokes the C++ copy constructor
-    /// on the underlying model.  This is a proper deep copy: the returned spec
-    /// is fully independent from the original.
+    /// Internally calls `mj_copySpec`, which invokes the C++ copy constructor on the underlying
+    /// model. A child specification that the model attaches from another file stays shared with
+    /// the original, behind MuJoCo's own reference count.
     ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] if MuJoCo fails to allocate
@@ -469,17 +458,31 @@ impl MjSpec {
     /// On success, returns [`Ok`] variant containing the loaded [`MjModel`].
     /// # Errors
     /// Returns [`MjEditError::CompileFailed`] if the model fails to compile, including when a
-    /// texture has a builtin pattern set while its `nchannel` is less than 3.
+    /// texture has a builtin pattern set while its `nchannel` is less than 3, and when a texture
+    /// has a negative dimension or a pixel count that does not fit in an [`i32`].
     pub fn compile(&mut self) -> Result<MjModel, MjEditError> {
-        // The builtin-texture generators (`Builtin2D`/`BuiltinCube`) write a hard-coded 3 bytes per
-        // pixel, but MuJoCo only allocates `nchannel*width*height` bytes and (unlike the file/data
-        // paths) does not check `nchannel >= 3` for the builtin path, so `nchannel < 3` heap-overflows
-        // during compilation. Both setters (`set_nchannel`, `set_builtin`) are safe and independent,
-        // so this cross-field invariant can only be enforced at the compile choke point.
+        // A texture carries four independent safe setters whose values MuJoCo only checks against
+        // each other during compilation. Both cross-field invariants can therefore only be
+        // enforced at this choke point.
         for texture in self.texture_iter() {
+            // The builtin generators (`Builtin2D`/`BuiltinCube`) write a hard-coded 3 bytes per
+            // pixel, but MuJoCo allocates `nchannel*width*height` bytes and, unlike the file and
+            // data paths, does not check `nchannel >= 3` for the builtin path.
             if texture.builtin() != MjtBuiltin::mjBUILTIN_NONE && texture.nchannel() < 3 {
                 return Err(MjEditError::CompileFailed(
                     "texture with a builtin pattern requires nchannel >= 3".to_owned(),
+                ));
+            }
+
+            let (nchannel, width, height) = (texture.nchannel(), texture.width(), texture.height());
+            if nchannel < 0 || width < 0 || height < 0 {
+                return Err(MjEditError::CompileFailed(
+                    "texture nchannel, width and height must be non-negative".to_owned(),
+                ));
+            }
+            if i64::from(nchannel) * i64::from(width) * i64::from(height) > i64::from(i32::MAX) {
+                return Err(MjEditError::CompileFailed(
+                    "texture nchannel*width*height must fit in an i32".to_owned(),
                 ));
             }
         }
@@ -834,7 +837,7 @@ impl Clone for MjSpec {
 /***************************
 ** Site specification
 ***************************/
-mjs_struct!(Site [SpecObject]);
+mjs_struct!(Site with SpecObject: MjsSite <= mjsSite);
 impl MjsSite {
     getter_setter! {
         [&] with, get, [
@@ -864,7 +867,7 @@ impl MjsSite {
 /***************************
 ** Joint specification
 ***************************/
-mjs_struct!(Joint [SpecObject]);
+mjs_struct!(Joint with SpecObject: MjsJoint <= mjsJoint);
 impl MjsJoint {
     getter_setter! {
         [&] with, get, [
@@ -919,7 +922,7 @@ impl MjsJoint {
 /***************************
 ** Geom specification
 ***************************/
-mjs_struct!(Geom [SpecObject]);
+mjs_struct!(Geom with SpecObject: MjsGeom <= mjsGeom);
 impl MjsGeom {
     getter_setter! {
         [&] with, get, [
@@ -942,7 +945,7 @@ impl MjsGeom {
         ]
     }
 
-    nested_handle!(plugin: MjsPlugin; "sdf plugin.");
+    nested_handle!(plugin: MjsPluginReference; "sdf plugin.");
 
     getter_setter!([&] with, get, set, [
         [ffi, ffi_mut] type_ + _: MjtGeom;            "geom type.";
@@ -974,7 +977,7 @@ impl MjsGeom {
 /***************************
 ** Camera specification
 ***************************/
-mjs_struct!(Camera [SpecObject]);
+mjs_struct!(Camera with SpecObject: MjsCamera <= mjsCamera);
 impl MjsCamera {
     getter_setter! {
         [&] with, get, [
@@ -1009,7 +1012,7 @@ impl MjsCamera {
 /***************************
 ** Light specification
 ***************************/
-mjs_struct!(Light [SpecObject]);
+mjs_struct!(Light with SpecObject: MjsLight <= mjsLight);
 impl MjsLight {
     getter_setter! {
         [&] with, get, [
@@ -1049,7 +1052,7 @@ impl MjsLight {
 /***************************
 ** Frame specification
 ***************************/
-mjs_struct!(Frame [SpecObject]);
+mjs_struct!(Frame with SpecObject: MjsFrame <= mjsFrame);
 impl MjsFrame {
     add_x_method_by_frame! { body, site, joint, geom, camera, light }
 
@@ -1105,7 +1108,7 @@ impl MjsFrame {
 /***************************
 ** Actuator specification
 ***************************/
-mjs_struct!(Actuator [SpecObject]);
+mjs_struct!(Actuator with SpecObject: MjsActuator <= mjsActuator);
 impl MjsActuator {
     getter_setter! {
         [&] with, get, [
@@ -1128,7 +1131,7 @@ impl MjsActuator {
         ]
     }
 
-    nested_handle!(plugin: MjsPlugin; "actuator plugin.");
+    nested_handle!(plugin: MjsPluginReference; "actuator plugin.");
 
     getter_setter!([&] with, get, set, [
         [ffi, ffi_mut] gaintype: MjtGain;             "gain type.";
@@ -1538,7 +1541,7 @@ impl MjsActuator {
 /***************************
 ** Sensor specification
 ***************************/
-mjs_struct!(Sensor [SpecObject]);
+mjs_struct!(Sensor with SpecObject: MjsSensor <= mjsSensor);
 impl MjsSensor {
     getter_setter! {
         [&] with, get, [
@@ -1552,7 +1555,7 @@ impl MjsSensor {
         ]
     }
 
-    nested_handle!(plugin: MjsPlugin; "sensor plugin.");
+    nested_handle!(plugin: MjsPluginReference; "sensor plugin.");
 
     getter_setter!([&] with, get, set, [
         [ffi, ffi_mut] type_ + _: MjtSensor;          "sensor type.";
@@ -1581,7 +1584,7 @@ impl MjsSensor {
 /***************************
 ** Flex specification
 ***************************/
-mjs_struct!(Flex [SpecObject]);
+mjs_struct!(Flex with SpecObject: MjsFlex <= mjsFlex);
 impl MjsFlex {
     getter_setter! {
         [&] with, get, [
@@ -1662,7 +1665,7 @@ impl MjsFlex {
 /***************************
 ** Pair specification
 ***************************/
-mjs_struct!(Pair [SpecObject]);
+mjs_struct!(Pair with SpecObject: MjsPair <= mjsPair);
 impl MjsPair {
     getter_setter! {
         [&] with, get, [
@@ -1691,7 +1694,7 @@ impl MjsPair {
 /***************************
 ** Exclude specification
 ***************************/
-mjs_struct!(Exclude [SpecObject]);
+mjs_struct!(Exclude with SpecObject: MjsExclude <= mjsExclude);
 impl MjsExclude {
     string_set_get_with! {[&]
         bodyname1; "name of body 1.";
@@ -1702,7 +1705,7 @@ impl MjsExclude {
 /***************************
 ** Equality specification
 ***************************/
-mjs_struct!(Equality [SpecObject]);
+mjs_struct!(Equality with SpecObject: MjsEquality <= mjsEquality);
 impl MjsEquality {
     getter_setter! {
         [&] with, get, [
@@ -1730,7 +1733,7 @@ impl MjsEquality {
 /***************************
 ** Tendon specification
 ***************************/
-mjs_struct!(Tendon [SpecObject]);
+mjs_struct!(Tendon with SpecObject: MjsTendon <= mjsTendon);
 impl MjsTendon {
     getter_setter! {
         [&] with, get, [
@@ -1939,7 +1942,7 @@ impl MjsTendon {
 /***************************
 ** Wrap specification
 ***************************/
-mjs_struct!(Wrap {
+mjs_struct!(MjsWrap <= mjsWrap {
     /// A wrap carries no name of its own; [`SpecItem::name`] reports the wrapped object's name.
     ///
     /// # Errors
@@ -1968,16 +1971,12 @@ impl MjsWrap {
     /// Return the side site element. Returns `None` when the wrap is not a sphere or cylinder
     /// wrap, when it holds no side site, or when the named site is missing from the spec (MuJoCo
     /// logs a warning in that last case).
+    ///
+    /// There is no mutable counterpart due to alising issues.
+    /// Edit the site through [`MjSpec::site_mut`] instead.
     pub fn side_site(&self) -> Option<&MjsSite> {
         let ptr = unsafe { mjs_getWrapSideSite(self.ffi()) };
         unsafe { MjsSite::from_ffi_ptr(ptr) }
-    }
-
-    /// Return the side site element mutably. Returns `None` under the same conditions as
-    /// [`MjsWrap::side_site`].
-    pub fn side_site_mut(&mut self) -> Option<&mut MjsSite> {
-        let ptr = unsafe { mjs_getWrapSideSite(self.ffi()) };
-        unsafe { MjsSite::from_ffi_ptr_mut(ptr) }
     }
 
     /// Return the wrap divisor. For a wrap whose type is not [`MjtWrap::mjWRAP_PULLEY`], MuJoCo
@@ -1996,7 +1995,7 @@ impl MjsWrap {
 /***************************
 ** Numeric specification
 ***************************/
-mjs_struct!(Numeric [SpecObject]);
+mjs_struct!(Numeric with SpecObject: MjsNumeric <= mjsNumeric);
 impl MjsNumeric {
     getter_setter! {
         [&] with, get, set, [
@@ -2012,7 +2011,7 @@ impl MjsNumeric {
 /***************************
 ** Text specification
 ***************************/
-mjs_struct!(Text [SpecObject]);
+mjs_struct!(Text with SpecObject: MjsText <= mjsText);
 impl MjsText {
     string_set_get_with! {[&]
         data; "text string.";
@@ -2022,7 +2021,7 @@ impl MjsText {
 /***************************
 ** Tuple specification
 ***************************/
-mjs_struct!(Tuple [SpecObject]);
+mjs_struct!(Tuple with SpecObject: MjsTuple <= mjsTuple);
 impl MjsTuple {
     vec_set! {
         // `objtype` is stored as a raw C `int` and, at `compile()` time, used to index the model
@@ -2046,7 +2045,7 @@ impl MjsTuple {
 /***************************
 ** Key specification
 ***************************/
-mjs_struct!(Key [SpecObject]);
+mjs_struct!(Key with SpecObject: MjsKey <= mjsKey);
 impl MjsKey {
     getter_setter! {
         [&] with, get, set, [
@@ -2067,7 +2066,28 @@ impl MjsKey {
 /***************************
 ** Plugin specification
 ***************************/
-mjs_struct!(Plugin [SpecObject]);
+mjs_struct!(Plugin with SpecObject: MjsPlugin <= mjsPlugin);
+
+mjs_opaque!(MjsPluginReference <= mjsPlugin,
+    "Reference to the plugin instance that an element embeds.\n\n\
+     A body, geom, mesh, actuator or sensor names the instance it uses through this reference. \
+     The reference carries no element of its own: MuJoCo resolves the `element` field to the \
+     [`MjsPlugin`] instance that the name selects. Reach the instance itself through \
+     [`MjSpec::plugin`].");
+
+impl MjsPluginReference {
+    string_set_get_with! {[&]
+        name; "instance name.";
+        plugin_name; "plugin name.";
+    }
+
+    getter_setter! {
+        [&] with, get, set, [
+            [ffi, ffi_mut] active: bool; "is the plugin active.";
+        ]
+    }
+}
+
 impl MjsPlugin {
     string_set_get_with! {[&]
         name; "instance name.";
@@ -2086,7 +2106,7 @@ impl MjsPlugin {
 /***************************
 ** Mesh specification
 ***************************/
-mjs_struct!(Mesh [SpecObject]);
+mjs_struct!(Mesh with SpecObject: MjsMesh <= mjsMesh);
 impl MjsMesh {
     getter_setter! {
         [&] with, get, [
@@ -2101,7 +2121,7 @@ impl MjsMesh {
         ]
     }
 
-    nested_handle!(plugin: MjsPlugin; "sdf plugin.");
+    nested_handle!(plugin: MjsPluginReference; "sdf plugin.");
 
     getter_setter! {
         [&] with, get, set, [
@@ -2147,7 +2167,7 @@ impl MjsMesh {
 /***************************
 ** Hfield specification
 ***************************/
-mjs_struct!(Hfield [SpecObject]);
+mjs_struct!(HField with SpecObject: MjsHfield <= mjsHField);
 impl MjsHfield {
     getter_setter! {
         [&] with, get, [
@@ -2175,7 +2195,7 @@ impl MjsHfield {
 /***************************
 ** Skin specification
 ***************************/
-mjs_struct!(Skin [SpecObject]);
+mjs_struct!(Skin with SpecObject: MjsSkin <= mjsSkin);
 impl MjsSkin {
     getter_setter! {
         [&] with, get, [
@@ -2222,7 +2242,7 @@ impl MjsSkin {
 /***************************
 ** Texture specification
 ***************************/
-mjs_struct!(Texture [SpecObject]);
+mjs_struct!(Texture with SpecObject: MjsTexture <= mjsTexture);
 
 /// # Note: cube-map files
 ///
@@ -2292,7 +2312,7 @@ impl MjsTexture {
 /***************************
 ** Material specification
 ***************************/
-mjs_struct!(Material [SpecObject]);
+mjs_struct!(Material with SpecObject: MjsMaterial <= mjsMaterial);
 
 /// # Note: texture assignment
 ///
@@ -2334,7 +2354,7 @@ impl MjsMaterial {
 /***************************
 ** Body specification
 ***************************/
-mjs_struct!(Body [SpecObject] {
+mjs_struct!(Body with SpecObject: MjsBody <= mjsBody {
     // Override the delete method to prevent deletion of world.
     /// Delete this body from its parent spec.
     ///
@@ -2654,7 +2674,7 @@ impl MjsBody {
         ]
     }
 
-    nested_handle!(plugin: MjsPlugin; "passive force plugin.");
+    nested_handle!(plugin: MjsPluginReference; "passive force plugin.");
 
     // Plain types with normal getters and setters.
     getter_setter! {

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -137,36 +137,38 @@ impl MjsOrientation {
     }
 }
 
-/// Compiler options.
-pub type MjsCompiler = mjsCompiler;
+mjs_opaque!(MjsCompiler, mjsCompiler,
+    "Compiler options. An opaque handle for the FFI type [`mjsCompiler`], reached through \
+[`ffi`](Self::ffi).");
+
 impl MjsCompiler {
     getter_setter! {[&] with, get, set, [
-        autolimits: bool;              "infer \"limited\" attribute based on range.";
-        balanceinertia: bool;          "automatically impose A + B >= C rule.";
-        fitaabb: bool;                 "meshfit to aabb instead of inertia box.";
-        degree: bool;                  "angles in radians or degrees.";
-        discardvisual: bool;           "discard visual geoms in parser.";
-        usethread: bool;               "use multiple threads to speed up compiler.";
-        fusestatic: bool;              "fuse static bodies with parent.";
-        saveinertial: bool;            "save explicit inertial clause for all bodies to XML.";
-        alignfree: bool;               "align free joints with inertial frame.";
+        [ffi, ffi_mut] autolimits: bool;              "infer \"limited\" attribute based on range.";
+        [ffi, ffi_mut] balanceinertia: bool;          "automatically impose A + B >= C rule.";
+        [ffi, ffi_mut] fitaabb: bool;                 "meshfit to aabb instead of inertia box.";
+        [ffi, ffi_mut] degree: bool;                  "angles in radians or degrees.";
+        [ffi, ffi_mut] discardvisual: bool;           "discard visual geoms in parser.";
+        [ffi, ffi_mut] usethread: bool;               "use multiple threads to speed up compiler.";
+        [ffi, ffi_mut] fusestatic: bool;              "fuse static bodies with parent.";
+        [ffi, ffi_mut] saveinertial: bool;            "save explicit inertial clause for all bodies to XML.";
+        [ffi, ffi_mut] alignfree: bool;               "align free joints with inertial frame.";
     ]}
 
     getter_setter! {[&] with, get, set, [
-        boundmass: f64;                "enforce minimum body mass.";
-        boundinertia: f64;             "enforce minimum body diagonal inertia.";
-        settotalmass: f64;             "rescale masses and inertias; <=0: ignore.";
+        [ffi, ffi_mut] boundmass: f64;                "enforce minimum body mass.";
+        [ffi, ffi_mut] boundinertia: f64;             "enforce minimum body diagonal inertia.";
+        [ffi, ffi_mut] settotalmass: f64;             "rescale masses and inertias; <=0: ignore.";
     ]}
 
     getter_setter! {[&] with, get, set, [
-        inertiafromgeom: MjtInertiaFromGeom [force];  "use geom inertias.";
-        conflict: MjtConflict [force];                "conflict-resolution policy for attach.";
+        [ffi, ffi_mut] inertiafromgeom: MjtInertiaFromGeom [force];  "use geom inertias.";
+        [ffi, ffi_mut] conflict: MjtConflict [force];                "conflict-resolution policy for attach.";
     ]}
 
     getter_setter! {[&] with, get, [
-        inertiagrouprange: &[i32; 2];       "range of geom groups used to compute inertia.";
-        eulerseq: &[c_char; 3];             "sequence for euler rotations.";
-        LRopt: &MjLROpt;                    "options for lengthrange computation.";
+        [ffi, ffi_mut] inertiagrouprange: &[i32; 2];       "range of geom groups used to compute inertia.";
+        [ffi, ffi_mut] eulerseq: &[c_char; 3];             "sequence for euler rotations.";
+        [ffi, ffi_mut] LRopt: &MjLROpt;                    "options for lengthrange computation.";
     ]}
 
     string_set_get_with! {[&]
@@ -175,15 +177,14 @@ impl MjsCompiler {
     }
 
     getter_setter! { get, [
-        authored: u64; "bitmask of authored compiler fields.";
+        [ffi] authored: u64; "bitmask of authored compiler fields.";
     ]}
 }
 
 /// Authored-field tracking bitmasks for [`mjModel`] structs.
 ///
-/// Each field records, as a bitmask, which attributes of the corresponding
-/// section were explicitly authored (set) in the specification. MuJoCo's XML
-/// parser sets them and the attachment step uses them to resolve conflicts.
+/// Each field records, as a bitmask, which attributes of the corresponding section were
+/// explicitly authored in the specification.
 pub type MjsAuthored = mjsAuthored;
 
 /***************************
@@ -217,16 +218,7 @@ impl MjSpec {
     /// Fallible version of [`MjSpec::new`].
     ///
     /// # Note
-    ///
-    /// <div class="warning">
-    ///
-    /// MuJoCo cannot report a failure here: `mj_makeSpec` allocates the spec with C++ `new`,
-    /// which throws instead of returning null, and then returns the address of the spec it just
-    /// created, so this method never returns `Err`. An allocation failure ends the process: the
-    /// exception cannot cross the C API. Prefer [`MjSpec::new`]. This method may be undeprecated
-    /// in the future if MuJoCo's upstream C++ code is changed to report the failure recoverably.
-    ///
-    /// </div>
+    /// MuJoCo ends the process when the allocation fails, so this never returns `Err`.
     ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] if MuJoCo fails to allocate
@@ -625,19 +617,20 @@ impl MjSpec {
 /// Public attributes.
 impl MjSpec {
     string_set_get_with! {
-        [ffi, ffi_mut] modelname; "model name.";
-        [ffi, ffi_mut] comment; "comment at top of XML.";
-        [ffi, ffi_mut] modelfiledir; "path to model file.";
+        modelname; "model name.";
+        comment; "comment at top of XML.";
+        modelfiledir; "path to model file.";
     }
 
     getter_setter! {
         with, get, [
-            [ffi, ffi_mut] compiler: &MjsCompiler; "compiler options.";
             [ffi, ffi_mut] stat: &MjStatistic; "statistic overrides.";
             [ffi, ffi_mut] visual: &MjVisual; "visualization options.";
             [ffi, ffi_mut] option: &MjOption; "simulation options.";
         ]
     }
+
+    nested_handle!(compiler: MjsCompiler; "compiler options.");
 
     getter_setter! {
         get, [
@@ -702,7 +695,7 @@ impl MjSpec {
         let c_class_name = CString::new(class_name).unwrap();
 
         let parent_ptr = if let Some(name) = parent_class_name {
-                self.default(name).ok_or(MjEditError::NotFound)?
+                self.default(name).ok_or(MjEditError::NotFound)?.ffi()
         } else {
             ptr::null()
         };
@@ -717,7 +710,7 @@ impl MjSpec {
                 Err(MjEditError::AlreadyExists)
             }
             else {
-                Ok(&mut *ptr_default)
+                Ok(MjsDefault::from_ffi_ptr_mut(ptr_default).unwrap())
             }
         }
     }
@@ -846,19 +839,19 @@ impl MjsSite {
     getter_setter! {
         [&] with, get, [
             // frame, size
-            pos:  &[f64; 3];              "position.";
-            quat: &[f64; 4];              "orientation.";
-            alt:  &MjsOrientation;        "alternative orientation.";
-            fromto: &[f64; 6];            "alternative for capsule, cylinder, box, ellipsoid.";
-            size: &[f64; 3];              "geom size.";
+            [ffi, ffi_mut] pos:  &[f64; 3];              "position.";
+            [ffi, ffi_mut] quat: &[f64; 4];              "orientation.";
+            [ffi, ffi_mut] alt:  &MjsOrientation;        "alternative orientation.";
+            [ffi, ffi_mut] fromto: &[f64; 6];            "alternative for capsule, cylinder, box, ellipsoid.";
+            [ffi, ffi_mut] size: &[f64; 3];              "geom size.";
 
             // visual
-            rgba: &[f32; 4];              "rgba when material is omitted.";
+            [ffi, ffi_mut] rgba: &[f32; 4];              "rgba when material is omitted.";
     ]}
 
     getter_setter!([&] with, get, set, [
-        type_ + _: MjtGeom;               "geom type.";
-        group: i32;                       "group.";
+        [ffi, ffi_mut] type_ + _: MjtGeom;               "geom type.";
+        [ffi, ffi_mut] group: i32;                       "group.";
     ]);
 
     userdata_method!(f64);
@@ -876,47 +869,47 @@ impl MjsJoint {
     getter_setter! {
         [&] with, get, [
             // kinematics
-            pos:     &[f64; 3];         "anchor position.";
-            axis:    &[f64; 3];         "joint axis.";
-            ref_ + _:    &f64;          "value at reference configuration: qpos0.";
-            springdamper: &[f64; 2];    "timeconst, dampratio.";
+            [ffi, ffi_mut] pos:     &[f64; 3];         "anchor position.";
+            [ffi, ffi_mut] axis:    &[f64; 3];         "joint axis.";
+            [ffi, ffi_mut] ref_ + _:    &f64;          "value at reference configuration: qpos0.";
+            [ffi, ffi_mut] springdamper: &[f64; 2];    "timeconst, dampratio.";
 
             // stiffness
-            stiffness: &[f64; mjNPOLY as usize + 1];            "stiffness coefficients.";
+            [ffi, ffi_mut] stiffness: &[f64; mjNPOLY as usize + 1];            "stiffness coefficients.";
 
             // limits
-            range:   &[f64; 2];         "joint limits.";
-            solref_limit: &[MjtNum; mjNREF as usize];  "solver reference: joint limits.";
-            solimp_limit: &[MjtNum; mjNIMP as usize];  "solver impedance: joint limits.";
-            actfrcrange: &[f64; 2];     "actuator force limits.";
+            [ffi, ffi_mut] range:   &[f64; 2];         "joint limits.";
+            [ffi, ffi_mut] solref_limit: &[MjtNum; mjNREF as usize];  "solver reference: joint limits.";
+            [ffi, ffi_mut] solimp_limit: &[MjtNum; mjNIMP as usize];  "solver impedance: joint limits.";
+            [ffi, ffi_mut] actfrcrange: &[f64; 2];     "actuator force limits.";
 
             // dof properties
-            damping: &[f64; mjNPOLY as usize + 1];                 "damping coefficients.";
-            solref_friction: &[MjtNum; mjNREF as usize]; "solver reference: dof friction.";
-            solimp_friction: &[MjtNum; mjNIMP as usize]; "solver impedance: dof friction.";
+            [ffi, ffi_mut] damping: &[f64; mjNPOLY as usize + 1];                 "damping coefficients.";
+            [ffi, ffi_mut] solref_friction: &[MjtNum; mjNREF as usize]; "solver reference: dof friction.";
+            [ffi, ffi_mut] solimp_friction: &[MjtNum; mjNIMP as usize]; "solver impedance: dof friction.";
         ]
     }
 
     getter_setter!([&] with, get, set, [
-        type_ + _: MjtJoint;           "joint type.";
-        group: i32;                    "joint group.";
-        springref: f64;               "spring reference value: qpos_spring.";
-        margin: f64;                  "margin value for joint limit detection.";
-        armature: f64;                "armature inertia (mass for slider).";
-        frictionloss: f64;            "friction loss.";
+        [ffi, ffi_mut] type_ + _: MjtJoint;           "joint type.";
+        [ffi, ffi_mut] group: i32;                    "joint group.";
+        [ffi, ffi_mut] springref: f64;               "spring reference value: qpos_spring.";
+        [ffi, ffi_mut] margin: f64;                  "margin value for joint limit detection.";
+        [ffi, ffi_mut] armature: f64;                "armature inertia (mass for slider).";
+        [ffi, ffi_mut] frictionloss: f64;            "friction loss.";
     ]);
 
     getter_setter! {
         [&] with, get, set, [
-            align: MjtAlignFree [force];       "align free joint with body com (mjtAlignFree).";
-            limited: MjtLimited [force];       "does joint have limits (mjtLimited).";
-            actfrclimited: MjtLimited [force]; "are actuator forces on joint limited (mjtLimited).";
+            [ffi, ffi_mut] align: MjtAlignFree [force];       "align free joint with body com (mjtAlignFree).";
+            [ffi, ffi_mut] limited: MjtLimited [force];       "does joint have limits (mjtLimited).";
+            [ffi, ffi_mut] actfrclimited: MjtLimited [force]; "are actuator forces on joint limited (mjtLimited).";
         ]
     }
 
     getter_setter! {
         [&] with, get, set, [
-            actgravcomp: bool;         "is gravcomp force applied via actuators.";
+            [ffi, ffi_mut] actgravcomp: bool;         "is gravcomp force applied via actuators.";
         ]
     }
 
@@ -930,42 +923,43 @@ mjs_struct!(Geom [SpecObject]);
 impl MjsGeom {
     getter_setter! {
         [&] with, get, [
-            pos: &[f64; 3];                         "geom position.";
-            quat: &[f64; 4];                        "geom orientation.";
-            alt: &MjsOrientation;                   "alternative orientation.";
-            fromto: &[f64; 6];                      "alternative for capsule, cylinder, box, ellipsoid.";
-            size: &[f64; 3];                        "geom size.";
-            rgba: &[f32; 4];                        "rgba when material is omitted.";
-            friction: &[f64; 3];                    "one-sided friction coefficients: slide, spin, roll.";
-            solref: &[MjtNum; mjNREF as usize];     "solver reference.";
-            solimp: &[MjtNum; mjNIMP as usize];     "solver impedance.";
-            surfacevel: &[f64; 6];                  "surface velocity in local frame: linear, angular.";
-            fluid_coefs: &[MjtNum; 5];              "ellipsoid-fluid interaction coefs."
+            [ffi, ffi_mut] pos: &[f64; 3];                         "geom position.";
+            [ffi, ffi_mut] quat: &[f64; 4];                        "geom orientation.";
+            [ffi, ffi_mut] alt: &MjsOrientation;                   "alternative orientation.";
+            [ffi, ffi_mut] fromto: &[f64; 6];                      "alternative for capsule, cylinder, box, ellipsoid.";
+            [ffi, ffi_mut] size: &[f64; 3];                        "geom size.";
+            [ffi, ffi_mut] rgba: &[f32; 4];                        "rgba when material is omitted.";
+            [ffi, ffi_mut] friction: &[f64; 3];                    "one-sided friction coefficients: slide, spin, roll.";
+            [ffi, ffi_mut] solref: &[MjtNum; mjNREF as usize];     "solver reference.";
+            [ffi, ffi_mut] solimp: &[MjtNum; mjNIMP as usize];     "solver impedance.";
+            [ffi, ffi_mut] surfacevel: &[f64; 6];                  "surface velocity in local frame: linear, angular.";
+            [ffi, ffi_mut] fluid_coefs: &[MjtNum; 5];              "ellipsoid-fluid interaction coefs."
         ]
     }
 
     getter_setter! {
         get, [
-            plugin: &MjsPlugin;                     "sdf plugin.";
         ]
     }
 
+    nested_handle!(plugin: MjsPlugin; "sdf plugin.");
+
     getter_setter!([&] with, get, set, [
-        type_ + _: MjtGeom;            "geom type.";
-        group: i32;                    "group.";
-        contype: i32;                  "contact type.";
-        conaffinity: i32;              "contact affinity.";
-        condim: i32;                   "contact dimensionality.";
-        priority: i32;                 "contact priority.";
-        solmix: f64;                   "solver mixing for contact pairs.";
-        margin: f64;                   "margin for contact detection.";
-        gap: f64;                      "additional contact detection buffer.";
-        adhesion: f64;                 "adhesive force of contacts.";
-        mass: f64;                     "used to compute density.";
-        density: f64;                  "used to compute mass and inertia from volume or surface.";
-        typeinertia: MjtGeomInertia;   "selects between surface and volume inertia.";
-        fluid_ellipsoid: MjtNum;       "whether ellipsoid-fluid model is active.";
-        fitscale: f64;                 "scale mesh uniformly.";
+        [ffi, ffi_mut] type_ + _: MjtGeom;            "geom type.";
+        [ffi, ffi_mut] group: i32;                    "group.";
+        [ffi, ffi_mut] contype: i32;                  "contact type.";
+        [ffi, ffi_mut] conaffinity: i32;              "contact affinity.";
+        [ffi, ffi_mut] condim: i32;                   "contact dimensionality.";
+        [ffi, ffi_mut] priority: i32;                 "contact priority.";
+        [ffi, ffi_mut] solmix: f64;                   "solver mixing for contact pairs.";
+        [ffi, ffi_mut] margin: f64;                   "margin for contact detection.";
+        [ffi, ffi_mut] gap: f64;                      "additional contact detection buffer.";
+        [ffi, ffi_mut] adhesion: f64;                 "adhesive force of contacts.";
+        [ffi, ffi_mut] mass: f64;                     "used to compute density.";
+        [ffi, ffi_mut] density: f64;                  "used to compute mass and inertia from volume or surface.";
+        [ffi, ffi_mut] typeinertia: MjtGeomInertia;   "selects between surface and volume inertia.";
+        [ffi, ffi_mut] fluid_ellipsoid: MjtNum;       "whether ellipsoid-fluid model is active.";
+        [ffi, ffi_mut] fitscale: f64;                 "scale mesh uniformly.";
     ]);
 
     userdata_method!(f64);
@@ -984,25 +978,25 @@ mjs_struct!(Camera [SpecObject]);
 impl MjsCamera {
     getter_setter! {
         [&] with, get, [
-            pos: &[f64; 3];               "camera position.";
-            quat: &[f64; 4];              "camera orientation.";
-            alt: &MjsOrientation;         "alternative orientation.";
-            intrinsic: &[f32; 4];         "intrinsic parameters.";
-            sensor_size: &[f32; 2];       "sensor size.";
-            resolution: &[i32; 2];        "resolution.";
-            focal_length: &[f32; 2];      "focal length (length).";
-            focal_pixel: &[f32; 2];       "focal length (pixel).";
-            principal_length: &[f32; 2];  "principal point (length).";
-            principal_pixel: &[f32; 2];   "principal point (pixel).";
+            [ffi, ffi_mut] pos: &[f64; 3];               "camera position.";
+            [ffi, ffi_mut] quat: &[f64; 4];              "camera orientation.";
+            [ffi, ffi_mut] alt: &MjsOrientation;         "alternative orientation.";
+            [ffi, ffi_mut] intrinsic: &[f32; 4];         "intrinsic parameters.";
+            [ffi, ffi_mut] sensor_size: &[f32; 2];       "sensor size.";
+            [ffi, ffi_mut] resolution: &[i32; 2];        "resolution.";
+            [ffi, ffi_mut] focal_length: &[f32; 2];      "focal length (length).";
+            [ffi, ffi_mut] focal_pixel: &[f32; 2];       "focal length (pixel).";
+            [ffi, ffi_mut] principal_length: &[f32; 2];  "principal point (length).";
+            [ffi, ffi_mut] principal_pixel: &[f32; 2];   "principal point (pixel).";
         ]
     }
 
     getter_setter!([&] with, get, set, [
-        mode: MjtCamLight;              "camera mode.";
-        fovy: f64;                      "field of view in y direction.";
-        ipd: f64;                       "inter-pupillary distance for stereo.";
-        proj: MjtProjection;            "camera projection type.";
-        output: i32;                    "bit flags for output type.";
+        [ffi, ffi_mut] mode: MjtCamLight;              "camera mode.";
+        [ffi, ffi_mut] fovy: f64;                      "field of view in y direction.";
+        [ffi, ffi_mut] ipd: f64;                       "inter-pupillary distance for stereo.";
+        [ffi, ffi_mut] proj: MjtProjection;            "camera projection type.";
+        [ffi, ffi_mut] output: i32;                    "bit flags for output type.";
     ]);
 
     userdata_method!(f64);
@@ -1019,30 +1013,30 @@ mjs_struct!(Light [SpecObject]);
 impl MjsLight {
     getter_setter! {
         [&] with, get, [
-            pos: &[f64; 3];               "light position.";
-            dir: &[f64; 3];               "light direction.";
-            ambient: &[f32; 3];           "ambient color.";
-            diffuse: &[f32; 3];           "diffuse color.";
-            specular: &[f32; 3];          "specular color.";
-            attenuation: &[f32; 3];       "OpenGL attenuation (quadratic model).";
+            [ffi, ffi_mut] pos: &[f64; 3];               "light position.";
+            [ffi, ffi_mut] dir: &[f64; 3];               "light direction.";
+            [ffi, ffi_mut] ambient: &[f32; 3];           "ambient color.";
+            [ffi, ffi_mut] diffuse: &[f32; 3];           "diffuse color.";
+            [ffi, ffi_mut] specular: &[f32; 3];          "specular color.";
+            [ffi, ffi_mut] attenuation: &[f32; 3];       "OpenGL attenuation (quadratic model).";
         ]
     }
 
     getter_setter!([&] with, get, set, [
-        mode: MjtCamLight;             "light mode.";
-        type_ + _: MjtLightType;       "light type.";
-        bulbradius: f32;               "bulb radius, for soft shadows.";
-        intensity: f32;                "intensity, in candelas.";
-        range: f32;                    "range of effectiveness.";
-        cutoff: f32;                   "OpenGL cutoff.";
-        softness: f32;                 "spotlight edge softness.";
-        exponent: f32;                 "OpenGL exponent.";
+        [ffi, ffi_mut] mode: MjtCamLight;             "light mode.";
+        [ffi, ffi_mut] type_ + _: MjtLightType;       "light type.";
+        [ffi, ffi_mut] bulbradius: f32;               "bulb radius, for soft shadows.";
+        [ffi, ffi_mut] intensity: f32;                "intensity, in candelas.";
+        [ffi, ffi_mut] range: f32;                    "range of effectiveness.";
+        [ffi, ffi_mut] cutoff: f32;                   "OpenGL cutoff.";
+        [ffi, ffi_mut] softness: f32;                 "spotlight edge softness.";
+        [ffi, ffi_mut] exponent: f32;                 "OpenGL exponent.";
     ]);
 
     getter_setter! {
         [&] with, get, set, [
-            active: bool;       "active flag.";
-            castshadow: bool;   "whether light cast shadows."
+            [ffi, ffi_mut] active: bool;       "active flag.";
+            [ffi, ffi_mut] castshadow: bool;   "whether light cast shadows."
         ]
     }
 
@@ -1061,9 +1055,9 @@ impl MjsFrame {
 
     getter_setter! {
         [&] with, get, [
-            pos: &[f64; 3];               "frame position.";
-            quat: &[f64; 4];              "frame orientation.";
-            alt: &MjsOrientation;         "alternative orientation.";
+            [ffi, ffi_mut] pos: &[f64; 3];               "frame position.";
+            [ffi, ffi_mut] quat: &[f64; 4];              "frame orientation.";
+            [ffi, ffi_mut] alt: &MjsOrientation;         "alternative orientation.";
         ]
     }
 
@@ -1083,17 +1077,7 @@ impl MjsFrame {
     /// Fallible version of [`Self::add_frame`].
     ///
     /// # Note
-    ///
-    /// <div class="warning">
-    ///
-    /// MuJoCo cannot report a failure here: `mjs_addFrame` allocates the frame with C++ `new`,
-    /// which throws instead of returning null, and then returns the address of the frame it just
-    /// added, so this method never returns `Err`. An allocation failure ends the process: the
-    /// exception cannot cross the C API. Prefer the panicking [`Self::add_frame`]. This method
-    /// may be undeprecated in the future if MuJoCo's upstream C++ code is changed to report the
-    /// failure recoverably.
-    ///
-    /// </div>
+    /// MuJoCo ends the process when the allocation fails, so this never returns `Err`.
     ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] when MuJoCo fails to allocate
@@ -1108,11 +1092,11 @@ impl MjsFrame {
         // mjs_addFrame, which always calls SetParent(body).
         let parent_body = unsafe { mjs_getParent(self.element_mut_pointer()) };
         debug_assert!(!parent_body.is_null(), "mjs_getParent returned null; frame has no parent body");
-        let ptr = unsafe { mjs_addFrame(parent_body, self) };
+        let ptr = unsafe { mjs_addFrame(parent_body, self.ffi_mut()) };
         // SAFETY: ptr.as_mut() returns None for null, handled by ok_or; when non-null the
         // pointee is properly aligned and initialized by C++ operator new, and freshly
         // allocated so no existing Rust reference aliases it for the returned lifetime.
-        unsafe { ptr.as_mut() }.ok_or(MjEditError::AllocationFailed)
+        unsafe { MjsFrame::from_ffi_ptr_mut(ptr) }.ok_or(MjEditError::AllocationFailed)
     }
 }
 
@@ -1125,58 +1109,59 @@ mjs_struct!(Actuator [SpecObject]);
 impl MjsActuator {
     getter_setter! {
         [&] with, get, [
-            gear: &[f64; 6];                            "gear parameters.";
-            gainprm: &[f64; mjNGAIN as usize];          "gain parameters.";
-            biasprm: &[f64; mjNBIAS as usize];          "bias parameters.";
-            dynprm: &[f64; mjNDYN as usize];            "dynamic parameters.";
-            lengthrange: &[f64; 2];                     "transmission length range.";
-            damping: &[f64; mjNPOLY as usize + 1];      "damping coefficients.";
-            ctrlrange: &[f64; 2];                       "control range.";
-            velrange: &[f64; 2];                        "range of the velocity-setpoint input (pid).";
-            ffrange: &[f64; 2];                         "range of the feedforward input (pid).";
-            forcerange: &[f64; 2];                      "force range.";
-            actrange: &[f64; 2];                        "activation range.";
+            [ffi, ffi_mut] gear: &[f64; 6];                            "gear parameters.";
+            [ffi, ffi_mut] gainprm: &[f64; mjNGAIN as usize];          "gain parameters.";
+            [ffi, ffi_mut] biasprm: &[f64; mjNBIAS as usize];          "bias parameters.";
+            [ffi, ffi_mut] dynprm: &[f64; mjNDYN as usize];            "dynamic parameters.";
+            [ffi, ffi_mut] lengthrange: &[f64; 2];                     "transmission length range.";
+            [ffi, ffi_mut] damping: &[f64; mjNPOLY as usize + 1];      "damping coefficients.";
+            [ffi, ffi_mut] ctrlrange: &[f64; 2];                       "control range.";
+            [ffi, ffi_mut] velrange: &[f64; 2];                        "range of the velocity-setpoint input (pid).";
+            [ffi, ffi_mut] ffrange: &[f64; 2];                         "range of the feedforward input (pid).";
+            [ffi, ffi_mut] forcerange: &[f64; 2];                      "force range.";
+            [ffi, ffi_mut] actrange: &[f64; 2];                        "activation range.";
         ]
     }
 
     getter_setter! {
         get, [
-            plugin: &MjsPlugin;                     "actuator plugin.";
         ]
     }
 
+    nested_handle!(plugin: MjsPlugin; "actuator plugin.");
+
     getter_setter!([&] with, get, set, [
-        gaintype: MjtGain;             "gain type.";
-        biastype: MjtBias;             "bias type.";
-        dyntype: MjtDyn;               "dyn type.";
-        group: i32;                    "group.";
-        actdim: i32;                   "number of activation variables.";
-        trntype: MjtTrn;               "transmission type.";
-        cranklength: f64;              "crank length, for slider-crank.";
-        inheritrange: f64;             "automatic range setting for position and intvelocity.";
-        armature: f64;                 "armature inertia.";
-        nsample: i32;                  "number of samples in history buffer.";
-        interp: i32;                   "interpolation order (0=ZOH, 1=linear, 2=cubic).";
-        delay: f64;                    "delay time in seconds; 0: no delay.";
-        ctrlspec: i32;                 "input signature, scoped by gaintype; 0: type default.";
+        [ffi, ffi_mut] gaintype: MjtGain;             "gain type.";
+        [ffi, ffi_mut] biastype: MjtBias;             "bias type.";
+        [ffi, ffi_mut] dyntype: MjtDyn;               "dyn type.";
+        [ffi, ffi_mut] group: i32;                    "group.";
+        [ffi, ffi_mut] actdim: i32;                   "number of activation variables.";
+        [ffi, ffi_mut] trntype: MjtTrn;               "transmission type.";
+        [ffi, ffi_mut] cranklength: f64;              "crank length, for slider-crank.";
+        [ffi, ffi_mut] inheritrange: f64;             "automatic range setting for position and intvelocity.";
+        [ffi, ffi_mut] armature: f64;                 "armature inertia.";
+        [ffi, ffi_mut] nsample: i32;                  "number of samples in history buffer.";
+        [ffi, ffi_mut] interp: i32;                   "interpolation order (0=ZOH, 1=linear, 2=cubic).";
+        [ffi, ffi_mut] delay: f64;                    "delay time in seconds; 0: no delay.";
+        [ffi, ffi_mut] ctrlspec: i32;                 "input signature, scoped by gaintype; 0: type default.";
     ]);
 
     getter_setter! {
         [&] with, get, set, [
-            ctrllimited: MjtLimited [force];        "are control limits defined.";
-            forcelimited: MjtLimited [force];       "are force limits defined.";
+            [ffi, ffi_mut] ctrllimited: MjtLimited [force];        "are control limits defined.";
+            [ffi, ffi_mut] forcelimited: MjtLimited [force];       "are force limits defined.";
         ]
     }
 
     getter_setter! {
         [&] with, get, set, [
-            actlimited: MjtLimited [force];         "are activation limits defined.";
+            [ffi, ffi_mut] actlimited: MjtLimited [force];         "are activation limits defined.";
         ]
     }
 
     getter_setter! {
         [&] with, get, set, [
-            actearly: bool;                "apply next activations to qfrc.";
+            [ffi, ffi_mut] actearly: bool;                "apply next activations to qfrc.";
         ]
     }
 
@@ -1383,7 +1368,7 @@ impl MjsActuator {
     /// Configure the actuator to be a motor.
     pub fn set_to_motor(&mut self) {
         // mjs_setToMotor cannot fail; it always returns an empty string.
-        unsafe { mjs_setToMotor(self) };
+        unsafe { mjs_setToMotor(self.ffi_mut()) };
     }
 
     /// Configure the actuator to be a positional-target motor (with a proportional regulator).
@@ -1394,7 +1379,7 @@ impl MjsActuator {
     pub fn set_to_position(&mut self, config: PositionConfig) -> Result<(), MjEditError> {
         let PositionConfig { kp, inheritrange, mut kv, mut dampratio, mut timeconst } = config;
         let c_err_msg = unsafe { mjs_setToPosition(
-            self, kp,
+            self.ffi_mut(), kp,
             kv.as_mut().map_or(ptr::null_mut(), |x| x),
             dampratio.as_mut().map_or(ptr::null_mut(), |x| x),
             timeconst.as_mut().map_or(ptr::null_mut(), |x| x),
@@ -1412,7 +1397,7 @@ impl MjsActuator {
     pub fn set_to_int_velocity(&mut self, config: IntVelocityConfig) -> Result<(), MjEditError> {
         let IntVelocityConfig { kp, inheritrange, mut kv, mut dampratio, mut timeconst } = config;
         let c_err_msg = unsafe { mjs_setToIntVelocity(
-            self, kp,
+            self.ffi_mut(), kp,
             kv.as_mut().map_or(ptr::null_mut(), |x| x),
             dampratio.as_mut().map_or(ptr::null_mut(), |x| x),
             timeconst.as_mut().map_or(ptr::null_mut(), |x| x),
@@ -1424,7 +1409,7 @@ impl MjsActuator {
     /// Configure the actuator to be a velocity servo with velocity feedback gain `kv`.
     pub fn set_to_velocity(&mut self, kv: f64) {
         // mjs_setToVelocity cannot fail; it always returns an empty string.
-        unsafe { mjs_setToVelocity(self, kv) };
+        unsafe { mjs_setToVelocity(self.ffi_mut(), kv) };
     }
 
     /// Configure the actuator to be a damper with damping coefficient `kv`. The applied force is
@@ -1433,7 +1418,7 @@ impl MjsActuator {
     /// Returns [`MjEditError::InvalidParameter`] when `kv` is negative or the control range is
     /// negative.
     pub fn set_to_damper(&mut self, kv: f64) -> Result<(), MjEditError> {
-        actuator_set_result(unsafe { mjs_setToDamper(self, kv) })
+        actuator_set_result(unsafe { mjs_setToDamper(self.ffi_mut(), kv) })
     }
 
     /// Configure the actuator to be a hydraulic or pneumatic cylinder. `timeconst` is the
@@ -1442,7 +1427,7 @@ impl MjsActuator {
     /// `diameter` to use `area` directly).
     pub fn set_to_cylinder(&mut self, timeconst: f64, bias: f64, area: f64, diameter: f64) {
         // mjs_setToCylinder cannot fail; it always returns an empty string.
-        unsafe { mjs_setToCylinder(self, timeconst, bias, area, diameter) };
+        unsafe { mjs_setToCylinder(self.ffi_mut(), timeconst, bias, area, diameter) };
     }
 
     /// Configure the actuator to be a muscle. `timeconst` holds the activation and deactivation
@@ -1458,7 +1443,7 @@ impl MjsActuator {
     ) -> Result<(), MjEditError>
     {
         let c_err_msg = unsafe { mjs_setToMuscle(
-            self, &mut timeconst, tausmooth, &mut range,
+            self.ffi_mut(), &mut timeconst, tausmooth, &mut range,
             force, scale, lmin, lmax, vmax, fpmax, fvmax
         ) };
         actuator_set_result(c_err_msg)
@@ -1469,7 +1454,7 @@ impl MjsActuator {
     /// Returns [`MjEditError::InvalidParameter`] when `gain` is negative or the control range is
     /// negative.
     pub fn set_to_adhesion(&mut self, gain: f64) -> Result<(), MjEditError> {
-        actuator_set_result(unsafe { mjs_setToAdhesion(self, gain) })
+        actuator_set_result(unsafe { mjs_setToAdhesion(self.ffi_mut(), gain) })
     }
 
     /// Configure the actuator to be a DC motor.
@@ -1484,7 +1469,7 @@ impl MjsActuator {
             mut cogging, mut controller, mut thermal, mut lugre
         } = config;
         let c_err_msg = unsafe { mjs_setToDCMotor(
-            self,
+            self.ffi_mut(),
             motorconst.as_mut().map_or(ptr::null_mut(), |x| x),
             resistance,
             nominal.as_mut().map_or(ptr::null_mut(), |x| x),
@@ -1513,7 +1498,7 @@ impl MjsActuator {
 
         let c_err_msg = unsafe {
             mjs_setToPID(
-                self,
+                self.ffi_mut(),
                 kp,
                 kv.as_mut().map_or(ptr::null_mut(), |x| x),
                 dampratio.as_mut().map_or(ptr::null_mut(), |x| x),
@@ -1539,7 +1524,7 @@ impl MjsActuator {
 
         let c_err_msg = unsafe {
             mjs_setToOrientation(
-                self,
+                self.ffi_mut(),
                 kp,
                 kv.as_mut().map_or(ptr::null_mut(), |x| x),
                 dampratio.as_mut().map_or(ptr::null_mut(), |x| x),
@@ -1557,31 +1542,32 @@ mjs_struct!(Sensor [SpecObject]);
 impl MjsSensor {
     getter_setter! {
         [&] with, get, [
-            intprm: &[i32; mjNSENS as usize];            "integer parameters.";
-            interval: &[f64; 2];                         "[period, time_prev] in seconds.";
+            [ffi, ffi_mut] intprm: &[i32; mjNSENS as usize];            "integer parameters.";
+            [ffi, ffi_mut] interval: &[f64; 2];                         "[period, time_prev] in seconds.";
         ]
     }
 
     getter_setter! {
         get, [
-            plugin: &MjsPlugin;                     "sensor plugin.";
         ]
     }
 
+    nested_handle!(plugin: MjsPlugin; "sensor plugin.");
+
     getter_setter!([&] with, get, set, [
-        type_ + _: MjtSensor;          "sensor type.";
-        objtype: MjtObj { check_objtype, "[`MjEditError::InvalidParameter`] when the object type is not a real object type (i.e. not below [`MjtObj::mjNOBJECT`])" } => MjEditError;
+        [ffi, ffi_mut] type_ + _: MjtSensor;          "sensor type.";
+        [ffi, ffi_mut] objtype: MjtObj { check_objtype, "[`MjEditError::InvalidParameter`] when the object type is not a real object type (i.e. not below [`MjtObj::mjNOBJECT`])" } => MjEditError;
                                        "object type the sensor refers to.";
-        reftype: MjtObj { check_objtype, "[`MjEditError::InvalidParameter`] when the reference type is not a real object type (i.e. not below [`MjtObj::mjNOBJECT`])" } => MjEditError;
+        [ffi, ffi_mut] reftype: MjtObj { check_objtype, "[`MjEditError::InvalidParameter`] when the reference type is not a real object type (i.e. not below [`MjtObj::mjNOBJECT`])" } => MjEditError;
                                        "type of referenced object.";
-        datatype: MjtDataType;         "data type.";
-        cutoff: f64;                   "cutoff for real and positive datatypes.";
-        noise: f64;                    "noise stdev.";
-        needstage: MjtStage;           "compute stage needed to simulate sensor.";
-        dim: i32;                      "number of scalar outputs.";
-        nsample: i32;                  "number of samples in history buffer.";
-        interp: i32;                   "interpolation order (0=ZOH, 1=linear, 2=cubic).";
-        delay: f64;                    "delay time in seconds; 0: no delay.";
+        [ffi, ffi_mut] datatype: MjtDataType;         "data type.";
+        [ffi, ffi_mut] cutoff: f64;                   "cutoff for real and positive datatypes.";
+        [ffi, ffi_mut] noise: f64;                    "noise stdev.";
+        [ffi, ffi_mut] needstage: MjtStage;           "compute stage needed to simulate sensor.";
+        [ffi, ffi_mut] dim: i32;                      "number of scalar outputs.";
+        [ffi, ffi_mut] nsample: i32;                  "number of samples in history buffer.";
+        [ffi, ffi_mut] interp: i32;                   "interpolation order (0=ZOH, 1=linear, 2=cubic).";
+        [ffi, ffi_mut] delay: f64;                    "delay time in seconds; 0: no delay.";
     ]);
 
     userdata_method!(f64);
@@ -1599,51 +1585,51 @@ mjs_struct!(Flex [SpecObject]);
 impl MjsFlex {
     getter_setter! {
         [&] with, get, [
-            rgba: &[f32; 4];                                "rgba when material is omitted.";
-            friction: &[f64; 3];                            "one-sided friction coefficients: slide, spin, roll.";
-            solref: &[MjtNum; mjNREF as usize];             "solver reference.";
-            solimp: &[MjtNum; mjNIMP as usize];             "solver impedance.";
-            size: &[f64; 3];                                "vertex bounding box half sizes in qpos0.";
-            cellcount: &[i32; 3];                           "grid cell count for finite cell method.";
+            [ffi, ffi_mut] rgba: &[f32; 4];                                "rgba when material is omitted.";
+            [ffi, ffi_mut] friction: &[f64; 3];                            "one-sided friction coefficients: slide, spin, roll.";
+            [ffi, ffi_mut] solref: &[MjtNum; mjNREF as usize];             "solver reference.";
+            [ffi, ffi_mut] solimp: &[MjtNum; mjNIMP as usize];             "solver impedance.";
+            [ffi, ffi_mut] size: &[f64; 3];                                "vertex bounding box half sizes in qpos0.";
+            [ffi, ffi_mut] cellcount: &[i32; 3];                           "grid cell count for finite cell method.";
         ]
     }
 
     getter_setter! {
         [&] with, get, set, [
-            young: f64;                    "Young's modulus, in units of pressure (force/area).";
-            group: i32;                    "group.";
-            contype: i32;                  "contact type.";
-            conaffinity: i32;              "contact affinity.";
-            condim: i32;                   "contact dimensionality.";
-            priority: i32;                 "contact priority.";
-            solmix: f64;                   "solver mixing for contact pairs.";
-            margin: f64;                   "margin for contact detection.";
-            gap: f64;                      "additional contact detection buffer.";
+            [ffi, ffi_mut] young: f64;                    "Young's modulus, in units of pressure (force/area).";
+            [ffi, ffi_mut] group: i32;                    "group.";
+            [ffi, ffi_mut] contype: i32;                  "contact type.";
+            [ffi, ffi_mut] conaffinity: i32;              "contact affinity.";
+            [ffi, ffi_mut] condim: i32;                   "contact dimensionality.";
+            [ffi, ffi_mut] priority: i32;                 "contact priority.";
+            [ffi, ffi_mut] solmix: f64;                   "solver mixing for contact pairs.";
+            [ffi, ffi_mut] margin: f64;                   "margin for contact detection.";
+            [ffi, ffi_mut] gap: f64;                      "additional contact detection buffer.";
 
-            dim: i32;                "element dimensionality.";
-            radius: f64;             "radius around primitive element.";
-            activelayers: i32;       "number of active element layers in 3D.";
-            edgestiffness: f64;      "edge stiffness.";
-            edgedamping: f64;        "edge damping.";
-            poisson: f64;            "Poisson's ratio.";
-            damping: f64;            "Rayleigh's damping.";
-            thickness: f64;          "thickness (2D only).";
-            elastic2d: i32;          "2D passive forces; 0: none, 1: bending, 2: stretching, 3: both.";
-            order: i32;              "interpolation order (1: trilinear, 2: quadratic).";
+            [ffi, ffi_mut] dim: i32;                "element dimensionality.";
+            [ffi, ffi_mut] radius: f64;             "radius around primitive element.";
+            [ffi, ffi_mut] activelayers: i32;       "number of active element layers in 3D.";
+            [ffi, ffi_mut] edgestiffness: f64;      "edge stiffness.";
+            [ffi, ffi_mut] edgedamping: f64;        "edge damping.";
+            [ffi, ffi_mut] poisson: f64;            "Poisson's ratio.";
+            [ffi, ffi_mut] damping: f64;            "Rayleigh's damping.";
+            [ffi, ffi_mut] thickness: f64;          "thickness (2D only).";
+            [ffi, ffi_mut] elastic2d: i32;          "2D passive forces; 0: none, 1: bending, 2: stretching, 3: both.";
+            [ffi, ffi_mut] order: i32;              "interpolation order (1: trilinear, 2: quadratic).";
         ]
     }
 
     getter_setter! {
         [&] with, get, set, [
-            internal: bool;       "enable internal collisions.";
-            flatskin: bool;       "render flex skin with flat shading.";
-            passive: bool;        "mode for passive collisions.";
+            [ffi, ffi_mut] internal: bool;       "enable internal collisions.";
+            [ffi, ffi_mut] flatskin: bool;       "render flex skin with flat shading.";
+            [ffi, ffi_mut] passive: bool;        "mode for passive collisions.";
         ]        
     }
 
     getter_setter! {
         [&] with, get, set, [
-            selfcollide: MjtFlexSelf [force];        "mode for flex self collision.";
+            [ffi, ffi_mut] selfcollide: MjtFlexSelf [force];        "mode for flex self collision.";
         ]
     }
 
@@ -1680,19 +1666,19 @@ mjs_struct!(Pair [SpecObject]);
 impl MjsPair {
     getter_setter! {
         [&] with, get, [
-            friction: &[f64; 5];                            "contact friction: slide1, slide2, spin, roll1, roll2.";
-            solref: &[MjtNum; mjNREF as usize];             "solver reference, normal direction.";
-            solimp: &[MjtNum; mjNIMP as usize];             "solimp for the pair.";
-            solreffriction: &[MjtNum; mjNREF as usize];     "solver reference, frictional directions.";
+            [ffi, ffi_mut] friction: &[f64; 5];                            "contact friction: slide1, slide2, spin, roll1, roll2.";
+            [ffi, ffi_mut] solref: &[MjtNum; mjNREF as usize];             "solver reference, normal direction.";
+            [ffi, ffi_mut] solimp: &[MjtNum; mjNIMP as usize];             "solimp for the pair.";
+            [ffi, ffi_mut] solreffriction: &[MjtNum; mjNREF as usize];     "solver reference, frictional directions.";
         ]
     }
 
     getter_setter! {
         [&] with, get, set, [
-            margin: f64;             "margin for contact detection.";
-            gap: f64;         "additional contact detection buffer.";
-            adhesion: f64;           "adhesive force of contacts.";
-            condim: i32;                   "contact dimensionality.";
+            [ffi, ffi_mut] margin: f64;             "margin for contact detection.";
+            [ffi, ffi_mut] gap: f64;         "additional contact detection buffer.";
+            [ffi, ffi_mut] adhesion: f64;           "adhesive force of contacts.";
+            [ffi, ffi_mut] condim: i32;                   "contact dimensionality.";
         ]
     }
 
@@ -1720,19 +1706,19 @@ mjs_struct!(Equality [SpecObject]);
 impl MjsEquality {
     getter_setter! {
         [&] with, get, [
-            data: &[f64; mjNEQDATA as usize];   "data array for equality parameters.";
-            solref: &[f64; mjNREF as usize];    "solver reference.";         
-            solimp: &[f64; mjNIMP as usize];    "solver impedance.";
+            [ffi, ffi_mut] data: &[f64; mjNEQDATA as usize];   "data array for equality parameters.";
+            [ffi, ffi_mut] solref: &[f64; mjNREF as usize];    "solver reference.";
+            [ffi, ffi_mut] solimp: &[f64; mjNIMP as usize];    "solver impedance.";
         ]
     }
 
     getter_setter! {[&] with, get, set, [
-        active: bool;   "active flag.";
+        [ffi, ffi_mut] active: bool;   "active flag.";
     ]}
 
     getter_setter! {[&] with, get, set, [
-        type_ + _: MjtEq;   "equality type.";
-        objtype: MjtObj;    "type of both objects.";
+        [ffi, ffi_mut] type_ + _: MjtEq;   "equality type.";
+        [ffi, ffi_mut] objtype: MjtObj;    "type of both objects.";
     ]}
 
     string_set_get_with! {[&]
@@ -1748,31 +1734,31 @@ mjs_struct!(Tendon [SpecObject]);
 impl MjsTendon {
     getter_setter! {
         [&] with, get, [
-            damping: &[f64; mjNPOLY as usize + 1];       "damping coefficients.";
-            stiffness: &[f64; mjNPOLY as usize + 1];     "stiffness coefficients.";
-            springlength: &[f64; 2];                    "spring length.";
-            solref_friction: &[f64; mjNREF as usize];   "solver reference: tendon friction.";
-            solimp_friction: &[f64; mjNIMP as usize];   "solver impedance: tendon friction.";
-            range: &[f64; 2];                           "range.";
-            actfrcrange: &[f64; 2];                     "actuator force limits.";
-            solref_limit: &[f64; mjNREF as usize];      "solver reference: tendon limits.";
-            solimp_limit: &[f64; mjNIMP as usize];      "solver impedance: tendon limits.";
-            rgba: &[f32; 4];                            "rgba when material omitted.";
+            [ffi, ffi_mut] damping: &[f64; mjNPOLY as usize + 1];       "damping coefficients.";
+            [ffi, ffi_mut] stiffness: &[f64; mjNPOLY as usize + 1];     "stiffness coefficients.";
+            [ffi, ffi_mut] springlength: &[f64; 2];                    "spring length.";
+            [ffi, ffi_mut] solref_friction: &[f64; mjNREF as usize];   "solver reference: tendon friction.";
+            [ffi, ffi_mut] solimp_friction: &[f64; mjNIMP as usize];   "solver impedance: tendon friction.";
+            [ffi, ffi_mut] range: &[f64; 2];                           "range.";
+            [ffi, ffi_mut] actfrcrange: &[f64; 2];                     "actuator force limits.";
+            [ffi, ffi_mut] solref_limit: &[f64; mjNREF as usize];      "solver reference: tendon limits.";
+            [ffi, ffi_mut] solimp_limit: &[f64; mjNIMP as usize];      "solver impedance: tendon limits.";
+            [ffi, ffi_mut] rgba: &[f32; 4];                            "rgba when material omitted.";
         ]
     }
 
     getter_setter! {[&] with, get, set, [
-        group: i32;         "group.";
-        frictionloss: f64;  "friction loss.";
-        armature: f64;      "inertia associated with tendon velocity.";
-        margin: f64;        "margin value for tendon limit detection.";
-        width: f64;         "width for rendering.";
+        [ffi, ffi_mut] group: i32;         "group.";
+        [ffi, ffi_mut] frictionloss: f64;  "friction loss.";
+        [ffi, ffi_mut] armature: f64;      "inertia associated with tendon velocity.";
+        [ffi, ffi_mut] margin: f64;        "margin value for tendon limit detection.";
+        [ffi, ffi_mut] width: f64;         "width for rendering.";
     ]}
 
     getter_setter! {
         [&] with, get, set, [
-            limited: MjtLimited [force];       "does tendon have limits (mjtLimited).";
-            actfrclimited: MjtLimited [force]; "does tendon have actuator force limits."
+            [ffi, ffi_mut] limited: MjtLimited [force];       "does tendon have limits (mjtLimited).";
+            [ffi, ffi_mut] actfrclimited: MjtLimited [force]; "does tendon have actuator force limits."
         ]
     }
 
@@ -1793,17 +1779,7 @@ impl MjsTendon {
     /// Fallible version of [`MjsTendon::wrap_site`].
     ///
     /// # Note
-    ///
-    /// <div class="warning">
-    ///
-    /// MuJoCo cannot report a failure here: it allocates the wrap object with
-    /// C++ `new`, which throws instead of returning null, and then returns
-    /// the address of the wrap it just added, so this method never returns
-    /// `Err`. Prefer the panicking [`MjsTendon::wrap_site`]. This method may be undeprecated
-    /// in the future if MuJoCo's upstream C++ code is changed to report the
-    /// failure recoverably.
-    ///
-    /// </div>
+    /// MuJoCo ends the process when the allocation fails, so this never returns `Err`.
     ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] if MuJoCo returns a null
@@ -1817,8 +1793,8 @@ impl MjsTendon {
     )]
     pub fn try_wrap_site(&mut self, name: &str) -> Result<&mut MjsWrap, MjEditError> {
         let cname = CString::new(name).unwrap();
-        let wrap_ptr = unsafe { mjs_wrapSite(self, cname.as_ptr()) };
-        unsafe { wrap_ptr.as_mut() }.ok_or(MjEditError::AllocationFailed)
+        let wrap_ptr = unsafe { mjs_wrapSite(self.ffi_mut(), cname.as_ptr()) };
+        unsafe { MjsWrap::from_ffi_ptr_mut(wrap_ptr) }.ok_or(MjEditError::AllocationFailed)
     }
 
     /// Wrap a geom corresponding to `name`, using the tendon.
@@ -1833,17 +1809,7 @@ impl MjsTendon {
     /// Fallible version of [`MjsTendon::wrap_geom`].
     ///
     /// # Note
-    ///
-    /// <div class="warning">
-    ///
-    /// MuJoCo cannot report a failure here: it allocates the wrap object with
-    /// C++ `new`, which throws instead of returning null, and then returns
-    /// the address of the wrap it just added, so this method never returns
-    /// `Err`. Prefer the panicking [`MjsTendon::wrap_geom`]. This method may be undeprecated
-    /// in the future if MuJoCo's upstream C++ code is changed to report the
-    /// failure recoverably.
-    ///
-    /// </div>
+    /// MuJoCo ends the process when the allocation fails, so this never returns `Err`.
     ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] if MuJoCo returns a null
@@ -1859,10 +1825,10 @@ impl MjsTendon {
         let cname = CString::new(name).unwrap();
         let csidesite = CString::new(sidesite).unwrap();
         let wrap_ptr = unsafe { mjs_wrapGeom(
-            self,
+            self.ffi_mut(),
             cname.as_ptr(), csidesite.as_ptr()
         ) };
-        unsafe { wrap_ptr.as_mut() }.ok_or(MjEditError::AllocationFailed)
+        unsafe { MjsWrap::from_ffi_ptr_mut(wrap_ptr) }.ok_or(MjEditError::AllocationFailed)
     }
 
     /// Wrap a joint corresponding to `name`, using the tendon.
@@ -1877,17 +1843,7 @@ impl MjsTendon {
     /// Fallible version of [`MjsTendon::wrap_joint`].
     ///
     /// # Note
-    ///
-    /// <div class="warning">
-    ///
-    /// MuJoCo cannot report a failure here: it allocates the wrap object with
-    /// C++ `new`, which throws instead of returning null, and then returns
-    /// the address of the wrap it just added, so this method never returns
-    /// `Err`. Prefer the panicking [`MjsTendon::wrap_joint`]. This method may be undeprecated
-    /// in the future if MuJoCo's upstream C++ code is changed to report the
-    /// failure recoverably.
-    ///
-    /// </div>
+    /// MuJoCo ends the process when the allocation fails, so this never returns `Err`.
     ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] if MuJoCo returns a null
@@ -1901,8 +1857,8 @@ impl MjsTendon {
     )]
     pub fn try_wrap_joint(&mut self, name: &str, coef: f64) -> Result<&mut MjsWrap, MjEditError> {
         let cname = CString::new(name).unwrap();
-        let wrap_ptr = unsafe { mjs_wrapJoint(self, cname.as_ptr(), coef) };
-        unsafe { wrap_ptr.as_mut() }.ok_or(MjEditError::AllocationFailed)
+        let wrap_ptr = unsafe { mjs_wrapJoint(self.ffi_mut(), cname.as_ptr(), coef) };
+        unsafe { MjsWrap::from_ffi_ptr_mut(wrap_ptr) }.ok_or(MjEditError::AllocationFailed)
     }
 
     /// Wrap a pulley using the tendon.
@@ -1914,17 +1870,7 @@ impl MjsTendon {
     /// Fallible version of [`MjsTendon::wrap_pulley`].
     ///
     /// # Note
-    ///
-    /// <div class="warning">
-    ///
-    /// MuJoCo cannot report a failure here: it allocates the wrap object with
-    /// C++ `new`, which throws instead of returning null, and then returns
-    /// the address of the wrap it just added, so this method never returns
-    /// `Err`. Prefer the panicking [`MjsTendon::wrap_pulley`]. This method may be undeprecated
-    /// in the future if MuJoCo's upstream C++ code is changed to report the
-    /// failure recoverably.
-    ///
-    /// </div>
+    /// MuJoCo ends the process when the allocation fails, so this never returns `Err`.
     ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] if MuJoCo returns a null
@@ -1934,13 +1880,13 @@ impl MjsTendon {
         note = "always returns Ok; use `wrap_pulley`"
     )]
     pub fn try_wrap_pulley(&mut self, divisor: f64) -> Result<&mut MjsWrap, MjEditError> {
-        let wrap_ptr = unsafe { mjs_wrapPulley(self, divisor) };
-        unsafe { wrap_ptr.as_mut() }.ok_or(MjEditError::AllocationFailed)
+        let wrap_ptr = unsafe { mjs_wrapPulley(self.ffi_mut(), divisor) };
+        unsafe { MjsWrap::from_ffi_ptr_mut(wrap_ptr) }.ok_or(MjEditError::AllocationFailed)
     }
 
     /// Return the number of wrap objects.
     pub fn wrap_num(&self) -> usize {
-        unsafe { mjs_getWrapNum(self) as usize }
+        unsafe { mjs_getWrapNum(self.ffi()) as usize }
     }
 
     /// Return an indexed wrap object.
@@ -1962,9 +1908,9 @@ impl MjsTendon {
         if i >= len {
             return Err(MjEditError::IndexOutOfBounds { id: i, len });
         }
-        let ptr = unsafe { mjs_getWrap(self, i as i32) };
+        let ptr = unsafe { mjs_getWrap(self.ffi(), i as i32) };
         // SAFETY: index validated above; mjs_getWrap returns a non-null pointer for in-range indices.
-        Ok(unsafe { &*ptr })
+        Ok(unsafe { MjsWrap::from_ffi_ptr(ptr) }.unwrap())
     }
 
     /// Return a mutable indexed wrap object.
@@ -1984,9 +1930,9 @@ impl MjsTendon {
         if i >= len {
             return Err(MjEditError::IndexOutOfBounds { id: i, len });
         }
-        let ptr = unsafe { mjs_getWrap(self, i as i32) };
+        let ptr = unsafe { mjs_getWrap(self.ffi(), i as i32) };
         // SAFETY: see try_wrap().
-        Ok(unsafe { &mut *ptr })
+        Ok(unsafe { MjsWrap::from_ffi_ptr_mut(ptr) }.unwrap())
     }
 }
 
@@ -2015,7 +1961,7 @@ mjs_struct!(Wrap {
 impl MjsWrap {
     getter_setter! {
         [&] with, get, set, [
-            type_ + _: MjtWrap; "wrap type.";
+            [ffi, ffi_mut] type_ + _: MjtWrap; "wrap type.";
         ]
     }
 
@@ -2023,27 +1969,27 @@ impl MjsWrap {
     /// wrap, when it holds no side site, or when the named site is missing from the spec (MuJoCo
     /// logs a warning in that last case).
     pub fn side_site(&self) -> Option<&MjsSite> {
-        let ptr = unsafe { mjs_getWrapSideSite(self) };
-        if ptr.is_null() { None } else { Some(unsafe { &*ptr }) }
+        let ptr = unsafe { mjs_getWrapSideSite(self.ffi()) };
+        unsafe { MjsSite::from_ffi_ptr(ptr) }
     }
 
     /// Return the side site element mutably. Returns `None` under the same conditions as
     /// [`MjsWrap::side_site`].
     pub fn side_site_mut(&mut self) -> Option<&mut MjsSite> {
-        let ptr = unsafe { mjs_getWrapSideSite(self) };
-        if ptr.is_null() { None } else { Some(unsafe { &mut *ptr }) }
+        let ptr = unsafe { mjs_getWrapSideSite(self.ffi()) };
+        unsafe { MjsSite::from_ffi_ptr_mut(ptr) }
     }
 
     /// Return the wrap divisor. For a wrap whose type is not [`MjtWrap::mjWRAP_PULLEY`], MuJoCo
     /// logs a warning and this returns 1.0.
     pub fn divisor(&self) -> f64 {
-        unsafe { mjs_getWrapDivisor(self) }
+        unsafe { mjs_getWrapDivisor(self.ffi()) }
     }
 
     /// Return the wrap coefficient. For a wrap whose type is not [`MjtWrap::mjWRAP_JOINT`],
     /// MuJoCo logs a warning and this returns 1.0.
     pub fn coef(&self) -> f64 {
-        unsafe { mjs_getWrapCoef(self) }
+        unsafe { mjs_getWrapCoef(self.ffi()) }
     }
 }
 
@@ -2054,7 +2000,7 @@ mjs_struct!(Numeric [SpecObject]);
 impl MjsNumeric {
     getter_setter! {
         [&] with, get, set, [
-            size: i32 { check_numeric_size, "[`MjEditError::InvalidParameter`] when the size is negative" } => MjEditError;     "size of the numeric array.";
+            [ffi, ffi_mut] size: i32 { check_numeric_size, "[`MjEditError::InvalidParameter`] when the size is negative" } => MjEditError;     "size of the numeric array.";
         ]
     }
 
@@ -2104,7 +2050,7 @@ mjs_struct!(Key [SpecObject]);
 impl MjsKey {
     getter_setter! {
         [&] with, get, set, [
-            time: f64; "time."
+            [ffi, ffi_mut] time: f64; "time."
         ]
     }
 
@@ -2130,7 +2076,7 @@ impl MjsPlugin {
 
     getter_setter! {
         [&] with, get, set, [
-            active: bool; "is the plugin active.";
+            [ffi, ffi_mut] active: bool; "is the plugin active.";
         ]
     }
 }
@@ -2144,30 +2090,31 @@ mjs_struct!(Mesh [SpecObject]);
 impl MjsMesh {
     getter_setter! {
         [&] with, get, [
-            refpos: &[f64; 3];            "reference position.";
-            refquat: &[f64; 4];           "reference orientation.";
-            scale: &[f64; 3];             "scale vector.";
+            [ffi, ffi_mut] refpos: &[f64; 3];            "reference position.";
+            [ffi, ffi_mut] refquat: &[f64; 4];           "reference orientation.";
+            [ffi, ffi_mut] scale: &[f64; 3];             "scale vector.";
         ]
     }
 
     getter_setter! {
         get, [
-            plugin: &MjsPlugin;                     "sdf plugin.";
         ]
     }
 
+    nested_handle!(plugin: MjsPlugin; "sdf plugin.");
+
     getter_setter! {
         [&] with, get, set, [
-            inertia: MjtMeshInertia;      "inertia type (convex, legacy, exact, shell).";
-            maxhullvert: i32;             "maximum vertex count for the convex hull.";
-            octree_maxdepth: i32;         "max octree depth.";
+            [ffi, ffi_mut] inertia: MjtMeshInertia;      "inertia type (convex, legacy, exact, shell).";
+            [ffi, ffi_mut] maxhullvert: i32;             "maximum vertex count for the convex hull.";
+            [ffi, ffi_mut] octree_maxdepth: i32;         "max octree depth.";
         ]
     }
 
     getter_setter! {
         [&] with, get,set, [
-            smoothnormal: bool;           "do not exclude large-angle faces from normals.";
-            needsdf: bool;                "compute sdf from mesh.";
+            [ffi, ffi_mut] smoothnormal: bool;           "do not exclude large-angle faces from normals.";
+            [ffi, ffi_mut] needsdf: bool;                "compute sdf from mesh.";
         ]
     }
 
@@ -2204,13 +2151,13 @@ mjs_struct!(Hfield [SpecObject]);
 impl MjsHfield {
     getter_setter! {
         [&] with, get, [
-            size: &[f64; 4];              "size of the hfield.";
+            [ffi, ffi_mut] size: &[f64; 4];              "size of the hfield.";
         ]
     }
 
     getter_setter! { [&] with, get, set, [
-        nrow: i32;  "number of rows.";
-        ncol: i32;  "number of columns.";
+        [ffi, ffi_mut] nrow: i32;  "number of rows.";
+        [ffi, ffi_mut] ncol: i32;  "number of columns.";
     ]}
 
     string_set_get_with! {[&]
@@ -2221,7 +2168,7 @@ impl MjsHfield {
     /// Sets `userdata`.
     pub fn set_userdata<T: AsRef<[f32]>>(&mut self, userdata: T) {
         // SAFETY: self.userdata is a valid mjFloatVec pointer for the lifetime of self.
-        unsafe { write_mjs_vec_f32(userdata.as_ref(), self.userdata) };
+        unsafe { write_mjs_vec_f32(userdata.as_ref(), self.ffi().userdata) };
     }
 }
 
@@ -2232,14 +2179,14 @@ mjs_struct!(Skin [SpecObject]);
 impl MjsSkin {
     getter_setter! {
         [&] with, get, [
-            rgba: &[f32; 4];    "rgba when material is omitted.";
+            [ffi, ffi_mut] rgba: &[f32; 4];    "rgba when material is omitted.";
         ]
     }
 
     getter_setter! {
         [&] with, get, set, [
-            inflate: f32;       "inflate in normal direction.";
-            group: i32;         "group for visualization.";
+            [ffi, ffi_mut] inflate: f32;       "inflate in normal direction.";
+            [ffi, ffi_mut] group: i32;         "group for visualization.";
         ]
     }
 
@@ -2287,19 +2234,19 @@ mjs_struct!(Texture [SpecObject]);
 impl MjsTexture {
     getter_setter! {
         [&] with, get, [
-            rgb1: &[f64; 3];               "first color for builtin.";
-            rgb2: &[f64; 3];               "second color for builtin.";
-            markrgb: &[f64; 3];            "mark color.";
-            gridsize: &[i32; 2];           "size of grid for composite file; (1,1)-repeat.";
-            gridlayout: &[c_char; 12];     "row-major: L,R,F,B,U,D for faces; . for unused.";
+            [ffi, ffi_mut] rgb1: &[f64; 3];               "first color for builtin.";
+            [ffi, ffi_mut] rgb2: &[f64; 3];               "second color for builtin.";
+            [ffi, ffi_mut] markrgb: &[f64; 3];            "mark color.";
+            [ffi, ffi_mut] gridsize: &[i32; 2];           "size of grid for composite file; (1,1)-repeat.";
+            [ffi, ffi_mut] gridlayout: &[c_char; 12];     "row-major: L,R,F,B,U,D for faces; . for unused.";
         ]
     }
 
     getter_setter! {
         [&] with, get, set, [
-            random: f64;                  "probability of random dots.";
-            width: i32;                   "image width.";
-            height: i32;                  "image height.";
+            [ffi, ffi_mut] random: f64;                  "probability of random dots.";
+            [ffi, ffi_mut] width: i32;                   "image width.";
+            [ffi, ffi_mut] height: i32;                  "image height.";
         ]
     }
 
@@ -2308,16 +2255,16 @@ impl MjsTexture {
             // `nchannel` must be `>= 3` whenever a builtin pattern is set
             // (`builtin != MjtBuiltin::mjBUILTIN_NONE`); this cross-field invariant is
             // enforced at the compile choke point in `MjSpec::compile`.
-            nchannel: i32; "number of channels.";
+            [ffi, ffi_mut] nchannel: i32; "number of channels.";
         ]
     }
 
     getter_setter! {
         [&] with, get, set, [
-            type_ + _: MjtTexture [force];        "texture type.";
-            colorspace: MjtColorSpace [force];    "colorspace.";
-            builtin: MjtBuiltin [force];          "builtin type.";
-            mark: MjtMark [force];                "mark type.";
+            [ffi, ffi_mut] type_ + _: MjtTexture [force];        "texture type.";
+            [ffi, ffi_mut] colorspace: MjtColorSpace [force];    "colorspace.";
+            [ffi, ffi_mut] builtin: MjtBuiltin [force];          "builtin type.";
+            [ffi, ffi_mut] mark: MjtMark [force];                "mark type.";
         ]
     }
 
@@ -2326,14 +2273,14 @@ impl MjsTexture {
     }
 
     getter_setter! {[&] with, get, set, [
-        hflip: bool;    "horizontal flip.";
-        vflip: bool;    "vertical flip.";
+        [ffi, ffi_mut] hflip: bool;    "horizontal flip.";
+        [ffi, ffi_mut] vflip: bool;    "vertical flip.";
     ]}
 
     /// Sets texture `data`.
     pub fn set_data<T: bytemuck::NoUninit>(&mut self, data: &[T]) {
         // SAFETY: self.data is a valid mjByteVec pointer for the lifetime of self.
-        unsafe { write_mjs_vec_byte(data, self.data) };
+        unsafe { write_mjs_vec_byte(data, self.ffi().data) };
     }
 
     string_set_get_with! {[&]
@@ -2358,23 +2305,23 @@ mjs_struct!(Material [SpecObject]);
 impl MjsMaterial {
     getter_setter! {
         [&] with, get, [
-            rgba: &[f32; 4];                               "rgba color.";
-            texrepeat: &[f32; 2];    "texture repetition for 2D mapping.";
+            [ffi, ffi_mut] rgba: &[f32; 4];                               "rgba color.";
+            [ffi, ffi_mut] texrepeat: &[f32; 2];    "texture repetition for 2D mapping.";
         ]
     }
 
     getter_setter! {[&] with, get, set, [
-        texuniform: bool;       "make texture cube uniform.";
+        [ffi, ffi_mut] texuniform: bool;       "make texture cube uniform.";
     ]}
 
     getter_setter! {
         [&] with, get, set, [
-            emission: f32;                           "emission.";
-            specular: f32;                           "specular.";
-            shininess: f32;                         "shininess.";
-            reflectance: f32;                     "reflectance.";
-            metallic: f32;                           "metallic.";
-            roughness: f32;                         "roughness.";
+            [ffi, ffi_mut] emission: f32;                           "emission.";
+            [ffi, ffi_mut] specular: f32;                           "specular.";
+            [ffi, ffi_mut] shininess: f32;                         "shininess.";
+            [ffi, ffi_mut] reflectance: f32;                     "reflectance.";
+            [ffi, ffi_mut] metallic: f32;                           "metallic.";
+            [ffi, ffi_mut] roughness: f32;                         "roughness.";
         ]
     }
 
@@ -2423,8 +2370,8 @@ impl MjsBody {
     pub fn child(&self, name: &str) -> Option<&MjsBody> {
         let c_name = CString::new(name).unwrap();
         unsafe {
-            let ptr = mjs_findChild(self, c_name.as_ptr());
-            if ptr.is_null() { None } else { ptr.as_ref() }
+            let ptr = mjs_findChild(self.ffi(), c_name.as_ptr());
+            MjsBody::from_ffi_ptr(ptr)
         }
     }
 
@@ -2436,21 +2383,10 @@ impl MjsBody {
     pub fn child_mut(&mut self, name: &str) -> Option<&mut MjsBody> {
         let c_name = CString::new(name).unwrap();
         unsafe {
-            let ptr = mjs_findChild(self, c_name.as_ptr());
-            if ptr.is_null() { None } else { ptr.as_mut() }
+            let ptr = mjs_findChild(self.ffi(), c_name.as_ptr());
+            MjsBody::from_ffi_ptr_mut(ptr)
         }
     }
-
-    /// Dummy mutable FFI method used to simplify access through macros.
-    ///
-    /// # Safety
-    /// Callers must ensure that any mutations performed through the returned reference
-    /// preserve the invariants that MuJoCo expects for `mjsBody`.
-    #[inline]
-    unsafe fn ffi_mut(&mut self) -> &mut Self {
-        self
-    }
-
     // Special case
     /// Add and return a child frame.
     ///
@@ -2464,17 +2400,7 @@ impl MjsBody {
     /// Fallible version of [`Self::add_frame`].
     ///
     /// # Note
-    ///
-    /// <div class="warning">
-    ///
-    /// MuJoCo cannot report a failure here: `mjs_addFrame` allocates the frame with C++ `new`,
-    /// which throws instead of returning null, and then returns the address of the frame it just
-    /// added, so this method never returns `Err`. An allocation failure ends the process: the
-    /// exception cannot cross the C API. Prefer the panicking [`Self::add_frame`]. This method
-    /// may be undeprecated in the future if MuJoCo's upstream C++ code is changed to report the
-    /// failure recoverably.
-    ///
-    /// </div>
+    /// MuJoCo ends the process when the allocation fails, so this never returns `Err`.
     ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] when MuJoCo fails to allocate
@@ -2491,7 +2417,7 @@ impl MjsBody {
         // SAFETY: ptr.as_mut() returns None for null, handled by ok_or; when non-null the
         // pointee is properly aligned and initialized by C++ operator new, and freshly
         // allocated so no existing Rust reference aliases it for the returned lifetime.
-        unsafe { ptr.as_mut() }.ok_or(MjEditError::AllocationFailed)
+        unsafe { MjsFrame::from_ffi_ptr_mut(ptr) }.ok_or(MjEditError::AllocationFailed)
     }
 }
 
@@ -2501,13 +2427,9 @@ impl MjsBody {
 
 /// Configuration for [`MjsBody::add_flexcomp`], mirroring the `flexcomp` element.
 ///
-/// Unset array, string, and VFS fields are passed to MuJoCo as null, which makes the compiler
-/// fall back to its own defaults; the scalar fields default to MuJoCo's own defaults (so `dim`
-/// is 2 and `radius` is 0.005). `mass` and `inertiabox` stay 0, which makes MuJoCo keep its own
-/// defaults of 1 and 0.005; every other scalar is zero, which is also MuJoCo's default.
-/// Build one with struct-update syntax or the chainable `with_*` methods, starting from
-/// [`MjFlexcompConfig::default`]. Field documentation is adapted from MuJoCo's `flexcomp`
-/// XML reference.
+/// An unset array, string or VFS field reaches MuJoCo as null, so the compiler applies its own
+/// default. `dim` is 2 and `radius` is 0.005; every other scalar is zero, which MuJoCo also
+/// reads as its own default.
 ///
 /// # Example
 /// ```
@@ -2574,10 +2496,8 @@ pub struct MjFlexcompConfig<'a> {
     pub vfs: Option<&'a MjVfs>,
 }
 
-// `dim` and `radius` must default to MuJoCo's own defaults (2 and 0.005), not zero:
-// `mjs_makeFlex` applies both unconditionally, so a zero `dim` would fail compilation
-// ("Invalid dim, must be between 1 and 3") and a zero `radius` would silently override
-// MuJoCo's default element radius.
+// `mjs_makeFlex` applies `dim` and `radius` unconditionally, so both must carry MuJoCo's own
+// defaults (2 and 0.005) rather than zero.
 impl Default for MjFlexcompConfig<'_> {
     fn default() -> Self {
         Self {
@@ -2638,8 +2558,6 @@ impl MjsBody {
     /// Creates a flex with auto-generated bodies, joints, and optional equality constraints, the
     /// programmatic equivalent of the `flexcomp` element, configured via
     /// [`MjFlexcompConfig`]. Wraps [`mjs_makeFlex`].
-    ///
-    /// Delegates to [`Self::try_add_flexcomp`] and panics if creation fails.
     ///
     /// # Panics
     /// Panics if MuJoCo fails to create the flex, or if `name` or any string in
@@ -2709,7 +2627,7 @@ impl MjsBody {
         };
         // SAFETY: null maps to None (reported as AllocationFailed); a non-null pointer
         // is a freshly allocated, initialized mjsFlex with no aliasing Rust references.
-        unsafe { ptr.as_mut() }.ok_or(MjEditError::AllocationFailed)
+        unsafe { MjsFlex::from_ffi_ptr_mut(ptr) }.ok_or(MjEditError::AllocationFailed)
     }
 }
 
@@ -2718,39 +2636,40 @@ impl MjsBody {
     getter_setter! {
         [&] with, get, [
             // body frame
-            pos: &[f64; 3];                   "frame position.";
-            quat: &[f64; 4];                  "frame orientation.";
-            alt: &MjsOrientation;             "frame alternative orientation.";
+            [ffi, ffi_mut] pos: &[f64; 3];                   "frame position.";
+            [ffi, ffi_mut] quat: &[f64; 4];                  "frame orientation.";
+            [ffi, ffi_mut] alt: &MjsOrientation;             "frame alternative orientation.";
 
             //inertial frame
-            ipos: &[f64; 3];                  "inertial frame position.";
-            iquat: &[f64; 4];                 "inertial frame orientation.";
-            inertia: &[f64; 3];               "diagonal inertia (in i-frame).";
-            ialt: &MjsOrientation;            "inertial frame alternative orientation.";
-            fullinertia: &[f64; 6];           "non-axis-aligned inertia matrix.";
+            [ffi, ffi_mut] ipos: &[f64; 3];                  "inertial frame position.";
+            [ffi, ffi_mut] iquat: &[f64; 4];                 "inertial frame orientation.";
+            [ffi, ffi_mut] inertia: &[f64; 3];               "diagonal inertia (in i-frame).";
+            [ffi, ffi_mut] ialt: &MjsOrientation;            "inertial frame alternative orientation.";
+            [ffi, ffi_mut] fullinertia: &[f64; 6];           "non-axis-aligned inertia matrix.";
         ]
     }
 
     getter_setter! {
         get, [
-            plugin: &MjsPlugin;                     "passive force plugin.";
         ]
     }
+
+    nested_handle!(plugin: MjsPlugin; "passive force plugin.");
 
     // Plain types with normal getters and setters.
     getter_setter! {
         [&] with, get, set, [
-            mass: f64;                     "mass.";
-            gravcomp: f64;                 "gravity compensation.";
-            sleep: MjtSleepPolicy;           "sleep policy.";
+            [ffi, ffi_mut] mass: f64;                     "mass.";
+            [ffi, ffi_mut] gravcomp: f64;                 "gravity compensation.";
+            [ffi, ffi_mut] sleep: MjtSleepPolicy;           "sleep policy.";
         ]
     }
 
     getter_setter! {
         [&] with, get, set, [
-            mocap: bool;                   "whether this is a mocap body.";
-            explicitinertial: bool;        "whether to save the body with explicit inertial clause.";
-            simple: bool;                  "simple body optimization (false: disabled, true: auto).";
+            [ffi, ffi_mut] mocap: bool;                   "whether this is a mocap body.";
+            [ffi, ffi_mut] explicitinertial: bool;        "whether to save the body with explicit inertial clause.";
+            [ffi, ffi_mut] simple: bool;                  "simple body optimization (false: disabled, true: auto).";
         ]
     }
 
@@ -2760,11 +2679,8 @@ impl MjsBody {
 /// Mutable iterator over items in [`MjsBody`].
 #[derive(Debug)]
 pub struct MjsBodyItemIterMut<'a, T> {
-    /// Raw pointer to the FFI type [`mjsBody`].
-    /// [`MjsBody`] is its alias, thus storing it plainly
-    /// would technically be UB as Rust can't see across
-    /// boundary to verify . 
-    ffi_ptr: *mut MjsBody,
+    /// Raw pointer to the body; a borrow would alias the handles that the iterator yields.
+    ffi_ptr: *mut mjsBody,
     last: *mut mjsElement,
     recurse: bool,
     /// Used for generic implementation of iterator's methods.
@@ -2773,8 +2689,11 @@ pub struct MjsBodyItemIterMut<'a, T> {
 
 impl<'a, T: SpecObject> MjsBodyItemIterMut<'a, T> {
     fn new(root: &'a mut MjsBody, recurse: bool) -> Self {
-        let last = unsafe { mjs_firstChild(root, T::OBJ_TYPE, recurse.into()) };
-        Self { ffi_ptr: root, last, recurse, item_type: PhantomData }
+        // SAFETY: the iterator walks the children of the body; it never exchanges its contents,
+        // and the borrow of root keeps the body alive.
+        let ffi_ptr = unsafe { root.ffi_mut() } as *mut mjsBody;
+        let last = unsafe { mjs_firstChild(ffi_ptr, T::OBJ_TYPE, recurse.into()) };
+        Self { ffi_ptr, last, recurse, item_type: PhantomData }
     }
 }
 
@@ -2799,7 +2718,7 @@ impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsBodyItemIterMut<'a,
 /// Immutable iterator over items in [`MjsBody`].
 #[derive(Debug, Clone)]
 pub struct MjsBodyItemIter<'a, T> {
-    ffi_ptr: *const MjsBody,
+    ffi_ptr: *const mjsBody,
     last: *const mjsElement,
     recurse: bool,
     /// Used for generic implementation of iterator's methods.
@@ -2809,16 +2728,17 @@ pub struct MjsBodyItemIter<'a, T> {
 
 impl<'a, T: SpecObject> MjsBodyItemIter<'a, T> {
     fn new(root: &'a MjsBody, recurse: bool) -> Self {
+        let ffi_ptr = root.ffi() as *const mjsBody;
         // SAFETY: mjs_firstChild takes a *const mjsBody; the borrow of root keeps the body
         // alive for the call.
         let last = unsafe {
             mjs_firstChild(
-                root,
+                ffi_ptr,
                 T::OBJ_TYPE,
                 recurse.into()
             )
         };
-        Self { ffi_ptr: root, last, recurse, item_type: PhantomData }
+        Self { ffi_ptr, last, recurse, item_type: PhantomData }
     }
 }
 
@@ -4033,10 +3953,8 @@ mod tests {
         spec.compile().expect("spec with generated flex failed to compile");
     }
 
-    /// Verifies [`MjFlexcompConfig::default`] carries MuJoCo's own defaults for `dim` and
-    /// `radius`, which `mjs_makeFlex` applies unconditionally: a config that sets only the
-    /// required structural fields must still compile, with the flex keeping MuJoCo's
-    /// default dim (2) and radius (0.005).
+    /// A config that sets only the structural fields must compile and keep MuJoCo's own default
+    /// dim (2) and radius (0.005).
     #[test]
     fn test_flexcomp_config_defaults() {
         let mut spec = MjSpec::new();
@@ -4119,9 +4037,8 @@ mod tests {
         assert!(numeric.set_size(4).is_ok());
     }
 
-    /// A frame carries no default class name, so `default()` must report that instead of
-    /// dereferencing the null pointer `mjs_getDefault` returns for it. A geom and a body are
-    /// added with a default class, so they must still yield one.
+    /// A frame carries no default class name, so `default()` reports `None` for it, while a geom
+    /// and a body added with a default class still yield one.
     #[test]
     fn test_frame_has_no_default() {
         let mut spec = MjSpec::new();

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -751,9 +751,13 @@ impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsSpecItemIter<'a, T>
 /// Iterator methods.
 impl MjSpec {
     spec_get_iter! {
-        body, geom, joint, site, camera, light, frame, actuator, sensor, flex, pair, equality,
+        geom, joint, site, camera, light, frame, actuator, sensor, flex, pair, equality,
         exclude, tendon, numeric, text, tuple, key, mesh, hfield, skin, texture, material, plugin
     }
+
+    // A body owns a subtree, so a flat mutable iterator would hand out an ancestor and that
+    // ancestor's own descendant at once. Reach a body through `world_body_mut` and walk down.
+    spec_get_iter!(read_only: body);
 }
 
 impl Default for MjSpec {
@@ -2282,6 +2286,14 @@ impl MjsBody {
     ///
     /// # Panics
     /// When the `name` contains '\0' characters, a panic occurs.
+    ///
+    /// # Examples
+    /// ```
+    /// # use mujoco_rs::prelude::*;
+    /// let mut spec = MjSpec::new();
+    /// spec.world_body_mut().add_body().with_name("ball");
+    /// spec.world_body_mut().child_mut("ball").unwrap().set_gravcomp(1.0);
+    /// ```
     pub fn child_mut(&mut self, name: &str) -> Option<&mut MjsBody> {
         let c_name = CString::new(name).unwrap();
         unsafe {
@@ -2645,7 +2657,8 @@ impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsBodyItemIter<'a, T>
 
 /// Iterator methods.
 impl MjsBody {
-    body_get_iter! {[body, joint, geom, site, camera, light, frame] }
+    body_get_iter! {[joint, geom, site, camera, light, frame] }
+    body_get_iter! { direct_children_mut: [body] }
 }
 
 /******************************
@@ -3223,18 +3236,18 @@ mod tests {
 
         // Iter MjSpec
         assert_eq!(spec.geom_iter_mut().count(), N_GEOM);
-        assert_eq!(spec.body_iter_mut().count(), N_BODY);
+        assert_eq!(spec.body_iter().count(), N_BODY);
         assert_eq!(spec.site_iter_mut().count(), N_SITE);
         assert_eq!(spec.tendon_iter_mut().count(), N_TENDON);
         assert_eq!(spec.mesh_iter_mut().count(), N_MESH);
-        assert_eq!(spec.body_iter_mut().last().unwrap().name(), LAST_BODY_NAME);
+        assert_eq!(spec.body_iter().last().unwrap().name(), LAST_BODY_NAME);
 
         // Iter MjsBody
         let world = spec.world_body_mut();
         assert_eq!(world.geom_iter_mut(true).count(), N_GEOM);
-        assert_eq!(world.body_iter_mut(true).count(), N_BODY - 1);  // world must now be excluded
+        assert_eq!(world.body_iter(true).count(), N_BODY - 1);  // world must now be excluded
         assert_eq!(world.site_iter_mut(true).count(), N_SITE);
-        assert_eq!(world.body_iter_mut(false).last().unwrap().name(), LAST_WORLD_BODY_NAME);
+        assert_eq!(world.body_iter_mut().last().unwrap().name(), LAST_WORLD_BODY_NAME);
     }
 
     /// Tests wrapper method of [`mj_parse`] with VFS.
@@ -3929,7 +3942,7 @@ mod tests {
             "<mujoco><worldbody><body name=\"a&#xD800;b\"/></worldbody></mujoco>"
         ).unwrap();
 
-        let body = spec.body_iter_mut().nth(1).unwrap();
+        let body = spec.world_body_mut().body_iter_mut().next().unwrap();
         // SAFETY: the spec owns the name string for as long as the element lives.
         let name = unsafe { CStr::from_ptr(mjs_getString(mjs_getName(body.element_mut_pointer()))) };
         assert!(
@@ -4095,7 +4108,7 @@ mod tests {
         world.add_site();
         world.add_camera();
         world.add_light();
-        spec.body_iter_mut().last().unwrap().add_joint();
+        world.body_iter_mut().last().unwrap().add_joint();
         spec.add_actuator();
         spec.add_pair();
         spec.add_equality();
@@ -4120,7 +4133,7 @@ mod tests {
         );
 
         // The world body stays, so the body list never empties.
-        assert!(unsafe { spec.body_iter_mut().last().unwrap().delete() }.is_ok(), "body");
+        assert!(unsafe { spec.world_body_mut().body_iter_mut().last().unwrap().delete() }.is_ok(), "body");
         assert_eq!(spec.body_iter().count(), 1);
     }
 }

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -252,8 +252,6 @@ impl MjSpec {
     }
 
     /// Creates a [`MjSpec`] from the `path` to a file.
-    /// # Returns
-    /// On success, returns [`Ok`] variant containing the loaded [`MjSpec`].
     /// # Errors
     /// - [`MjEditError::InvalidUtf8Path`] if the path contains invalid UTF-8.
     /// - [`MjEditError::ParseFailed`] if MuJoCo fails to parse the XML.
@@ -265,8 +263,6 @@ impl MjSpec {
     }
 
     /// Creates a [`MjSpec`] from the `path` to a file, located in a virtual file system (`vfs`).
-    /// # Returns
-    /// On success, returns [`Ok`] variant containing the loaded [`MjSpec`].
     /// # Errors
     /// - [`MjEditError::InvalidUtf8Path`] if the path contains invalid UTF-8.
     /// - [`MjEditError::ParseFailed`] if MuJoCo fails to parse the XML.
@@ -295,8 +291,6 @@ impl MjSpec {
     }
 
     /// Creates a [`MjSpec`] from an `xml` string.
-    /// # Returns
-    /// On success, returns [`Ok`] variant containing the loaded [`MjSpec`].
     /// # Errors
     /// Returns [`MjEditError::ParseFailed`] if MuJoCo encounters an error parsing the string.
     /// # Panics
@@ -319,8 +313,6 @@ impl MjSpec {
     /// Parse and create a [`MjSpec`] from `filename`.
     /// The `content_type` controls the decoder to use.
     /// This is a wrapper around low-level method [`mj_parse`].
-    /// # Returns
-    /// On success, returns [`Ok`] variant containing the loaded [`MjSpec`].
     /// # Errors
     /// - [`MjEditError::InvalidUtf8Path`] if the path contains invalid UTF-8.
     /// - [`MjEditError::ParseFailed`] if MuJoCo fails to parse the file.
@@ -332,8 +324,6 @@ impl MjSpec {
     }
 
     /// Same as [`MjSpec::from_parse`], except `filename` is taken from `vfs`.
-    /// # Returns
-    /// On success, returns [`Ok`] variant containing the loaded [`MjSpec`].
     /// # Errors
     /// - [`MjEditError::InvalidUtf8Path`] if the path contains invalid UTF-8.
     /// - [`MjEditError::ParseFailed`] if MuJoCo fails to parse the file.
@@ -435,8 +425,6 @@ impl MjSpec {
     /// Compile [`MjSpec`] to [`MjModel`].
     /// A spec can be edited and compiled multiple times,
     /// returning a new mjModel instance that takes the edits into account.
-    /// # Returns
-    /// On success, returns [`Ok`] variant containing the loaded [`MjModel`].
     /// # Errors
     /// Returns [`MjEditError::CompileFailed`] if the model fails to compile, including when a
     /// texture has a builtin pattern set while its `nchannel` is less than 3, and when a texture
@@ -504,8 +492,6 @@ impl MjSpec {
     }
 
     /// Saves the spec to an XML file.
-    /// # Returns
-    /// `Ok(())` on success.
     /// # Errors
     /// - [`MjEditError::InvalidUtf8Path`] if the path contains invalid UTF-8.
     /// - [`MjEditError::SaveFailed`] with MuJoCo's error message if saving fails.
@@ -536,8 +522,6 @@ impl MjSpec {
 
     /// Saves the spec to an XML string.
     /// `buffer_size` controls how many bytes are allocated for the output.
-    /// # Returns
-    /// On success, returns the generated XML string.
     /// # Errors
     /// - [`MjEditError::XmlBufferTooSmall`] when `buffer_size` is too small.
     ///   The `required_size` field uses `snprintf`-style semantics (bytes to write, excluding NUL),
@@ -662,8 +646,6 @@ impl MjSpec {
     }
 
     /// Fallible version of [`MjSpec::add_default`].
-    /// # Returns
-    /// On success, returns a mutable reference to the newly created [`MjsDefault`].
     /// # Errors
     /// Returns [`MjEditError::AlreadyExists`] when `class_name` already exists.
     /// Returns [`MjEditError::NotFound`] when `parent_class_name` doesn't exist.
@@ -1031,7 +1013,7 @@ impl MjsFrame {
     /// Add and return a child frame.
     ///
     /// # Note
-    /// MuJoCo ends the process when the allocation fails, so this never fails.
+    /// MuJoCo ends the process when the allocation fails.
     #[expect(deprecated, reason = "try_add_frame keeps the implementation until it is removed")]
     pub fn add_frame(&mut self) -> &mut MjsFrame {
         self.try_add_frame().expect("mjs_addFrame returned null; allocation failed")
@@ -2311,7 +2293,7 @@ impl MjsBody {
     /// Add and return a child frame.
     ///
     /// # Note
-    /// MuJoCo ends the process when the allocation fails, so this never fails.
+    /// MuJoCo ends the process when the allocation fails.
     #[expect(deprecated, reason = "try_add_frame keeps the implementation until it is removed")]
     pub fn add_frame(&mut self) -> &mut MjsFrame {
         self.try_add_frame().expect("mjs_addFrame returned null; allocation failed")

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -4,6 +4,7 @@ use crate::error::MjEditError;
 use std::ptr::{self, NonNull};
 use std::marker::PhantomData;
 use std::path::Path;
+use std::fmt;
 
 #[macro_use]
 mod utility;
@@ -34,12 +35,10 @@ use crate::mujoco_c::{mjs_addHField as mjs_addHfield, mjs_asHField as mjs_asHfie
 use crate::util::{assert_mujoco_version, ERROR_BUF_LEN};
 
 /* Validation helpers */
-/// Validates that an object-type value is a real object type, i.e. an [`MjtObj`] discriminant below
-/// [`MjtObj::mjNOBJECT`]. Meta variants (`mjOBJ_FRAME`, `mjOBJ_DEFAULT`, `mjOBJ_MODEL`) and
-/// `mjNOBJECT` itself are rejected because the model compiler uses such values as an unchecked
-/// index into a `mjNOBJECT`-sized array (via `mjCModel::FindObject`), which would read out of
-/// bounds. Used for any safe setter whose value reaches `FindObject` during `compile()`.
+/// Validates that `t` is a real object type, i.e. an [`MjtObj`] discriminant below
+/// [`MjtObj::mjNOBJECT`].
 fn check_objtype(t: MjtObj) -> Result<(), MjEditError> {
+    // A meta variant indexes `mjCModel::FindObject`'s `mjNOBJECT`-sized array out of bounds.
     if (t as i32) < (MjtObj::mjNOBJECT as i32) {
         Ok(())
     } else {
@@ -50,12 +49,9 @@ fn check_objtype(t: MjtObj) -> Result<(), MjEditError> {
 }
 
 /// Validates that a custom-numeric array size is non-negative.
-///
-/// A negative `size` slips through every guard in the model compiler's `mjCNumeric::Compile`
-/// (the `size < data_.size()` check is gated on a non-empty init array, and the zero checks treat
-/// negatives as non-zero), so it undersizes the shared `numeric_data` allocation while another
-/// numeric's zero-fill loop still runs up to its own positive size, writing out of bounds.
 fn check_numeric_size(size: i32) -> Result<(), MjEditError> {
+    // A negative size passes every guard in `mjCNumeric::Compile` and undersizes the shared
+    // `numeric_data` allocation, which another numeric's zero-fill loop then overruns.
     if size < 0 {
         Err(MjEditError::InvalidParameter(format!(
             "numeric size must be non-negative, got {size}"
@@ -191,10 +187,23 @@ pub type MjsAuthored = mjsAuthored;
 ** Model Specification
 ***************************/
 /// Model specification. This wraps the FFI type [`mjSpec`] internally.
-#[derive(Debug)]
-pub struct MjSpec(NonNull<mjSpec>);
+pub struct MjSpec {
+    /// The specification that MuJoCo owns.
+    ffi: NonNull<mjSpec>,
+}
+
+impl fmt::Debug for MjSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MjSpec").field("ffi", &self.ffi).finish_non_exhaustive()
+    }
+}
 
 impl MjSpec {
+    /// Wraps a specification that MuJoCo allocated.
+    fn from_ffi(ffi: NonNull<mjSpec>) -> Self {
+        Self { ffi }
+    }
+
     /// Creates an empty [`MjSpec`].
     ///
     /// # Panics
@@ -224,23 +233,22 @@ impl MjSpec {
         // SAFETY: mj_makeSpec allocates a new MjSpec; returns null on allocation
         // failure, handled by ok_or below.
         let ptr = unsafe { mj_makeSpec() };
-        Ok(MjSpec(NonNull::new(ptr).ok_or(MjEditError::AllocationFailed)?))
+        Ok(Self::from_ffi(NonNull::new(ptr).ok_or(MjEditError::AllocationFailed)?))
     }
 
     /// Creates a deep copy of this [`MjSpec`].
     ///
-    /// Internally calls `mj_copySpec`, which invokes the C++ copy constructor on the underlying
-    /// model. A child specification that the model attaches from another file stays shared with
-    /// the original, behind MuJoCo's own reference count.
+    /// A child specification that the model attaches from another file stays shared with the
+    /// original, behind MuJoCo's own reference count.
     ///
     /// # Errors
     /// Returns [`MjEditError::AllocationFailed`] if MuJoCo fails to allocate
     /// the copy (e.g. out of memory or an internal C++ exception).
     pub fn try_clone(&self) -> Result<Self, MjEditError> {
-        // SAFETY: self.0 is a valid non-null mjSpec pointer for the lifetime of self
+        // SAFETY: self.ffi is a valid non-null mjSpec pointer for the lifetime of self
         // (struct invariant); mj_copySpec returns null on allocation failure, handled below.
-        let ptr = unsafe { mj_copySpec(self.0.as_ptr()) };
-        NonNull::new(ptr).map(MjSpec).ok_or(MjEditError::AllocationFailed)
+        let ptr = unsafe { mj_copySpec(self.ffi.as_ptr()) };
+        NonNull::new(ptr).map(Self::from_ffi).ok_or(MjEditError::AllocationFailed)
     }
 
     /// Creates a [`MjSpec`] from the `path` to a file.
@@ -372,15 +380,15 @@ impl MjSpec {
         }
         else {
             // SAFETY: spec_ptr is confirmed non-null by the guard above.
-            Ok(MjSpec(unsafe { NonNull::new_unchecked(spec_ptr) }))
+            Ok(Self::from_ffi(unsafe { NonNull::new_unchecked(spec_ptr) }))
         }
     }
 
     /// An immutable reference to the internal FFI struct.
     pub fn ffi(&self) -> &mjSpec {
-        // SAFETY: self.0 is a valid non-null mjSpec pointer for the lifetime of
+        // SAFETY: self.ffi is a valid non-null mjSpec pointer for the lifetime of
         // self (struct invariant).
-        unsafe { self.0.as_ref() }
+        unsafe { self.ffi.as_ref() }
     }
 
     /// A mutable reference to the internal FFI struct.
@@ -389,10 +397,13 @@ impl MjSpec {
     /// Callers must ensure that any mutations performed through the returned reference
     /// preserve the invariants that MuJoCo expects for `mjSpec`.
     pub unsafe fn ffi_mut(&mut self) -> &mut mjSpec {
-        unsafe { self.0.as_mut() }
+        unsafe { self.ffi.as_mut() }
     }
 
     /// Delete an element from this specification.
+    ///
+    /// # Deprecated
+    /// Call [`SpecObject::delete`] on the element handle instead.
     ///
     /// # Errors
     /// - [`MjEditError::DeleteFailed`] if `element` is null, does not belong to this spec, or
@@ -401,54 +412,24 @@ impl MjSpec {
     ///   wrap, or the world body.
     ///
     /// # Safety
-    /// The caller must ensure:
-    /// - `element` is a valid pointer to an mjsElement
-    /// - `element` has not been previously deleted
-    /// - no Rust references derived from `element` exist
+    /// Same contract as [`SpecObject::delete`], and `element` must point to an element of a
+    /// specification.
+    #[deprecated(since = "6.0.0", note = "use SpecObject::delete on the element handle")]
     pub unsafe fn delete_element(&mut self, element: *mut mjsElement) -> Result<(), MjEditError> {
         if element.is_null() {
             return Err(MjEditError::DeleteFailed("null element pointer".to_owned()));
         }
 
-        // mjCDef is not an mjCBase, so this precedes mjs_getSpec. Deleting a frame indexes
-        // `object_lists_` past its `mjNOBJECT` end, and deleting a wrap hits its null slot.
-        if matches!(
-            unsafe { (*element).elemtype },
-            MjtObj::mjOBJ_DEFAULT | MjtObj::mjOBJ_FRAME | MjtObj::mjOBJ_UNKNOWN
-        ) {
+        // mjCDef is not an mjCBase, so a default class must not reach the owner check below.
+        if unsafe { (*element).elemtype } == MjtObj::mjOBJ_DEFAULT {
             return Err(MjEditError::UnsupportedOperation);
         }
 
-        let spec = unsafe { self.ffi_mut() };
-        let owner = unsafe { mjs_getSpec(element) };
-        if owner != spec {
+        if unsafe { mjs_getSpec(element) } != self.ffi.as_ptr() {
             return Err(MjEditError::DeleteFailed("element does not belong to this spec".to_owned()));
         }
 
-        if unsafe { (*element).elemtype } == MjtObj::mjOBJ_BODY {
-            // Compare the raw bytes: a name loaded from a file need not be valid UTF-8, and the
-            // &str conversion panics on it.
-            let name = unsafe { mjs_getString(mjs_getName(element)) };
-            if !name.is_null() && unsafe { CStr::from_ptr(name) }.to_bytes() == b"world" {
-                return Err(MjEditError::UnsupportedOperation);
-            }
-        }
-
-        let result = unsafe { mjs_delete(spec, element) };
-        match result {
-            0 => Ok(()),
-            _ => {
-                let error_msg = unsafe {
-                    let ptr = mjs_getError(spec);
-                    if ptr.is_null() {
-                        "Unknown error".to_owned()
-                    } else {
-                        CStr::from_ptr(ptr).to_string_lossy().into_owned()
-                    }
-                };
-                Err(MjEditError::DeleteFailed(error_msg))
-            }
-        }
+        unsafe { utility::delete_element(element) }
     }
 
     /// Compile [`MjSpec`] to [`MjModel`].
@@ -461,13 +442,9 @@ impl MjSpec {
     /// texture has a builtin pattern set while its `nchannel` is less than 3, and when a texture
     /// has a negative dimension or a pixel count that does not fit in an [`i32`].
     pub fn compile(&mut self) -> Result<MjModel, MjEditError> {
-        // A texture carries four independent safe setters whose values MuJoCo only checks against
-        // each other during compilation. Both cross-field invariants can therefore only be
-        // enforced at this choke point.
+        // The builtin generators write 3 bytes per pixel into an `nchannel*width*height` buffer,
+        // and the setters are independent, so `compile` is the only place to check them together.
         for texture in self.texture_iter() {
-            // The builtin generators (`Builtin2D`/`BuiltinCube`) write a hard-coded 3 bytes per
-            // pixel, but MuJoCo allocates `nchannel*width*height` bytes and, unlike the file and
-            // data paths, does not check `nchannel >= 3` for the builtin path.
             if texture.builtin() != MjtBuiltin::mjBUILTIN_NONE && texture.nchannel() < 3 {
                 return Err(MjEditError::CompileFailed(
                     "texture with a builtin pattern requires nchannel >= 3".to_owned(),
@@ -487,7 +464,7 @@ impl MjSpec {
             }
         }
 
-        let result = unsafe { MjModel::from_raw( mj_compile(self.0.as_ptr(), ptr::null()) ) };
+        let result = unsafe { MjModel::from_raw( mj_compile(self.ffi.as_ptr(), ptr::null()) ) };
         result.map_err(|_| {
             // SAFETY: The spec is still valid after failed compilation.
             // The error pointer is valid until the next MuJoCo call on this spec.
@@ -505,22 +482,20 @@ impl MjSpec {
 
     /// Return the compiler timers, in seconds, in `mjtCTimer` order.
     pub fn timer(&self) -> &[f64; MjtCTimer::mjNCTIMER as usize] {
-        unsafe { &*mjs_getTimer(self.0.as_ptr()).cast() }
+        unsafe { &*mjs_getTimer(self.ffi.as_ptr()).cast() }
     }
 
     /// Get number of warnings accumulated in the spec. Wraps [`mjs_numWarnings`].
     pub fn num_warnings(&self) -> i32 {
-        // SAFETY: self.0 is a valid non-null mjSpec pointer.
-        unsafe { mjs_numWarnings(self.0.as_ptr()) }
+        // SAFETY: self.ffi is a valid non-null mjSpec pointer.
+        unsafe { mjs_numWarnings(self.ffi.as_ptr()) }
     }
 
     /// Get the i-th warning message. Returns `None` if the index is out of bounds, or if the
     /// message is not valid UTF-8. Wraps [`mjs_getWarning`].
     pub fn warning(&self, index: i32) -> Option<&str> {
-        // SAFETY: mjs_getWarning returns a pointer to a NUL-terminated C string owned
-        // by the spec, valid as long as self is alive and not mutated. We return a &str
-        // with the same lifetime as &self, which is sound.
-        let ptr = unsafe { mjs_getWarning(self.0.as_ptr(), index) };
+        // SAFETY: the string belongs to the spec and lives as long as the borrow of self.
+        let ptr = unsafe { mjs_getWarning(self.ffi.as_ptr(), index) };
         if ptr.is_null() {
             None
         } else {
@@ -722,35 +697,26 @@ impl MjSpec {
 /// Mutable iterator over items in [`MjSpec`].
 #[derive(Debug)]
 pub struct MjsSpecItemIterMut<'a, T> {
-    /// Copy of the raw `mjSpec` pointer that [`MjSpec`] wraps.
-    /// This is the FFI type wrapped inside [`MjSpec`].
+    /// Raw pointer to the spec; a borrow would alias the handles that the iterator yields.
     ffi_ptr: *mut mjSpec,
-    /// Last obtained element in the iterator.
-    /// This CAN be null, and this iterator it uses the null to detect
-    /// end of iteration. 
+    /// Element that the last `next` yielded. Null marks the end of the iteration.
     last: *mut mjsElement,
-    /// Used for generic implementation of iterator's methods.
     item_type: PhantomData<&'a mut T>
 }
 
 /// Immutable iterator over items in [`MjSpec`].
 #[derive(Debug, Clone)]
 pub struct MjsSpecItemIter<'a, T> {
-    /// Copy of the raw `mjSpec` pointer that [`MjSpec`] wraps.
-    /// This is the FFI type wrapped inside [`MjSpec`].
     ffi_ptr: *const mjSpec,
-    /// Last obtained element in the iterator.
-    /// This CAN be null, and this iterator it uses the null to detect
-    /// end of iteration. 
+    /// Element that the last `next` yielded. Null marks the end of the iteration.
     last: *mut mjsElement,
-    /// Used for generic implementation of iterator's methods.
     item_type: PhantomData<&'a T>
 }
 
 impl<'a, T: SpecObject> MjsSpecItemIterMut<'a, T> {
     fn new(root: &'a mut MjSpec) -> Self {
-        let last = unsafe { mjs_firstElement(root.0.as_ptr(), T::OBJ_TYPE) };
-        Self { ffi_ptr: root.0.as_ptr(), last, item_type: PhantomData }
+        let last = unsafe { mjs_firstElement(root.ffi.as_ptr(), T::OBJ_TYPE) };
+        Self { ffi_ptr: root.ffi.as_ptr(), last, item_type: PhantomData }
     }
 }
 
@@ -758,8 +724,8 @@ impl<'a, T: SpecObject> MjsSpecItemIter<'a, T> {
     fn new(root: &'a MjSpec) -> Self {
         // SAFETY: mjs_firstElement takes a *const mjSpec; the borrow of root keeps the spec
         // alive for the call.
-        let last = unsafe { mjs_firstElement(root.0.as_ptr(), T::OBJ_TYPE) };
-        Self { ffi_ptr: root.0.as_ptr(), last, item_type: PhantomData }
+        let last = unsafe { mjs_firstElement(root.ffi.as_ptr(), T::OBJ_TYPE) };
+        Self { ffi_ptr: root.ffi.as_ptr(), last, item_type: PhantomData }
     }
 }
 
@@ -797,7 +763,6 @@ impl<'a, T: SpecObject + 'a> Iterator for MjsSpecItemIter<'a, T> {
     }
 }
 
-// Once self.last is null, next() always returns None.
 impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsSpecItemIterMut<'a, T> {}
 impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsSpecItemIter<'a, T> {}
 
@@ -817,9 +782,9 @@ impl Default for MjSpec {
 
 impl Drop for MjSpec {
     fn drop(&mut self) {
-        // SAFETY: self.0 is a valid non-null mjSpec pointer; called exactly once
+        // SAFETY: self.ffi is a valid non-null mjSpec pointer; called exactly once
         // in Drop.
-        unsafe { mj_deleteSpec(self.0.as_ptr()); }
+        unsafe { mj_deleteSpec(self.ffi.as_ptr()); }
     }
 }
 
@@ -937,11 +902,6 @@ impl MjsGeom {
             [ffi, ffi_mut] solimp: &[MjtNum; mjNIMP as usize];     "solver impedance.";
             [ffi, ffi_mut] surfacevel: &[f64; 6];                  "surface velocity in local frame: linear, angular.";
             [ffi, ffi_mut] fluid_coefs: &[MjtNum; 5];              "ellipsoid-fluid interaction coefs."
-        ]
-    }
-
-    getter_setter! {
-        get, [
         ]
     }
 
@@ -1090,15 +1050,11 @@ impl MjsFrame {
         note = "always returns Ok; use `add_frame`"
     )]
     pub fn try_add_frame(&mut self) -> Result<&mut MjsFrame, MjEditError> {
-        // SAFETY: element_mut_pointer() reads `self.element`, valid for any live MjsFrame.
-        // mjs_getParent returns non-null because every Rust-API MjsFrame was created via
-        // mjs_addFrame, which always calls SetParent(body).
+        // SAFETY: mjs_addFrame always calls SetParent(body), so every frame the Rust API hands out
+        // has a non-null parent. The frame it returns is freshly allocated, so nothing aliases it.
         let parent_body = unsafe { mjs_getParent(self.element_mut_pointer()) };
         debug_assert!(!parent_body.is_null(), "mjs_getParent returned null; frame has no parent body");
         let ptr = unsafe { mjs_addFrame(parent_body, self.ffi_mut()) };
-        // SAFETY: ptr.as_mut() returns None for null, handled by ok_or; when non-null the
-        // pointee is properly aligned and initialized by C++ operator new, and freshly
-        // allocated so no existing Rust reference aliases it for the returned lifetime.
         unsafe { MjsFrame::from_ffi_ptr_mut(ptr) }.ok_or(MjEditError::AllocationFailed)
     }
 }
@@ -1123,11 +1079,6 @@ impl MjsActuator {
             [ffi, ffi_mut] ffrange: &[f64; 2];                         "range of the feedforward input (pid).";
             [ffi, ffi_mut] forcerange: &[f64; 2];                      "force range.";
             [ffi, ffi_mut] actrange: &[f64; 2];                        "activation range.";
-        ]
-    }
-
-    getter_setter! {
-        get, [
         ]
     }
 
@@ -1178,11 +1129,8 @@ impl MjsActuator {
 }
 
 
-/// Converts the error string returned by MuJoCo's `mjs_setToX` actuator
-/// configuration functions into a [`Result`].
-///
-/// Those functions return an empty string on success and a non-empty,
-/// NUL-terminated message describing the rejected parameter on failure.
+/// Converts the string that MuJoCo's `mjs_setToX` actuator functions return into a [`Result`].
+/// An empty string is success; anything else names the rejected parameter.
 fn actuator_set_result(c_err_msg: *const c_char) -> Result<(), MjEditError> {
     // SAFETY: MuJoCo's error messages are always NUL terminated.
     let err_msg = unsafe { CStr::from_ptr(c_err_msg) }.to_string_lossy();
@@ -1194,13 +1142,8 @@ fn actuator_set_result(c_err_msg: *const c_char) -> Result<(), MjEditError> {
     }
 }
 
-/* Actuator configuration structs.
-** Each `set_to_*` method taking optional (nullable in C) parameters has its own config struct.
-** Build either with struct-update syntax or with the chainable `with_*` builder methods, e.g.
-** `PositionConfig { kp: 10.0, kv: Some(2.0), ..Default::default() }` or
-** `PositionConfig::default().with_kp(10.0).with_kv(2.0)`. Optional fields default to `None`,
-** leaving the corresponding actuator parameter at its MuJoCo default; the `with_*` setters take
-** the inner value directly and wrap it in `Some`. */
+/* Actuator configuration structs. A `None` field reaches MuJoCo as a null pointer, which leaves
+** the corresponding actuator parameter at its own default. */
 
 /// Configuration for [`MjsActuator::set_to_position`].
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -1547,11 +1490,6 @@ impl MjsSensor {
         [&] with, get, [
             [ffi, ffi_mut] intprm: &[i32; mjNSENS as usize];            "integer parameters.";
             [ffi, ffi_mut] interval: &[f64; 2];                         "[period, time_prev] in seconds.";
-        ]
-    }
-
-    getter_setter! {
-        get, [
         ]
     }
 
@@ -1906,8 +1844,7 @@ impl MjsTendon {
     /// Returns [`MjEditError::IndexOutOfBounds`] if `i >= wrap_num()`.
     pub fn try_wrap(&self, i: usize) -> Result<&MjsWrap, MjEditError> {
         let len = self.wrap_num();
-        // mjs_getWrap aborts the process via mju_error for an out-of-range index, so the bound is
-        // checked here and turned into a recoverable error instead.
+        // mjs_getWrap ends the process via mju_error for an out-of-range index.
         if i >= len {
             return Err(MjEditError::IndexOutOfBounds { id: i, len });
         }
@@ -1972,8 +1909,8 @@ impl MjsWrap {
     /// wrap, when it holds no side site, or when the named site is missing from the spec (MuJoCo
     /// logs a warning in that last case).
     ///
-    /// There is no mutable counterpart due to alising issues.
-    /// Edit the site through [`MjSpec::site_mut`] instead.
+    /// There is no mutable counterpart, because it would alias. Edit the site through
+    /// [`MjSpec::site_mut`] instead.
     pub fn side_site(&self) -> Option<&MjsSite> {
         let ptr = unsafe { mjs_getWrapSideSite(self.ffi()) };
         unsafe { MjsSite::from_ffi_ptr(ptr) }
@@ -2024,11 +1961,8 @@ impl MjsText {
 mjs_struct!(Tuple with SpecObject: MjsTuple <= mjsTuple);
 impl MjsTuple {
     vec_set! {
-        // `objtype` is stored as a raw C `int` and, at `compile()` time, used to index the model
-        // compiler's `object_lists_` array (size `mjNOBJECT`) with no bounds check. Validating every
-        // element against `mjNOBJECT` rules out the meta `MjtObj` variants (`mjOBJ_FRAME`,
-        // `mjOBJ_DEFAULT`, `mjOBJ_MODEL`) that would otherwise cause an out-of-bounds read, which is
-        // what lets this setter be safe.
+        // `compile()` indexes `object_lists_` (size `mjNOBJECT`) with each value and no bounds
+        // check, so the per-element check is what makes this setter safe.
         objtype: MjtObj => i32 { check_objtype, "[`MjEditError::InvalidParameter`] when any value is not a real object type (i.e. not below [`MjtObj::mjNOBJECT`])" } => MjEditError;
             "object types. Every value must be a real object type (an `MjtObj` below `mjNOBJECT`).";
     }
@@ -2113,11 +2047,6 @@ impl MjsMesh {
             [ffi, ffi_mut] refpos: &[f64; 3];            "reference position.";
             [ffi, ffi_mut] refquat: &[f64; 4];           "reference orientation.";
             [ffi, ffi_mut] scale: &[f64; 3];             "scale vector.";
-        ]
-    }
-
-    getter_setter! {
-        get, [
         ]
     }
 
@@ -2246,11 +2175,9 @@ mjs_struct!(Texture with SpecObject: MjsTexture <= mjsTexture);
 
 /// # Note: cube-map files
 ///
-/// The `cubefiles` field is a **pre-sized** string vector (6 entries, one per cube face).
-/// Use [`set_cubefile`](Self::set_cubefile) with a [`MjtCubeFace`] variant to assign a
-/// file to a specific face. The bulk [`set_cubefiles`](Self::set_cubefiles) /
-/// [`append_cubefiles`](Self::append_cubefiles) methods are also available but
-/// operate on the vector as a whole.
+/// `cubefiles` is a pre-sized string vector of 6 entries, one per cube face. Assign one face with
+/// [`set_cubefile`](Self::set_cubefile); [`set_cubefiles`](Self::set_cubefiles) and
+/// [`append_cubefiles`](Self::append_cubefiles) replace or extend the vector as a whole.
 impl MjsTexture {
     getter_setter! {
         [&] with, get, [
@@ -2272,9 +2199,7 @@ impl MjsTexture {
 
     getter_setter! {
         [&] with, get, set, [
-            // `nchannel` must be `>= 3` whenever a builtin pattern is set
-            // (`builtin != MjtBuiltin::mjBUILTIN_NONE`); this cross-field invariant is
-            // enforced at the compile choke point in `MjSpec::compile`.
+            // A builtin pattern needs `nchannel >= 3`; `MjSpec::compile` enforces that.
             [ffi, ffi_mut] nchannel: i32; "number of channels.";
         ]
     }
@@ -2316,12 +2241,10 @@ mjs_struct!(Material with SpecObject: MjsMaterial <= mjsMaterial);
 
 /// # Note: texture assignment
 ///
-/// The `textures` field is a **pre-sized** string vector (`mjNTEXROLE` entries, one per
-/// [`MjtTextureRole`]). Use [`set_texture`](Self::set_texture) to assign a texture name
-/// to a specific role (e.g. [`MjtTextureRole::mjTEXROLE_RGB`] for the base colour used by
-/// the renderer). The bulk [`set_textures`](Self::set_textures) /
-/// [`append_textures`](Self::append_textures) methods are also available but operate on
-/// the vector as a whole and may disrupt the pre-sized layout.
+/// `textures` is a pre-sized string vector of `mjNTEXROLE` entries, one per [`MjtTextureRole`].
+/// Assign one role with [`set_texture`](Self::set_texture); [`set_textures`](Self::set_textures)
+/// and [`append_textures`](Self::append_textures) replace or extend the vector as a whole and
+/// break the pre-sized layout.
 impl MjsMaterial {
     getter_setter! {
         [&] with, get, [
@@ -2354,30 +2277,7 @@ impl MjsMaterial {
 /***************************
 ** Body specification
 ***************************/
-mjs_struct!(Body with SpecObject: MjsBody <= mjsBody {
-    // Override the delete method to prevent deletion of world.
-    /// Delete this body from its parent spec.
-    ///
-    /// # Deprecated
-    /// This API is deprecated and will be removed in a future release.
-    /// Use [`MjSpec::delete_element`](crate::wrappers::MjSpec::delete_element) instead.
-    ///
-    /// This method is inherently unsound: deleting a body mutates owner/ancestor graph
-    /// structures outside the borrowed `&mut self` region.
-    ///
-    /// # Errors
-    /// - Returns [`MjEditError::UnsupportedOperation`] if this is the world body.
-    /// - Returns [`MjEditError::DeleteFailed`] if MuJoCo's internal deletion fails.
-    ///
-    /// # Safety
-    /// This legacy method is not soundly callable; it exists only for backward compatibility.
-    unsafe fn delete(&mut self) -> Result<(), MjEditError> {
-        if self.name() == "world" {
-            return Err(MjEditError::UnsupportedOperation);
-        }
-        unsafe { SpecItem::__delete_default__(self) }
-    }
-});
+mjs_struct!(Body with SpecObject: MjsBody <= mjsBody);
 
 impl MjsBody {
     add_x_method! { body, site, joint, geom, camera, light }
@@ -2430,13 +2330,9 @@ impl MjsBody {
         note = "always returns Ok; use `add_frame`"
     )]
     pub fn try_add_frame(&mut self) -> Result<&mut MjsFrame, MjEditError> {
-        // SAFETY: ffi_mut() returns self unchanged; the coercion to *mut mjsBody is safe.
-        // ptr::null_mut() for parentframe is valid: the MuJoCo API accepts null to mean
-        // "attach directly to the body with no parent frame".
+        // SAFETY: a null parentframe attaches the frame directly to the body. The frame that
+        // mjs_addFrame returns is freshly allocated, so nothing aliases it.
         let ptr = unsafe { mjs_addFrame(self.ffi_mut(), ptr::null_mut()) };
-        // SAFETY: ptr.as_mut() returns None for null, handled by ok_or; when non-null the
-        // pointee is properly aligned and initialized by C++ operator new, and freshly
-        // allocated so no existing Rust reference aliases it for the returned lifetime.
         unsafe { MjsFrame::from_ffi_ptr_mut(ptr) }.ok_or(MjEditError::AllocationFailed)
     }
 }
@@ -2545,8 +2441,6 @@ impl Default for MjFlexcompConfig<'_> {
 }
 
 impl<'a> MjFlexcompConfig<'a> {
-    // Builders are macro-generated. Optional fields are `Option`, so `.into()` wraps the
-    // value in `Some` via the std `From<T> for Option<T>` impl.
     getter_setter! {
         with, [
             r#type: &'a str;      "the flexcomp type: \"grid\", \"box\", \"cylinder\", \"ellipsoid\", \"square\", \"disc\", \"circle\", \"mesh\", \"gmsh\", or \"direct\" (default \"grid\").";
@@ -2614,12 +2508,8 @@ impl MjsBody {
         let quat_ptr = config.quat.as_ref().map_or(ptr::null(), |a| a as *const [f64; 4]);
         let origin_ptr = config.origin.as_ref().map_or(ptr::null(), |a| a as *const [f64; 3]);
 
-        // SAFETY: ffi_mut() yields self as a valid *mut mjsBody. Every array/string
-        // pointer either references `config`, the local CStrings, or the widened count
-        // arrays (all of which outlive the call), or is null, which mjs_makeFlex
-        // documents as "use default". `name` is non-null as the C function requires.
-        // mjs_makeFlex copies the strings (name/file into std::string, type/dof read
-        // into enums) and retains no pointers, so call-duration validity is sufficient.
+        // SAFETY: every pointer below is either null, which mjs_makeFlex reads as "use the
+        // default", or borrows a local that outlives the call. MuJoCo retains no pointer of its own.
         let ptr = unsafe {
             mjs_makeFlex(
                 self.ffi_mut(),
@@ -2645,14 +2535,11 @@ impl MjsBody {
                 config.vfs.map_or(ptr::null(), |v| v.ffi() as *const mjVFS),
             )
         };
-        // SAFETY: null maps to None (reported as AllocationFailed); a non-null pointer
-        // is a freshly allocated, initialized mjsFlex with no aliasing Rust references.
         unsafe { MjsFlex::from_ffi_ptr_mut(ptr) }.ok_or(MjEditError::AllocationFailed)
     }
 }
 
 impl MjsBody {
-    // Complex types with mutable and immutable reference returns.
     getter_setter! {
         [&] with, get, [
             // body frame
@@ -2669,14 +2556,8 @@ impl MjsBody {
         ]
     }
 
-    getter_setter! {
-        get, [
-        ]
-    }
-
     nested_handle!(plugin: MjsPluginReference; "passive force plugin.");
 
-    // Plain types with normal getters and setters.
     getter_setter! {
         [&] with, get, set, [
             [ffi, ffi_mut] mass: f64;                     "mass.";
@@ -2701,16 +2582,15 @@ impl MjsBody {
 pub struct MjsBodyItemIterMut<'a, T> {
     /// Raw pointer to the body; a borrow would alias the handles that the iterator yields.
     ffi_ptr: *mut mjsBody,
+    /// Element that the last `next` yielded. Null marks the end of the iteration.
     last: *mut mjsElement,
     recurse: bool,
-    /// Used for generic implementation of iterator's methods.
     item_type: PhantomData<&'a mut T>
 }
 
 impl<'a, T: SpecObject> MjsBodyItemIterMut<'a, T> {
     fn new(root: &'a mut MjsBody, recurse: bool) -> Self {
-        // SAFETY: the iterator walks the children of the body; it never exchanges its contents,
-        // and the borrow of root keeps the body alive.
+        // SAFETY: the iterator walks the children of the body and never exchanges its contents.
         let ffi_ptr = unsafe { root.ffi_mut() } as *mut mjsBody;
         let last = unsafe { mjs_firstChild(ffi_ptr, T::OBJ_TYPE, recurse.into()) };
         Self { ffi_ptr, last, recurse, item_type: PhantomData }
@@ -2739,9 +2619,9 @@ impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsBodyItemIterMut<'a,
 #[derive(Debug, Clone)]
 pub struct MjsBodyItemIter<'a, T> {
     ffi_ptr: *const mjsBody,
+    /// Element that the last `next` yielded. Null marks the end of the iteration.
     last: *const mjsElement,
     recurse: bool,
-    /// Used for generic implementation of iterator's methods.
     item_type: PhantomData<&'a T>
 }
 
@@ -2779,7 +2659,6 @@ impl<'a, T: SpecObject + 'a> Iterator for MjsBodyItemIter<'a, T> {
     }
 }
 
-// Once self.last is null, next() always returns None.
 impl<'a, T: SpecObject + 'a> std::iter::FusedIterator for MjsBodyItemIter<'a, T> {}
 
 /// Iterator methods.
@@ -2929,19 +2808,15 @@ mod tests {
         body.set_name(NEW_MODEL_NAME).unwrap();
 
         /* Test normal body deletion */
-        let body_element = {
-            let body = spec.body_mut(NEW_MODEL_NAME).expect("failed to obtain the body");
-            body.element_mut_pointer()
-        };
-        assert!(unsafe { spec.delete_element(body_element) }.is_ok(), "failed to delete model");
+        assert!(
+            unsafe { spec.body_mut(NEW_MODEL_NAME).unwrap().delete() }.is_ok(),
+            "failed to delete model"
+        );
         assert!(spec.body(NEW_MODEL_NAME).is_none(), "body was not removed from spec");
 
         /* Test world body deletion */
-        let world_element = {
-            let world = spec.world_body_mut();
-            world.element_mut_pointer()
-        };
-        assert!(unsafe { spec.delete_element(world_element) }.is_err(), "the world model should not be deletable");
+        let world = unsafe { spec.world_body_mut().delete() };
+        assert!(world.is_err(), "the world model should not be deletable");
 
         spec.compile().unwrap();
     }
@@ -2956,11 +2831,10 @@ mod tests {
         joint.set_name(NEW_NAME).unwrap();
 
         /* Test normal body deletion */
-        let joint_element = {
-            let joint = spec.joint_mut(NEW_NAME).expect("failed to obtain the body");
-            joint.element_mut_pointer()
-        };
-        assert!(unsafe { spec.delete_element(joint_element) }.is_ok(), "failed to delete model");
+        assert!(
+            unsafe { spec.joint_mut(NEW_NAME).unwrap().delete() }.is_ok(),
+            "failed to delete model"
+        );
         assert!(spec.joint(NEW_NAME).is_none(), "body was not removed fom spec");
 
         spec.compile().unwrap();
@@ -2975,11 +2849,8 @@ mod tests {
         hfield.set_name(NEW_NAME).unwrap();
 
         /* Test normal hfield deletion */
-        let hfield_element = {
-            let hfield = spec.hfield_mut(NEW_NAME).expect("failed to obtain the hfield");
-            hfield.element_mut_pointer()
-        };
-        assert!(unsafe { spec.delete_element(hfield_element) }.is_ok(), "failed to delete hfield");
+        let hfield = spec.hfield_mut(NEW_NAME).expect("failed to obtain the hfield");
+        assert!(unsafe { hfield.delete() }.is_ok(), "failed to delete hfield");
         assert!(spec.hfield(NEW_NAME).is_none(), "hfield was not removed from spec");
 
         spec.compile().unwrap();
@@ -3162,9 +3033,7 @@ mod tests {
         };
         assert!(required_size > 1, "required_size must exceed the original 1-byte buffer");
 
-        // Retry with the size MuJoCo reported plus one extra byte for safety
-        // (MuJoCo uses a strict less-than comparison, so the buffer must be
-        // at least required_size + 1 to succeed).
+        // `required_size` excludes the NUL, so the retry needs one byte more.
         let xml = spec.save_xml_string(required_size + 1)
             .expect("save_xml_string should succeed with required_size + 1 bytes");
         assert!(!xml.is_empty(), "saved XML must be non-empty");
@@ -3677,13 +3546,9 @@ mod tests {
                 "Before compile: joint '{}' align should be {:?}", name, expected);
         }
 
-        // Compile and verify -- AUTO should resolve, FALSE/TRUE should remain
+        // Compiling proves MuJoCo accepted every enum value.
         let model = spec.compile().unwrap();
-        let jnt_count = model.ffi().njnt as usize;
-        assert_eq!(jnt_count, 3, "expected 3 joints");
-
-        // Must compile without error -- the key correctness is the round-trip above;
-        // compilation proves MuJoCo accepted the enum values.
+        assert_eq!(model.ffi().njnt as usize, 3, "expected 3 joints");
     }
 
     /// Test that MjsJoint `limited` also correctly round-trips all three states
@@ -3713,12 +3578,11 @@ mod tests {
                 "Before compile: joint '{}' limited should be {:?}", name, expected);
         }
 
-        // Compile -- AUTO resolves based on range presence
+        // AUTO resolves from the presence of a range.
         let model = spec.compile().unwrap();
         let jnt_limited = model.jnt_limited();
         assert!(!jnt_limited[0]);
         assert!(jnt_limited[1]);
-        // AUTO with range present should resolve to true
         assert!(jnt_limited[2], "Joint with limited=AUTO and range should resolve to true");
     }
 
@@ -3893,9 +3757,8 @@ mod tests {
             .set_nchannel(3);
         assert!(ok_spec.compile().is_ok(), "nchannel == 3 builtin texture should compile");
 
-        // nchannel < 3 with NO builtin pattern must not trip this guard. Such a texture still
-        // fails to compile (it has no pixel source), but with MuJoCo's own error message rather
-        // than the nchannel guard's, proving the guard is correctly scoped to the builtin path.
+        // Without a builtin pattern the texture still fails to compile, but through MuJoCo's own
+        // error, which scopes the guard to the builtin path.
         let mut no_builtin = MjSpec::new();
         no_builtin.add_texture()
             .with_name("plain")
@@ -4074,33 +3937,24 @@ mod tests {
         assert!(MjSpec::new().add_default("cls", None).id().is_none());
     }
 
-    /// `mjs_getSpec` casts to `mjCBase` too, so the default check must run before the owner check
-    /// for `delete_element` to reject a default of this very spec as unsupported.
+    /// A name that MuJoCo parses need not be valid UTF-8, so `delete` must reach the world body
+    /// through its address; a name comparison would panic instead of deleting the body.
     #[test]
-    fn test_delete_element_rejects_default() {
-        let mut spec = MjSpec::new();
-        let element = spec.add_default("cls", None).element_mut_pointer();
-        assert!(matches!(unsafe { spec.delete_element(element) }, Err(MjEditError::UnsupportedOperation)));
-    }
-
-    /// A name that MuJoCo parses need not be valid UTF-8, so `delete_element` compares the raw
-    /// bytes; a `&str` conversion would panic instead of deleting the body.
-    #[test]
-    fn test_delete_element_non_utf8_name() {
+    fn test_delete_non_utf8_name() {
         // tinyxml2 encodes a character reference without validating it, so the surrogate U+D800
         // becomes the three bytes ED A0 80, which no UTF-8 string may hold.
         let mut spec = MjSpec::from_xml_string(
             "<mujoco><worldbody><body name=\"a&#xD800;b\"/></worldbody></mujoco>"
         ).unwrap();
 
-        let element = spec.body_iter_mut().nth(1).unwrap().element_mut_pointer();
+        let body = spec.body_iter_mut().nth(1).unwrap();
         // SAFETY: the spec owns the name string for as long as the element lives.
-        let name = unsafe { CStr::from_ptr(mjs_getString(mjs_getName(element))) };
+        let name = unsafe { CStr::from_ptr(mjs_getString(mjs_getName(body.element_mut_pointer()))) };
         assert!(
             std::str::from_utf8(name.to_bytes()).is_err(), "the test needs a non-UTF-8 name"
         );
 
-        unsafe { spec.delete_element(element) }.unwrap();
+        unsafe { body.delete() }.unwrap();
         assert_eq!(spec.body_iter().count(), 1);
     }
 
@@ -4115,14 +3969,29 @@ mod tests {
         assert_eq!(wrap.name(), "s0");
     }
 
-    /// A frame's element type lies past the end of MuJoCo's element-list array, and a wrap's slot
-    /// in that array is empty, so `mjs_delete` corrupts the spec and still reports success.
+    /// A frame's element type lies past the end of MuJoCo's element-list array, so `mjs_delete`
+    /// corrupts the spec and still reports success.
     #[test]
-    fn test_delete_element_rejects_frame_and_wrap() {
+    fn test_delete_rejects_frame() {
         let mut spec = MjSpec::new();
-        let frame = spec.world_body_mut().add_frame().element_mut_pointer();
+        let frame = spec.world_body_mut().add_frame();
+        assert!(matches!(unsafe { frame.delete() }, Err(MjEditError::UnsupportedOperation)));
+        assert_eq!(spec.world_body().frame_iter(false).count(), 1, "the frame stays in the body");
+    }
+
+    /// The deprecated raw-pointer path reaches what a handle cannot: a null pointer, a default
+    /// class, a tendon wrap, and an element of another spec.
+    #[test]
+    #[expect(deprecated, reason = "the test covers the deprecated method itself")]
+    fn test_delete_element_guards() {
+        let mut spec = MjSpec::new();
         assert!(matches!(
-            unsafe { spec.delete_element(frame) }, Err(MjEditError::UnsupportedOperation)
+            unsafe { spec.delete_element(ptr::null_mut()) }, Err(MjEditError::DeleteFailed(_))
+        ));
+
+        let default = spec.add_default("cls", None).element_mut_pointer();
+        assert!(matches!(
+            unsafe { spec.delete_element(default) }, Err(MjEditError::UnsupportedOperation)
         ));
 
         spec.world_body_mut().add_site().with_name("s0");
@@ -4130,5 +3999,146 @@ mod tests {
         assert!(matches!(
             unsafe { spec.delete_element(wrap) }, Err(MjEditError::UnsupportedOperation)
         ));
+
+        let mut other = MjSpec::new();
+        let foreign = other.world_body_mut().add_body().element_mut_pointer();
+        assert!(matches!(
+            unsafe { spec.delete_element(foreign) }, Err(MjEditError::DeleteFailed(_))
+        ));
+        assert_eq!(other.body_iter().count(), 2, "the foreign body stays in its own spec");
+
+        let hfield = spec.add_hfield().element_mut_pointer();
+        unsafe { spec.delete_element(hfield) }.unwrap();
+        assert_eq!(spec.hfield_iter().count(), 0, "an element of this spec still deletes");
+    }
+
+    /// Deleting a body deletes its subtree, which the safety contract of `delete` builds on.
+    #[test]
+    fn test_delete_body_removes_subtree() {
+        let mut spec = MjSpec::new();
+        let parent = spec.world_body_mut().add_body();
+        parent.set_name("parent").unwrap();
+        parent.add_body().with_name("child");
+        spec.body_mut("child").unwrap().add_geom().with_name("g0");
+
+        unsafe { spec.body_mut("parent").unwrap().delete() }.unwrap();
+        assert!(spec.body("child").is_none(), "the child left the spec with its parent");
+        assert!(spec.geom("g0").is_none(), "so did the geom of the child");
+        assert_eq!(spec.body_iter().count(), 1, "only the world body stays");
+    }
+
+    /// Deleting a body frees the elements that referenced it, so their address returns to the
+    /// allocator and a later element can take it.
+    #[test]
+    fn test_delete_body_releases_dependents() {
+        const MODEL_WITH_ACTUATOR: &str = "\
+<mujoco>
+  <worldbody>
+    <body name=\"arm\"><joint name=\"j0\" type=\"hinge\"/><geom size=\".1\"/></body>
+  </worldbody>
+  <actuator><motor name=\"a0\" joint=\"j0\"/></actuator>
+</mujoco>";
+
+        let mut spec = MjSpec::from_xml_string(MODEL_WITH_ACTUATOR).unwrap();
+        unsafe { spec.body_mut("arm").unwrap().delete() }.unwrap();
+        assert!(spec.actuator("a0").is_none(), "the delete released the dependent actuator");
+        assert_eq!(spec.actuator_iter().count(), 0, "no walk reaches it either");
+    }
+
+    /// Compiling with `discardvisual` frees the visual geoms and their assets, so a later element
+    /// can take the address of a discarded one, and a walk must still reach only live geoms.
+    ///
+    /// The test walks instead of looking a name up: MuJoCo leaves the discarded name in its id map,
+    /// so `MjSpec::geom("visual")` throws out of C++ here. That is a separate defect of the lookup.
+    #[test]
+    fn test_delete_after_discardvisual() {
+        const VISUAL: &str = "\
+<mujoco>
+  <worldbody>
+    <geom name=\"solid\" size=\".1\"/>
+    <geom name=\"visual\" size=\".1\" contype=\"0\" conaffinity=\"0\" group=\"3\"/>
+  </worldbody>
+</mujoco>";
+
+        let mut spec = MjSpec::from_xml_string(VISUAL).unwrap();
+        spec.compiler_mut().set_discardvisual(true);
+        spec.compile().unwrap();
+        assert_eq!(spec.geom_iter().count(), 1, "the compile discarded the visual geom");
+        assert_eq!(spec.geom_iter().next().unwrap().name(), "solid");
+
+        for i in 0..64 {
+            spec.world_body_mut().add_geom().with_name(&format!("fresh{i}"))
+                .with_size([0.1, 0.0, 0.0]);
+        }
+        assert!(
+            unsafe { spec.geom_iter_mut().next().unwrap().delete() }.is_ok(), "the survivor deletes"
+        );
+        assert_eq!(spec.geom_iter().count(), 64);
+    }
+
+    /// A walk that deletes the first element of each round removes a whole selection, which is how
+    /// a caller deletes in bulk without holding a handle across a deletion.
+    #[test]
+    fn test_delete_removes_a_whole_selection() {
+        let mut spec = MjSpec::new();
+        let world = spec.world_body_mut();
+        for name in ["g0", "g1", "g2"] {
+            world.add_geom().with_name(name).with_size([0.1, 0.0, 0.0]);
+        }
+
+        let mut deleted = 0;
+        while let Some(geom) = spec.geom_iter_mut().next() {
+            unsafe { geom.delete() }.unwrap();
+            deleted += 1;
+        }
+        assert_eq!(deleted, 3);
+        assert_eq!(spec.geom_iter().count(), 0);
+    }
+
+    /// Every element kind that `delete` accepts removes through it.
+    #[test]
+    fn test_delete_every_element_kind() {
+        let mut spec = MjSpec::new();
+        macro_rules! delete_added {
+            ($($kind:ident),*) => {paste::paste! {$({
+                let element = spec.[<$kind _iter_mut>]().next().unwrap();
+                assert!(unsafe { element.delete() }.is_ok(), stringify!($kind));
+                assert_eq!(spec.[<$kind _iter>]().count(), 0, stringify!($kind));
+            })*}};
+        }
+
+        let world = spec.world_body_mut();
+        world.add_body();
+        world.add_geom();
+        world.add_site();
+        world.add_camera();
+        world.add_light();
+        spec.body_iter_mut().last().unwrap().add_joint();
+        spec.add_actuator();
+        spec.add_pair();
+        spec.add_equality();
+        spec.add_tendon();
+        spec.add_mesh();
+        spec.add_material();
+        spec.add_sensor();
+        spec.add_flex();
+        spec.add_exclude();
+        spec.add_numeric();
+        spec.add_text();
+        spec.add_tuple();
+        spec.add_key();
+        spec.add_hfield();
+        spec.add_skin();
+        spec.add_texture();
+        spec.add_plugin();
+
+        delete_added!(
+            joint, geom, site, camera, light, actuator, pair, equality, tendon, mesh, material,
+            sensor, flex, exclude, numeric, text, tuple, key, hfield, skin, texture, plugin
+        );
+
+        // The world body stays, so the body list never empties.
+        assert!(unsafe { spec.body_iter_mut().last().unwrap().delete() }.is_ok(), "body");
+        assert_eq!(spec.body_iter().count(), 1);
     }
 }

--- a/src/wrappers/mj_editing/default.rs
+++ b/src/wrappers/mj_editing/default.rs
@@ -17,13 +17,13 @@ macro_rules! default_accessor_wrapper {
             pub fn $name(&self) -> &[<Mjs $name:camel>] {
                 // SAFETY: MuJoCo's mjCDef::PointToLocal() always initializes these
                 // pointers to non-null addresses of the owning mjCDef's local members.
-                unsafe { &*self.$name }
+                unsafe { [<Mjs $name:camel>]::from_ffi_ptr(self.ffi().$name) }.unwrap()
             }
 
             #[doc = concat!("Returns a mutable reference to ", stringify!($name), "'s defaults.")]
             pub fn [<$name _mut>](&mut self) -> &mut [<Mjs $name:camel>] {
                 // SAFETY: see above.
-                unsafe { &mut *self.$name }
+                unsafe { [<Mjs $name:camel>]::from_ffi_ptr_mut(self.ffi().$name) }.unwrap()
             }
         )*
     }};
@@ -32,8 +32,9 @@ macro_rules! default_accessor_wrapper {
 // This is implemented manually since we can't directly borrow check if something is using the default.
 // We also override the delete method to return an error instead of deleting.
 
-/// Default specification. This is a type alias to [`mjsDefault`].
-pub type MjsDefault = mjsDefault;
+mjs_opaque!(MjsDefault, mjsDefault,
+    "Default specification. An opaque handle for the FFI type [`mjsDefault`], reached through \
+[`ffi`](Self::ffi).");
 
 impl MjsDefault {
     default_accessor_wrapper! {
@@ -46,7 +47,7 @@ impl super::traits::sealed::Sealed for MjsDefault {}
 
 impl SpecItem for MjsDefault {
     fn element_pointer(&self) -> *const mjsElement {
-        self.element
+        self.ffi().element
     }
 
     fn default(&self) -> Option<&MjsDefault> {

--- a/src/wrappers/mj_editing/default.rs
+++ b/src/wrappers/mj_editing/default.rs
@@ -29,9 +29,6 @@ macro_rules! default_accessor_wrapper {
     }};
 }
 
-// This is implemented manually since we can't directly borrow check if something is using the default.
-// We also override the delete method to return an error instead of deleting.
-
 mjs_opaque!(MjsDefault <= mjsDefault,
     "Default specification. An opaque handle for the FFI type [`mjsDefault`], reached through \
 [`ffi`](Self::ffi).");
@@ -54,19 +51,13 @@ impl SpecItem for MjsDefault {
         Some(self)
     }
 
-    /// MuJoCo exposes no id accessor for a default class.
-    ///
-    /// Always returns `None`.
+    /// A default class carries no id. Always returns `None`.
     fn id(&self) -> Option<usize> {
-        // mjs_getId casts to mjCBase, but mjCDef derives from mjsElement directly, so the cast
-        // would read an unrelated offset instead of an id.
+        // mjCDef derives from mjsElement, not mjCBase, so mjs_getId would read an unrelated offset.
         None
     }
 
-    /// `MjsDefault` cannot be assigned to a named default class.
-    ///
-    /// This override always returns [`MjEditError::UnsupportedOperation`] without using
-    /// `class_name` or performing any operation.
+    /// A default class cannot be assigned to another default class.
     ///
     /// # Errors
     /// Always returns [`MjEditError::UnsupportedOperation`].
@@ -74,33 +65,11 @@ impl SpecItem for MjsDefault {
         Err(MjEditError::UnsupportedOperation)
     }
 
-    /// `MjsDefault` cannot be assigned to a named default class.
-    ///
-    /// This override always returns [`MjEditError::UnsupportedOperation`] without using
-    /// `class_name` or performing any operation.
+    /// A default class cannot be assigned to another default class.
     ///
     /// # Errors
     /// Always returns [`MjEditError::UnsupportedOperation`].
     fn with_default(&mut self, _class_name: &str) -> Result<&mut Self, MjEditError> {
-        Err(MjEditError::UnsupportedOperation)
-    }
-
-    /// This crate does not delete a default class through the item itself.
-    ///
-    /// # Deprecated
-    /// This API is deprecated and will be removed in a future release.
-    /// Use [`MjSpec::delete_element`](super::MjSpec::delete_element) instead.
-    ///
-    /// This override always returns [`MjEditError::UnsupportedOperation`] without performing
-    /// any operation, so the post-deletion use-after-free restriction from [`SpecItem::delete`]
-    /// does not apply; `self` remains valid after an `Err` return.
-    ///
-    /// # Errors
-    /// This will always error with [`MjEditError::UnsupportedOperation`].
-    ///
-    /// # Safety
-    /// No unsafe operations are performed; the struct is unchanged on return.
-    unsafe fn delete(&mut self) -> Result<(), MjEditError> {
         Err(MjEditError::UnsupportedOperation)
     }
 }

--- a/src/wrappers/mj_editing/default.rs
+++ b/src/wrappers/mj_editing/default.rs
@@ -32,7 +32,7 @@ macro_rules! default_accessor_wrapper {
 // This is implemented manually since we can't directly borrow check if something is using the default.
 // We also override the delete method to return an error instead of deleting.
 
-mjs_opaque!(MjsDefault, mjsDefault,
+mjs_opaque!(MjsDefault <= mjsDefault,
     "Default specification. An opaque handle for the FFI type [`mjsDefault`], reached through \
 [`ffi`](Self::ffi).");
 
@@ -104,9 +104,3 @@ impl SpecItem for MjsDefault {
         Err(MjEditError::UnsupportedOperation)
     }
 }
-
-// MjsDefault is intentionally NEITHER Send NOR Sync, for the same reason as the Mjs*
-// element handles: it is a raw pointer into the shared mjSpec arena and its `&mut self`
-// mutators reach into model-global state. The raw-pointer field already makes it
-// auto-`!Send + !Sync`; do NOT add `unsafe impl Send`/`Sync` here. The owning `MjSpec`
-// remains `Send` (but not `Sync`), so the spec itself can still move between threads.

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -1,5 +1,5 @@
 //! Trait definitions for model editing.
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 
 use crate::error::MjEditError;
 use crate::mujoco_c::*;
@@ -12,18 +12,12 @@ pub(crate) mod sealed {
     pub trait Sealed {}
 }
 
-/// Represents all the types that [`MjSpec`](super::MjSpec) supports.
-/// This is pre-implemented for all the specification types and is not
-/// meant to be implemented by the user.
-///
+/// Every type that [`MjSpec`](super::MjSpec) supports. Sealed.
 pub trait SpecItem: Sized + sealed::Sealed {
-    /// Returns the internal element struct.
-    /// The element struct is the C++ implementation of the
-    /// actual item, which is hidden from the user, but is needed
-    /// in some functions.
-    /// 
-    /// The returned pointer is const. Callers that must satisfy MJS's wrong use of mutable
-    /// pointers, such as [`mjs_getName`], cast it at the call site.
+    /// Returns the `mjsElement` that MuJoCo keeps behind the item.
+    ///
+    /// The pointer is const. A caller that must satisfy MJS's wrong use of mutable pointers, such
+    /// as [`mjs_getName`], casts it at the call site.
     fn element_pointer(&self) -> *const mjsElement;
 
     /// Same as [`SpecItem::element_pointer`], but with a mutable borrow and a mutable pointer.
@@ -36,9 +30,8 @@ pub trait SpecItem: Sized + sealed::Sealed {
     /// # Panics
     /// Panics if the stored MuJoCo string is not valid UTF-8.
     fn name(&self) -> &str {
-        // SAFETY: mjs_getName returns a pointer to a null-terminated string owned
-        // by the spec element, valid for the element's lifetime.
-        // It is safe to convert to *mut _ as it doesn't actually modify anything.
+        // SAFETY: the string belongs to the element and lives as long as it does. mjs_getName
+        // takes a mutable pointer but writes nothing.
         unsafe { read_mjs_string(mjs_getName(self.element_pointer() as *mut _)) }
     }
 
@@ -66,21 +59,16 @@ pub trait SpecItem: Sized + sealed::Sealed {
 
     /// Returns the used default, or `None` when the element carries no default class name.
     ///
-    /// Only an element that MuJoCo adds with a default class carries one: body, joint, geom, site,
-    /// camera, light, actuator, pair, equality, tendon, mesh and material. Every other element,
-    /// a frame included, returns `None`.
+    /// Only a body, joint, geom, site, camera, light, actuator, pair, equality, tendon, mesh or
+    /// material can carry one. Every other element, a frame included, returns `None`.
     fn default(&self) -> Option<&MjsDefault> {
-        // mjs_getDefault looks the classname up in mjCModel::def_map and returns null on a miss;
-        // an element added without a default class keeps the empty classname it starts with.
         let ptr = unsafe { mjs_getDefault(self.element_pointer()) };
         // SAFETY: a non-null return points to the mjsDefault owned by a live mjCDef of the spec.
         unsafe { crate::wrappers::mj_editing::MjsDefault::from_ffi_ptr(ptr) }
     }
 
-    /// Returns the numeric id for this element, if assigned.
-    ///
-    /// MuJoCo returns `-1` when no id exists (for example before compilation);
-    /// in that case this returns `None`.
+    /// Returns the numeric id for this element, or `None` when it has none yet (before
+    /// compilation, for example).
     fn id(&self) -> Option<usize> {
         let id = unsafe { mjs_getId(self.element_pointer()) };
         usize::try_from(id).ok()
@@ -115,73 +103,12 @@ pub trait SpecItem: Sized + sealed::Sealed {
         Ok(self)
     }
 
-    /// Delete the item.
-    ///
-    /// # Deprecated
-    /// This API is deprecated and will be removed in a future release.
-    /// Use [`MjSpec::delete_element`](super::MjSpec::delete_element) instead.
-    ///
-    /// This method is inherently unsound: deleting one element mutates owner/ancestor graph
-    /// structures outside the borrowed `&mut self` region, so aliasing assumptions of existing
-    /// Rust references can already be violated by the call itself.
-    ///
-    /// In other words, calling this method is **undefined behavior** and should be avoided.
-    /// Use [`MjSpec::delete_element`](super::MjSpec::delete_element) for deletion.
-    ///
-    /// # Errors
-    /// - [`MjEditError::DeleteFailed`] if MuJoCo cannot delete the element.
-    /// - [`MjEditError::UnsupportedOperation`] if the element cannot be deleted
-    ///   (e.g. the world body or default classes).
-    ///
-    /// # Safety
-    /// This legacy method is not soundly callable; it exists only for backward compatibility.
-    #[deprecated(
-        since = "5.0.0",
-        note = "unsound legacy API; use MjSpec::delete_element(element_mut_pointer())"
-    )]
-    unsafe fn delete(&mut self) -> Result<(), MjEditError> {
-        unsafe { self.__delete_default__() }
-    }
-
-    /// Default implementation of the delete method.
-    /// Override [`SpecItem::delete`] for custom deletion logic.
-    ///
-    /// # Errors
-    /// Returns [`MjEditError::DeleteFailed`] if MuJoCo's internal deletion fails.
-    ///
-    /// # Safety
-    /// Same contract as [`SpecItem::delete`]: must be called at most once per item; any use
-    /// of `self` after a successful call is **use-after-free** undefined behavior. The item must
-    /// not be a [`MjsDefault`].
-    unsafe fn __delete_default__(&mut self) -> Result<(), MjEditError> {
-        // SAFETY: element_mut_pointer() is valid (struct invariant); mjs_getSpec
-        // returns the owning spec, also valid.
-        let element = self.element_mut_pointer();
-        let spec = unsafe { mjs_getSpec(element) };
-        let result = unsafe { mjs_delete(spec, element) };
-        match result {
-            0 => Ok(()),
-            _ => {
-                let error_msg: String = unsafe {
-                    let ptr = mjs_getError(spec);
-                    if ptr.is_null() {
-                        "Unknown error".to_owned()
-                    } else {
-                        CStr::from_ptr(ptr).to_string_lossy().into_owned()
-                    }
-                };
-                Err(MjEditError::DeleteFailed(error_msg))
-            }
-        }
-    }
 }
 
-/// Represents a [`SpecItem`] that is a concrete object inside [`crate::wrappers::mj_model::MjModel`]
-/// after compilation of [`super::MjSpec`]. This includes all the [`SpecItem`]-s except
-/// [`MjsDefault`] and [`MjsWrap`](super::MjsWrap).
-/// 
-/// This trait is used internally by MuJoCo-rs to provide a generic casting interface from
-/// *mut mjsElement during iteration. 
+/// A [`SpecItem`] that becomes a concrete object inside
+/// [`crate::wrappers::mj_model::MjModel`] once [`super::MjSpec`] compiles. That is every
+/// [`SpecItem`] except [`MjsDefault`] and [`MjsWrap`](super::MjsWrap). Only such an object carries
+/// [`SpecObject::delete`].
 pub trait SpecObject: SpecItem {
     /// The `mjtObj` discriminant passed to `mjs_firstElement` / `mjs_firstChild`.
     const OBJ_TYPE: mjtObj;
@@ -191,4 +118,43 @@ pub trait SpecObject: SpecItem {
     /// # Safety
     /// `ptr` must point to a valid element of type `Self`.
     unsafe fn from_element_as_ptr_mut(ptr: *mut mjsElement) -> *mut Self;
+
+    /// Delete the element from the specification that holds it.
+    ///
+    /// Deleting a body deletes its subtree, and frees every keyframe, and every actuator, sensor,
+    /// tendon, equality, pair and exclude that refers to the subtree.
+    ///
+    /// # Errors
+    /// - [`MjEditError::UnsupportedOperation`] if the element is a frame or the world body.
+    /// - [`MjEditError::DeleteFailed`] if MuJoCo refuses the deletion, which it does while another
+    ///   specification holds this one.
+    ///
+    /// # Safety
+    /// - Delete each element at most once. MuJoCo keeps the element allocated until the
+    ///   specification drops, so a second deletion frees it twice.
+    /// - Do not delete an element that the deletion of a body already took out of the
+    ///   specification. An iterator collected before that deletion still hands out its handle.
+    /// - Do not use the handle of an element that the deletion of a body freed.
+    ///
+    /// # Examples
+    /// ```
+    /// # use mujoco_rs::prelude::*;
+    /// let mut spec = MjSpec::new();
+    /// spec.world_body_mut().add_body().with_name("ball");
+    ///
+    /// // SAFETY: the body is deleted once, and no handle of the spec outlives the call.
+    /// unsafe { spec.body_mut("ball").unwrap().delete() }.unwrap();
+    /// ```
+    ///
+    /// A default class is no `SpecObject`, so it carries no `delete`.
+    /// ```compile_fail
+    /// # use mujoco_rs::prelude::*;
+    /// let mut spec = MjSpec::new();
+    /// unsafe { spec.add_default("cls", None).delete() }.unwrap();
+    /// ```
+    unsafe fn delete(&mut self) -> Result<(), MjEditError> {
+        // SAFETY: the handle stands at a live element, which the caller keeps out of a second
+        // deletion.
+        unsafe { delete_element(self.element_mut_pointer()) }
+    }
 }

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -70,12 +70,11 @@ pub trait SpecItem: Sized + sealed::Sealed {
     /// camera, light, actuator, pair, equality, tendon, mesh and material. Every other element,
     /// a frame included, returns `None`.
     fn default(&self) -> Option<&MjsDefault> {
-        // mjs_getDefault looks the element's classname up in mjCModel::def_map and returns null on
-        // a miss. An element added without a default class keeps the empty classname it starts
-        // with.
+        // mjs_getDefault looks the classname up in mjCModel::def_map and returns null on a miss;
+        // an element added without a default class keeps the empty classname it starts with.
         let ptr = unsafe { mjs_getDefault(self.element_pointer()) };
         // SAFETY: a non-null return points to the mjsDefault owned by a live mjCDef of the spec.
-        (!ptr.is_null()).then(|| unsafe { &*ptr })
+        unsafe { crate::wrappers::mj_editing::MjsDefault::from_ffi_ptr(ptr) }
     }
 
     /// Returns the numeric id for this element, if assigned.
@@ -153,8 +152,7 @@ pub trait SpecItem: Sized + sealed::Sealed {
     /// # Safety
     /// Same contract as [`SpecItem::delete`]: must be called at most once per item; any use
     /// of `self` after a successful call is **use-after-free** undefined behavior. The item must
-    /// not be a [`MjsDefault`]: `mjs_getSpec` casts to `mjCBase`, which `mjCDef` does not derive
-    /// from, so it would read the spec pointer at an unrelated offset.
+    /// not be a [`MjsDefault`].
     unsafe fn __delete_default__(&mut self) -> Result<(), MjEditError> {
         // SAFETY: element_mut_pointer() is valid (struct invariant); mjs_getSpec
         // returns the owning spec, also valid.

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -107,7 +107,7 @@ pub trait SpecItem: Sized + sealed::Sealed {
 
     /// Builder style make the item inherit from a default class.
     /// # Errors
-    /// Returns [`MjEditError::NotFound`] when the default with the `class_name` doesn't exist.
+    /// Same as [`SpecItem::set_default`].
     /// # Panics
     /// When the `class_name` contains '\0' characters, a panic occurs.
     fn with_default(&mut self, class_name: &str) -> Result<&mut Self, MjEditError> {

--- a/src/wrappers/mj_editing/utility.rs
+++ b/src/wrappers/mj_editing/utility.rs
@@ -205,7 +205,7 @@ macro_rules! add_x_method {
                 let ptr = unsafe { [<mjs_add $name:camel>](self.ffi_mut(), ptr::null()) };
                 // SAFETY: ptr.as_mut() returns None for null, handled by ok_or; when non-null
                 // the pointee is properly aligned and initialized by C++ operator new.
-                unsafe { ptr.as_mut() }.ok_or(MjEditError::AllocationFailed)
+                unsafe { [<Mjs $name:camel>]::from_ffi_ptr_mut(ptr) }.ok_or(MjEditError::AllocationFailed)
             }
         )*
     }};
@@ -267,9 +267,9 @@ macro_rules! add_x_method_by_frame {
                     if ptr.is_null() {
                         return Err(MjEditError::AllocationFailed);
                     }
-                    let set_result = mjs_setFrame((*ptr).element, self);
+                    let set_result = mjs_setFrame((*ptr).element, self.ffi_mut());
                     debug_assert_eq!(set_result, 0, "mjs_setFrame failed; element or frame is invalid");
-                    Ok(&mut *ptr)
+                    Ok([<Mjs $name:camel>]::from_ffi_ptr_mut(ptr).unwrap())
                 }
             }
         )*
@@ -314,7 +314,7 @@ macro_rules! add_x_method_no_default {
             )]
             pub fn [<try_add_ $name>](&mut self) -> Result<&mut [<Mjs $name:camel>], MjEditError> {
                 let ptr = unsafe { [<mjs_add $name:camel>](self.0.as_ptr()) };
-                unsafe { ptr.as_mut() }.ok_or(MjEditError::AllocationFailed)
+                unsafe { [<Mjs $name:camel>]::from_ffi_ptr_mut(ptr) }.ok_or(MjEditError::AllocationFailed)
             }
         )*
     }};
@@ -338,7 +338,7 @@ macro_rules! find_x_method {
                         None
                     }
                     else {
-                        [<mjs_as $item:camel>](ptr).as_ref()
+                        [<Mjs $item:camel>]::from_ffi_ptr([<mjs_as $item:camel>](ptr))
                     }
                 }
             }
@@ -356,7 +356,7 @@ macro_rules! find_x_method {
                         None
                     }
                     else {
-                        [<mjs_as $item:camel>](ptr).as_mut()
+                        [<Mjs $item:camel>]::from_ffi_ptr_mut([<mjs_as $item:camel>](ptr))
                     }
                 }
             }
@@ -381,7 +381,7 @@ macro_rules! find_x_method_direct {
                         None
                     }
                     else {
-                        ptr.as_ref()
+                        [<Mjs $item:camel>]::from_ffi_ptr(ptr)
                     }
                 }
             }
@@ -399,11 +399,91 @@ macro_rules! find_x_method_direct {
                         None
                     }
                     else {
-                        ptr.as_mut()
+                        [<Mjs $item:camel>]::from_ffi_ptr_mut(ptr)
                     }
                 }
             }
         )*
+    }};
+}
+
+
+/// Declares an opaque zero-sized element handle that stands at the address of `$raw`.
+///
+/// The handle must stay zero-sized, because [`std::mem::swap`] copies `size_of::<T>()` bytes and
+/// exchanging two elements would leave each specification holding pointers that the other owns.
+/// Do not give the handle a field of type `$raw`, and do not add [`DerefMut`](std::ops::DerefMut).
+macro_rules! mjs_opaque {
+    ($handle:ident, $raw:ident, $doc:expr) => {
+        #[doc = $doc]
+        #[repr(C)]
+        pub struct $handle {
+            // A private field with no constructor keeps the handle non-instantiable downstream.
+            _data: (),
+            // Removes the automatic `Send`, `Sync` and `Unpin`; the element belongs to its spec.
+            _marker: std::marker::PhantomData<(*mut u8, std::marker::PhantomPinned)>,
+        }
+
+        impl $handle {
+            /// Returns the FFI struct that the handle stands on.
+            pub fn ffi(&self) -> &$raw {
+                // SAFETY: the handle stands at the address of a live, aligned `$raw`, and the cast
+                // keeps the provenance of the pointer that built the handle.
+                unsafe { &*(self as *const Self).cast::<$raw>() }
+            }
+
+            /// Returns the FFI struct that the handle stands on, mutably.
+            ///
+            /// # Safety
+            /// The caller must not exchange the contents of the struct with another element's.
+            pub unsafe fn ffi_mut(&mut self) -> &mut $raw {
+                // SAFETY: a unique borrow of the handle is a unique borrow of the struct.
+                unsafe { &mut *(self as *mut Self).cast::<$raw>() }
+            }
+
+            /// Borrows the element that `ptr` addresses, or [`None`] when `ptr` is null.
+            ///
+            /// # Safety
+            /// `ptr` must address a valid element that stays alive and unmoved for `'a`.
+            pub(crate) unsafe fn from_ffi_ptr<'a>(ptr: *const $raw) -> Option<&'a Self> {
+                // SAFETY: the cast keeps the address, and the handle reads no bytes of its own.
+                unsafe { ptr.cast::<Self>().as_ref() }
+            }
+
+            /// Borrows the element mutably, or [`None`] when `ptr` is null.
+            ///
+            /// # Safety
+            /// `ptr` must address a valid element that stays alive and unmoved for `'a`, and no
+            /// other handle for that element may be live.
+            pub(crate) unsafe fn from_ffi_ptr_mut<'a>(ptr: *mut $raw) -> Option<&'a mut Self> {
+                unsafe { ptr.cast::<Self>().as_mut() }
+            }
+        }
+
+        impl std::fmt::Debug for $handle {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Debug::fmt(self.ffi(), f)
+            }
+        }
+    };
+}
+
+/// Generates the accessor pair for an element handle that the FFI struct embeds by value.
+///
+/// `$name` must be a field of the type that `ffi()` returns.
+macro_rules! nested_handle {
+    ($name:ident: $handle:ty; $doc:expr) => {paste::paste!{
+        #[doc = concat!("Returns an immutable reference to ", $doc)]
+        pub fn $name(&self) -> &$handle {
+            // SAFETY: the owner keeps the field alive and unmoved for as long as it is borrowed.
+            unsafe { <$handle>::from_ffi_ptr(&raw const self.ffi().$name) }.unwrap()
+        }
+
+        #[doc = concat!("Returns a mutable reference to ", $doc)]
+        pub fn [<$name _mut>](&mut self) -> &mut $handle {
+            // SAFETY: as above, and a unique borrow of the owner is a unique borrow of the field.
+            unsafe { <$handle>::from_ffi_ptr_mut(&raw mut self.ffi_mut().$name) }.unwrap()
+        }
     }};
 }
 
@@ -415,8 +495,9 @@ macro_rules! find_x_method_direct {
 /// When `[SpecObject]` is given to the right of `ffi_name`, the SpecObject trait also gets implemented.
 macro_rules! mjs_struct {
     ($ffi_name:ident $([$SpecObject:ident])? $({ $($extra_trait_methods:tt)* })?) => {paste::paste!{
-        #[doc = concat!(stringify!($ffi_name), " specification. This is an alias to the FFI type [`", stringify!([<mjs $ffi_name>]), "`].")]
-        pub type [<Mjs $ffi_name>] = [<mjs $ffi_name>];
+        mjs_opaque!([<Mjs $ffi_name>], [<mjs $ffi_name>], concat!(
+            stringify!($ffi_name), " specification. An opaque handle for the FFI type [`",
+            stringify!([<mjs $ffi_name>]), "`], reached through [`ffi`](Self::ffi)."));
 
         impl [<Mjs $ffi_name>] {
             /// Return the message appended to compiler errors.
@@ -424,7 +505,7 @@ macro_rules! mjs_struct {
             /// Panics if it contains invalid UTF-8.
             pub fn info(&self) -> &str {
                 // SAFETY: self.info is a valid mjString pointer for the lifetime of self.
-                unsafe { read_mjs_string(self.info) }
+                unsafe { read_mjs_string(self.ffi().info) }
             }
 
             /// Set the message appended to compiler errors.
@@ -432,7 +513,7 @@ macro_rules! mjs_struct {
             /// When the `info` contains '\0' characters, a panic occurs.
             pub fn set_info(&mut self, info: &str) {
                 // SAFETY: self.info is a valid mjString pointer for the lifetime of self.
-                unsafe { write_mjs_string(info, self.info) };
+                unsafe { write_mjs_string(info, self.ffi().info) };
             }
         }
 
@@ -440,7 +521,7 @@ macro_rules! mjs_struct {
 
         impl SpecItem for [<Mjs $ffi_name>] {
             fn element_pointer(&self) -> *const mjsElement {
-                self.element
+                self.ffi().element
             }
 
             $($(
@@ -453,9 +534,8 @@ macro_rules! mjs_struct {
             impl $SpecObject for [<Mjs $ffi_name>] {
                 const OBJ_TYPE: MjtObj = MjtObj::[<mjOBJ_ $ffi_name:upper>];
                 unsafe fn from_element_as_ptr_mut(element: *mut mjsElement) -> *mut Self {
-                    // SAFETY: *const conversion to *mut is valid, because mjs_as returns mut originally,
-                    // thus the data itself is *mut.
-                    unsafe { [<mjs_as $ffi_name:camel>](element) }
+                    // SAFETY: the handle stands at the address of the struct that mjs_as returns.
+                    unsafe { [<mjs_as $ffi_name:camel>](element) }.cast::<Self>()
                 }
             }
         )?
@@ -479,19 +559,19 @@ macro_rules! userdata_method {
         /// Return an immutable slice to userdata.
         pub fn userdata(&self) -> &[$type] {
             // SAFETY: self.userdata is a valid mjDoubleVec pointer for the lifetime of self.
-            unsafe { [<read_mjs_vec_ $type>](self.userdata) }
+            unsafe { [<read_mjs_vec_ $type>](self.ffi().userdata) }
         }
         
         /// Set `userdata`.
         pub fn set_userdata<T: AsRef<[$type]>>(&mut self, value: T) {
             // SAFETY: self.userdata is a valid pointer for the lifetime of self.
-            unsafe { [<write_mjs_vec_ $type>](value.as_ref(), self.userdata) };
+            unsafe { [<write_mjs_vec_ $type>](value.as_ref(), self.ffi().userdata) };
         }
 
         /// Builder method for setting `userdata`.
         pub fn with_userdata<T: AsRef<[$type]>>(&mut self, value: T) -> &mut Self {
             // SAFETY: self.userdata is a valid pointer for the lifetime of self.
-            unsafe { [<write_mjs_vec_ $type>](value.as_ref(), self.userdata) };
+            unsafe { [<write_mjs_vec_ $type>](value.as_ref(), self.ffi().userdata) };
             self
         }
     }};
@@ -509,7 +589,7 @@ macro_rules! vec_string_set_append {
             )]
             pub fn [<set_ $name>](&mut self, value: &str) {
                 // SAFETY: self.$name is a valid mjStringVec pointer for the lifetime of self.
-                unsafe { write_mjs_vec_string(value, self.$name) };
+                unsafe { write_mjs_vec_string(value, self.ffi().$name) };
             }
 
             #[doc = concat!(
@@ -520,7 +600,7 @@ macro_rules! vec_string_set_append {
             )]
             pub fn [<append_ $name>](&mut self, value: &str) {
                 // SAFETY: self.$name is a valid mjStringVec pointer for the lifetime of self.
-                unsafe { append_mjs_vec_string(value, self.$name) };
+                unsafe { append_mjs_vec_string(value, self.ffi().$name) };
             }
         )*
     }};
@@ -544,7 +624,7 @@ macro_rules! vec_string_set_append {
         pub fn [<set_ $singular>](&mut self, role: $role_ty, name: &str) {
             let c_name = CString::new(name).unwrap();
             // SAFETY: self.$name is a valid mjStringVec pre-sized to one entry per role.
-            unsafe { mjs_setInStringVec(self.$name, role as std::ffi::c_int, c_name.as_ptr()) };
+            unsafe { mjs_setInStringVec(self.ffi().$name, role as std::ffi::c_int, c_name.as_ptr()) };
         }
 
         #[doc = concat!(
@@ -577,7 +657,7 @@ macro_rules! vec_string_set_append {
         )]
         pub fn [<set_ $name>](&mut self, value: &str) {
             // SAFETY: self.$name is a valid mjStringVec pointer for the lifetime of self.
-            unsafe { write_mjs_vec_string(value, self.$name) };
+            unsafe { write_mjs_vec_string(value, self.ffi().$name) };
         }
 
         #[doc = concat!(
@@ -594,14 +674,14 @@ macro_rules! vec_string_set_append {
         )]
         pub fn [<append_ $name>](&mut self, value: &str) {
             // SAFETY: self.$name is a valid mjStringVec pointer for the lifetime of self.
-            unsafe { append_mjs_vec_string(value, self.$name) };
+            unsafe { append_mjs_vec_string(value, self.ffi().$name) };
         }
     }};
 }
 
 /// Implements string methods for given attribute $name.
 macro_rules! string_set_get_with {
-    (@impl common $([$ffi:ident, $ffi_mut:ident])? $name:ident; $comment:expr;) => {paste::paste!{
+    (@impl common $name:ident; $comment:expr;) => {paste::paste!{
         #[doc = concat!(
             "Return ", $comment,
             "\n",
@@ -610,7 +690,7 @@ macro_rules! string_set_get_with {
         )]
         pub fn $name(&self) -> &str {
                 // SAFETY: the mjString field is valid for the lifetime of self.
-                unsafe { read_mjs_string(self$(.$ffi())?.$name) }
+                unsafe { read_mjs_string(self.ffi().$name) }
         }
 
         #[allow(unused_unsafe)]
@@ -622,13 +702,13 @@ macro_rules! string_set_get_with {
         )]
         pub fn [<set_ $name>](&mut self, value: &str) {
             // SAFETY: the mjString field is valid for the lifetime of self.
-            unsafe { write_mjs_string(value, unsafe { self$(.$ffi_mut())?.$name }) };
+            unsafe { write_mjs_string(value, unsafe { self.ffi_mut() }.$name) };
         }
     }};
 
-    ( $($([$ffi:ident, $ffi_mut:ident])? $name:ident; $comment:expr;)* ) => {paste::paste!{
+    ( $($name:ident; $comment:expr;)* ) => {paste::paste!{
         $(
-            string_set_get_with!(@impl common $([$ffi, $ffi_mut])? $name; $comment;);
+            string_set_get_with!(@impl common $name; $comment;);
             #[allow(unused_unsafe)]
             #[doc = concat!(
                 "Builder method for setting ", $comment,
@@ -638,15 +718,15 @@ macro_rules! string_set_get_with {
             )]
             pub fn [<with_ $name>](mut self, value: &str) -> Self {
                 // SAFETY: the mjString field is valid for the lifetime of self.
-                unsafe { write_mjs_string(value, unsafe { self$(.$ffi_mut())?.$name }) };
+                unsafe { write_mjs_string(value, unsafe { self.ffi_mut() }.$name) };
                 self
             }
         )*
     }};
 
-    ([&] $($([$ffi:ident, $ffi_mut:ident])? $name:ident; $comment:expr;)* ) => {paste::paste!{
+    ([&] $($name:ident; $comment:expr;)* ) => {paste::paste!{
         $(
-            string_set_get_with!(@impl common $([$ffi, $ffi_mut])? $name; $comment;);
+            string_set_get_with!(@impl common $name; $comment;);
             #[allow(unused_unsafe)]
             #[doc = concat!(
                 "Builder method for setting ", $comment,
@@ -656,7 +736,7 @@ macro_rules! string_set_get_with {
             )]
             pub fn [<with_ $name>](&mut self, value: &str) -> &mut Self {
                 // SAFETY: the mjString field is valid for the lifetime of self.
-                unsafe { write_mjs_string(value, unsafe { self$(.$ffi_mut())?.$name }) };
+                unsafe { write_mjs_string(value, unsafe { self.ffi_mut() }.$name) };
                 self
             }
         )*
@@ -670,7 +750,7 @@ macro_rules! vec_set_get {
             #[doc = concat!("Return ", $comment)]
             pub fn $name(&self) -> &[$type] {
                 // SAFETY: self.$name is a valid mjDoubleVec/mjFloatVec pointer for the lifetime of self.
-                unsafe { [<read_mjs_vec_ $type>](self.$name) }
+                unsafe { [<read_mjs_vec_ $type>](self.ffi().$name) }
             }
         )*
 
@@ -697,15 +777,14 @@ macro_rules! vec_set_get {
 ///   own validation (e.g. as an unchecked array index, count, or `memcpy` length) and which
 ///   cannot be cheaply validated here. The optional leading `[unsafe: "safety"]` marker flips the
 ///   generated setter to `unsafe fn` and emits `"safety"` as its caller-facing `# Safety`
-///   obligation. The brackets keep the `unsafe` keyword unambiguous with the field's own `name`
-///   ident, and the keyword is captured (`$unsafe_kw:ident`) and echoed verbatim onto the `fn`.
+///   obligation.
 macro_rules! vec_set {
     ($($name:ident: $type:ty; $comment:expr);* $(;)?) => {paste::paste!{
         $(
             #[doc = concat!("Set ", $comment)]
             pub fn [<set_ $name>](&mut self, value: &[$type]) {
                 // SAFETY: self.$name is a valid pointer for the lifetime of self.
-                unsafe { [<write_mjs_vec_ $type>](value, self.$name) };
+                unsafe { [<write_mjs_vec_ $type>](value, self.ffi().$name) };
             }
         )*
     }};
@@ -737,7 +816,7 @@ macro_rules! vec_set {
                 // by the `$check` loop above when present, or by the caller's `# Safety` contract
                 // otherwise. self.$name is a valid pointer for the lifetime of self.
                 let raw = unsafe { std::slice::from_raw_parts(value.as_ptr().cast(), value.len()) };
-                unsafe { [<write_mjs_vec_ $type>](raw, self.$name) };
+                unsafe { [<write_mjs_vec_ $type>](raw, self.ffi().$name) };
                 $(Ok::<(), $err>(()))?
             }
         )*
@@ -751,7 +830,7 @@ macro_rules! vec_vec_append {
             #[doc = concat!("Append to ", $comment)]
             pub fn [<append_ $name>](&mut self, value: &[$type]) {
                 // SAFETY: self.$name is a valid pointer for the lifetime of self.
-                unsafe { [<append_mjs_vec_vec_ $type>](value, self.$name) };
+                unsafe { [<append_mjs_vec_vec_ $type>](value, self.ffi().$name) };
             }
 
             #[doc = concat!("Set ", $comment, " (deprecated; use ", stringify!([<append_ $name>]), " instead).")]

--- a/src/wrappers/mj_editing/utility.rs
+++ b/src/wrappers/mj_editing/utility.rs
@@ -215,7 +215,7 @@ macro_rules! add_x_method {
             #[doc = concat!(
                 "Add and return a child [`", stringify!([<Mjs $name:camel>]), "`].\n\n",
                 "# Note\n",
-                "MuJoCo ends the process when the allocation fails, so this never fails."
+                "MuJoCo ends the process when the allocation fails."
             )]
             #[expect(deprecated, reason = "try_add_* keeps the implementation until it is removed")]
             pub fn [<add_ $name>](&mut self) -> &mut [<Mjs $name:camel>] {
@@ -256,7 +256,7 @@ macro_rules! add_x_method_by_frame {
             #[doc = concat!(
                 "Add and return a child [`", stringify!([<Mjs $name:camel>]), "`].\n\n",
                 "# Note\n",
-                "MuJoCo ends the process when the allocation fails, so this never fails."
+                "MuJoCo ends the process when the allocation fails."
             )]
             #[expect(deprecated, reason = "try_add_* keeps the implementation until it is removed")]
             pub fn [<add_ $name>](&mut self) -> &mut [<Mjs $name:camel>] {
@@ -307,7 +307,7 @@ macro_rules! add_x_method_no_default {
             #[doc = concat!(
                 "Add and return a child [`", stringify!([<Mjs $name:camel>]), "`].\n\n",
                 "# Note\n",
-                "MuJoCo ends the process when the allocation fails, so this never fails."
+                "MuJoCo ends the process when the allocation fails."
             )]
             #[expect(deprecated, reason = "try_add_* keeps the implementation until it is removed")]
             pub fn [<add_ $name>](&mut self) -> &mut [<Mjs $name:camel>] {

--- a/src/wrappers/mj_editing/utility.rs
+++ b/src/wrappers/mj_editing/utility.rs
@@ -2,6 +2,7 @@
 use std::ffi::{CStr, CString};
 
 use crate::util::checked_c_len;
+use crate::error::MjEditError;
 use crate::mujoco_c::*;
 
 
@@ -10,12 +11,9 @@ use crate::mujoco_c::*;
 ***************************/
 /// Reads MJS string (C++) as a `&str`.
 ///
-/// The returned `&str` borrows from the `mjString` object pointed to by `string`.
-/// It remains valid as long as that object is alive and the string is not mutated
-/// (which would reallocate the internal C++ `std::string` buffer).
-///
 /// # Safety
-/// `string` must point to a valid `mjString` object for the duration `'a`.
+/// `string` must point to a valid `mjString` object for the duration `'a`, and the string must
+/// not be written during `'a`, because a write reallocates the C++ buffer.
 ///
 /// # Panics
 /// Panics if the string contains invalid UTF-8.
@@ -24,8 +22,7 @@ pub(crate) unsafe fn read_mjs_string<'a>(string: *const mjString) -> &'a str {
     if ptr.is_null() {
         ""
     } else {
-        // SAFETY: `ptr` points into the internal buffer of the C++ std::string
-        // referenced by `string`, which is valid for lifetime 'a.
+        // SAFETY: `ptr` points into the buffer of the C++ std::string, valid for `'a`.
         unsafe { CStr::from_ptr(ptr) }.to_str().unwrap()
     }
 }
@@ -161,6 +158,51 @@ pub(crate) unsafe fn write_mjs_vec_byte<T: bytemuck::NoUninit>(source: &[T], des
     }
 }
 
+/// Deletes `element` from the specification that holds it, with the checks MuJoCo omits.
+///
+/// # Errors
+/// Returns [`MjEditError::UnsupportedOperation`] for a default class, a frame, a tendon wrap and
+/// the world body, and [`MjEditError::DeleteFailed`] when MuJoCo refuses the deletion.
+///
+/// # Safety
+/// Same contract as [`SpecObject::delete`](super::traits::SpecObject::delete), and `element` must
+/// point to an element of a specification.
+pub(crate) unsafe fn delete_element(element: *mut mjsElement) -> Result<(), MjEditError> {
+    let elemtype = unsafe { (*element).elemtype };
+
+    // mjCDef is not an mjCBase, so this precedes mjs_getSpec. A frame's type is 100, past the
+    // mjNOBJECT end of the element list MuJoCo indexes with it, and a wrap's slot in it is null.
+    if matches!(
+        elemtype,
+        mjtObj::mjOBJ_DEFAULT | mjtObj::mjOBJ_FRAME | mjtObj::mjOBJ_UNKNOWN
+    ) {
+        return Err(MjEditError::UnsupportedOperation);
+    }
+
+    let spec = unsafe { mjs_getSpec(element) };
+
+    // Prevent deletion of the world-bodies.
+    if elemtype == mjtObj::mjOBJ_BODY && element == unsafe { mjs_firstElement(spec, elemtype) } {
+        return Err(MjEditError::UnsupportedOperation);
+    }
+
+    match unsafe { mjs_delete(spec, element) } {
+        0 => Ok(()),
+        _ => {
+            // SAFETY: the message belongs to the spec and lives until the next call on it.
+            let error_msg = unsafe {
+                let ptr = mjs_getError(spec);
+                if ptr.is_null() {
+                    "Unknown error".to_owned()
+                } else {
+                    CStr::from_ptr(ptr).to_string_lossy().into_owned()
+                }
+            };
+            Err(MjEditError::DeleteFailed(error_msg))
+        }
+    }
+}
+
 
 /***************************
 ** Helper macros
@@ -185,26 +227,21 @@ macro_rules! add_x_method {
                 "Fallible version of [`Self::add_", stringify!($name), "`].\n\n",
                 "# Note\n\n",
                 "<div class=\"warning\">\n\n",
-                "MuJoCo cannot report a failure here: `mjs_add", stringify!([<$name:camel>]),
-                "` allocates the element with C++ `new`, which throws instead of returning null, ",
-                "and then returns the address of the element it just added, so this method never ",
-                "returns `Err`. An allocation failure ends the process: the exception cannot ",
-                "cross the C API. Prefer the panicking [`Self::add_", stringify!($name), "`]. ",
-                "This method may be undeprecated in the future if MuJoCo's upstream C++ code is ",
-                "changed to report the failure recoverably.\n\n",
+                "`mjs_add", stringify!([<$name:camel>]), "` allocates with C++ `new`, which ends ",
+                "the process instead of returning null, so this never returns `Err`. Prefer ",
+                "[`Self::add_", stringify!($name), "`].\n\n",
                 "</div>\n\n",
                 "# Errors\n",
-                "Returns [`MjEditError::AllocationFailed`] when MuJoCo fails to allocate ",
-                "the element, instead of panicking."
+                "Returns [`MjEditError::AllocationFailed`] when MuJoCo fails to allocate the element."
             )]
             #[deprecated(
                 since = "6.0.0",
                 note = "always returns Ok; use the panicking variant"
             )]
             pub fn [<try_add_ $name>](&mut self) -> Result<&mut [<Mjs $name:camel>], MjEditError> {
+                // SAFETY: the element is freshly allocated by C++ operator new, so it is aligned,
+                // initialized and unaliased. A null pointer becomes `None`.
                 let ptr = unsafe { [<mjs_add $name:camel>](self.ffi_mut(), ptr::null()) };
-                // SAFETY: ptr.as_mut() returns None for null, handled by ok_or; when non-null
-                // the pointee is properly aligned and initialized by C++ operator new.
                 unsafe { [<Mjs $name:camel>]::from_ffi_ptr_mut(ptr) }.ok_or(MjEditError::AllocationFailed)
             }
         )*
@@ -231,13 +268,9 @@ macro_rules! add_x_method_by_frame {
                 "Fallible version of [`Self::add_", stringify!($name), "`].\n\n",
                 "# Note\n\n",
                 "<div class=\"warning\">\n\n",
-                "MuJoCo cannot report a failure here: `mjs_add", stringify!([<$name:camel>]),
-                "` allocates the element with C++ `new`, which throws instead of returning null, ",
-                "and then returns the address of the element it just added, so this method never ",
-                "returns `Err`. An allocation failure ends the process: the exception cannot ",
-                "cross the C API. Prefer the panicking [`Self::add_", stringify!($name), "`]. ",
-                "This method may be undeprecated in the future if MuJoCo's upstream C++ code is ",
-                "changed to report the failure recoverably.\n\n",
+                "`mjs_add", stringify!([<$name:camel>]), "` allocates with C++ `new`, which ends ",
+                "the process instead of returning null, so this never returns `Err`. Prefer ",
+                "[`Self::add_", stringify!($name), "`].\n\n",
                 "</div>\n\n",
                 "# Errors\n",
                 "Returns [`MjEditError::AllocationFailed`] when MuJoCo fails to allocate the element."
@@ -247,18 +280,8 @@ macro_rules! add_x_method_by_frame {
                 note = "always returns Ok; use the panicking variant"
             )]
             pub fn [<try_add_ $name>](&mut self) -> Result<&mut [<Mjs $name:camel>], MjEditError> {
-                // SAFETY:
-                // - element_mut_pointer() reads `self.element`, a field always valid after construction.
-                // - body_ptr is non-null for any MjsFrame reachable through the Rust API because
-                //   mjs_addFrame always calls SetParent(body).
-                // - The is_null() guard is defensive; mjs_addXxx functions do not perform
-                //   null-check error handling internally, so under current MuJoCo the
-                //   pointer is always non-null.
-                // - mjs_setFrame: both dest and frame are non-null and valid; failure for a
-                //   freshly-created element is treated as a bug via debug_assert.
-                // - `&mut *ptr`: ptr is confirmed non-null by the guard above, properly aligned
-                //   and initialized by C++ operator new, and freshly allocated so no Rust
-                //   reference can alias it for the returned lifetime.
+                // SAFETY: mjs_addFrame always calls SetParent(body), so the parent is non-null,
+                // and the element that mjs_addXxx returns is fresh, so nothing aliases it.
                 unsafe {
                     let ep = self.element_mut_pointer();
                     let body_ptr = mjs_getParent(ep);
@@ -296,24 +319,19 @@ macro_rules! add_x_method_no_default {
                 "Fallible version of [`Self::add_", stringify!($name), "`].\n\n",
                 "# Note\n\n",
                 "<div class=\"warning\">\n\n",
-                "MuJoCo cannot report a failure here: `mjs_add", stringify!([<$name:camel>]),
-                "` allocates the element with C++ `new`, which throws instead of returning null, ",
-                "and then returns the address of the element it just added, so this method never ",
-                "returns `Err`. An allocation failure ends the process: the exception cannot ",
-                "cross the C API. Prefer the panicking [`Self::add_", stringify!($name), "`]. ",
-                "This method may be undeprecated in the future if MuJoCo's upstream C++ code is ",
-                "changed to report the failure recoverably.\n\n",
+                "`mjs_add", stringify!([<$name:camel>]), "` allocates with C++ `new`, which ends ",
+                "the process instead of returning null, so this never returns `Err`. Prefer ",
+                "[`Self::add_", stringify!($name), "`].\n\n",
                 "</div>\n\n",
                 "# Errors\n",
-                "Returns [`MjEditError::AllocationFailed`] when MuJoCo fails to allocate ",
-                "the element, instead of panicking."
+                "Returns [`MjEditError::AllocationFailed`] when MuJoCo fails to allocate the element."
             )]
             #[deprecated(
                 since = "6.0.0",
                 note = "always returns Ok; use the panicking variant"
             )]
             pub fn [<try_add_ $name>](&mut self) -> Result<&mut [<Mjs $name:camel>], MjEditError> {
-                let ptr = unsafe { [<mjs_add $name:camel>](self.0.as_ptr()) };
+                let ptr = unsafe { [<mjs_add $name:camel>](self.ffi.as_ptr()) };
                 unsafe { [<Mjs $name:camel>]::from_ffi_ptr_mut(ptr) }.ok_or(MjEditError::AllocationFailed)
             }
         )*
@@ -333,7 +351,7 @@ macro_rules! find_x_method {
             pub fn $item(&self, name: &str) -> Option<&[<Mjs $item:camel>]> {
                 let c_name = CString::new(name).unwrap();
                 unsafe {
-                    let ptr = mjs_findElement(self.0.as_ptr(), MjtObj::[<mjOBJ_ $item:upper>], c_name.as_ptr());
+                    let ptr = mjs_findElement(self.ffi.as_ptr(), MjtObj::[<mjOBJ_ $item:upper>], c_name.as_ptr());
                     if ptr.is_null() {
                         None
                     }
@@ -351,7 +369,7 @@ macro_rules! find_x_method {
             pub fn [<$item _mut>](&mut self, name: &str) -> Option<&mut [<Mjs $item:camel>]> {
                 let c_name = CString::new(name).unwrap();
                 unsafe {
-                    let ptr = mjs_findElement(self.0.as_ptr(), MjtObj::[<mjOBJ_ $item:upper>], c_name.as_ptr());
+                    let ptr = mjs_findElement(self.ffi.as_ptr(), MjtObj::[<mjOBJ_ $item:upper>], c_name.as_ptr());
                     if ptr.is_null() {
                         None
                     }
@@ -376,7 +394,7 @@ macro_rules! find_x_method_direct {
             pub fn $item(&self, name: &str) -> Option<&[<Mjs $item:camel>]> {
                 let c_name = CString::new(name).unwrap();
                 unsafe {
-                    let ptr = [<mjs_find $item:camel>](self.0.as_ptr(), c_name.as_ptr());
+                    let ptr = [<mjs_find $item:camel>](self.ffi.as_ptr(), c_name.as_ptr());
                     if ptr.is_null() {
                         None
                     }
@@ -394,7 +412,7 @@ macro_rules! find_x_method_direct {
             pub fn [<$item _mut>](&mut self, name: &str) -> Option<&mut [<Mjs $item:camel>]> {
                 let c_name = CString::new(name).unwrap();
                 unsafe {
-                    let ptr = [<mjs_find $item:camel>](self.0.as_ptr(), c_name.as_ptr());
+                    let ptr = [<mjs_find $item:camel>](self.ffi.as_ptr(), c_name.as_ptr());
                     if ptr.is_null() {
                         None
                     }
@@ -607,18 +625,16 @@ macro_rules! vec_string_set_append {
         )*
     }};
 
-    // Indexed variant: the string vector is pre-sized (one entry per enum variant)
-    // and entries must be set by index. Generates `set_<singular>(role, name)` and
-    // `with_<singular>(role, name)` in addition to the bulk `set_<plural>` / `append_<plural>`.
+    // Indexed variant: the vector is pre-sized with one entry per enum variant, so an entry is
+    // set by index rather than appended.
     ($name:ident[$role_ty:ty] => $singular:ident; $comment:expr $(;)?) => {paste::paste!{
         #[doc = concat!(
             "Sets the entry at index `role` in `", stringify!($name), "` to `name`. ",
             $comment,
             "\n\n",
             "# Note\n",
-            "The `", stringify!($name), "` vector is pre-sized by MuJoCo with one slot per ",
-            "[`", stringify!($role_ty), "`] value. An index with no slot makes MuJoCo call ",
-            "`mju_error`, which ends the process under the default log handler.\n",
+            "MuJoCo pre-sizes `", stringify!($name), "` with one slot per [`", stringify!($role_ty),
+            "`] value. An index with no slot ends the process through `mju_error`.\n",
             "\n",
             "# Panics\n",
             "When `name` contains '\\0' characters, a panic occurs."
@@ -763,23 +779,15 @@ macro_rules! vec_set_get {
 /// Implements setters for non-string attributes.
 ///
 /// Three forms are supported:
-/// - `name: Type; "comment"`: a **safe** setter that takes `&[Type]` and writes it unchanged.
-/// - `name: InputType => StoredType { check, "reason" } => ErrType; "comment"`: a **safe** setter
-///   taking `&[InputType]` (typically a Rust enum) that stores each element as the raw C type
-///   `StoredType` via a zero-cost pointer reinterpretation (the same compile-time-checked cast the
-///   view layer uses, so no `bytemuck` trait is required on the enum). Every element is passed
-///   through `check` (a `Fn(InputType) -> Result<(), ErrType>`) before anything is written; if any
-///   element fails, nothing is written. Use this when the validation rules out the out-of-range
-///   values the C side would misuse, which is what makes the setter sound without `unsafe`.
-///   `"reason"` is a doc fragment in the crate's `# Errors` style (e.g.
-///   `"[`MjEditError::InvalidParameter`] when ..."`) reused verbatim in the generated `# Errors`
-///   section. The `{ check, "reason" } => ErrType` part may be omitted for a plain safe cast.
-/// - `[unsafe: "safety"] name: InputType => StoredType; "comment"`: the same cast setter made
-///   **`unsafe`** (the per-element `check` omitted), for vectors the C side later uses without its
-///   own validation (e.g. as an unchecked array index, count, or `memcpy` length) and which
-///   cannot be cheaply validated here. The optional leading `[unsafe: "safety"]` marker flips the
-///   generated setter to `unsafe fn` and emits `"safety"` as its caller-facing `# Safety`
-///   obligation.
+/// - `name: Type; "comment"`: a safe setter that takes `&[Type]` and writes it unchanged.
+/// - `name: InputType => StoredType { check, "reason" } => ErrType; "comment"`: a safe setter
+///   taking `&[InputType]` (an enum) and storing it as the C type `StoredType`. Every element
+///   passes `check`, a `Fn(InputType) -> Result<(), ErrType>`, before anything is written, which
+///   is what makes the cast sound without `unsafe`. `"reason"` is a doc fragment in the crate's
+///   `# Errors` style. Omit the `{ check, "reason" } => ErrType` tail for a plain cast.
+/// - `[unsafe: "safety"] name: InputType => StoredType; "comment"`: the same cast without the
+///   per-element check, for a vector the C side later trusts as an unchecked index, count or
+///   length. `"safety"` becomes the caller's `# Safety` obligation.
 macro_rules! vec_set {
     ($($name:ident: $type:ty; $comment:expr);* $(;)?) => {paste::paste!{
         $(
@@ -793,30 +801,15 @@ macro_rules! vec_set {
 
     ($($([$unsafe_kw:ident : $safety:literal])? $name:ident: $input_type:ty => $type:ty $({$check:expr , $reason:literal} => $err:ty)?; $comment:expr);* $(;)?) => {paste::paste!{
         $(
-            // One cast setter whose shape is driven by the optional check / safety tail:
-            // - `{ check, "reason" } => ErrType` makes it a safe `-> Result<(), ErrType>` that
-            //   validates every element first; passing validation rules out the values the C side
-            //   would misuse, so the reinterpretation is sound without `unsafe`. `"reason"` is a doc
-            //   fragment naming the error and condition, reused verbatim in the `# Errors` section.
-            // - a leading `[unsafe: "safety"]` marker makes it an `unsafe fn` (no per-element
-            //   check) for vectors the C side later trusts as an unchecked index/count/length;
-            //   `"safety"` documents the caller's `# Safety` obligation. The brackets keep the
-            //   marker unambiguous with the field's own `name` ident, and the `unsafe` keyword
-            //   (`$unsafe_kw`) is echoed onto the generated `fn`.
-            // - neither: a plain safe cast.
             #[doc = concat!("Set ", $comment
                 $(, "\n\n# Errors\nReturns ", $reason, " (in that case nothing is written).")?
                 $(, "\n\n# Safety\n", $safety)?
             )]
             pub $($unsafe_kw)? fn [<set_ $name>](&mut self, value: &[$input_type]) $(-> Result<(), $err>)? {
                 $(for &v in value { ($check)(v)?; })?
-                // Compile-time size/alignment check for the layout-compatible reinterpretation below.
                 $crate::util::assert_ptr_cast_valid::<$input_type, $type>(value.as_ptr());
-                // SAFETY: $input_type and $type are layout-compatible (asserted above) and every enum
-                // value is a valid bit pattern for its underlying integer, so reinterpreting the slice
-                // is sound and zero-cost. The value-range precondition the C side relies on is enforced
-                // by the `$check` loop above when present, or by the caller's `# Safety` contract
-                // otherwise. self.$name is a valid pointer for the lifetime of self.
+                // SAFETY: the assert proves the types are layout-compatible, and the `$check` loop
+                // or the caller's `# Safety` contract covers the value range that C relies on.
                 let raw = unsafe { std::slice::from_raw_parts(value.as_ptr().cast(), value.len()) };
                 unsafe { [<write_mjs_vec_ $type>](raw, self.ffi().$name) };
                 $(Ok::<(), $err>(()))?

--- a/src/wrappers/mj_editing/utility.rs
+++ b/src/wrappers/mj_editing/utility.rs
@@ -827,12 +827,6 @@ macro_rules! vec_vec_append {
                 // SAFETY: self.$name is a valid pointer for the lifetime of self.
                 unsafe { [<append_mjs_vec_vec_ $type>](value, self.ffi().$name) };
             }
-
-            #[doc = concat!("Set ", $comment, " (deprecated; use ", stringify!([<append_ $name>]), " instead).")]
-            #[deprecated(note = "use append_ instead of set_ for vector-of-vectors attributes", since = "3.0.0")]
-            pub fn [<set_ $name>](&mut self, value: &[$type]) {
-                self.[<append_ $name>](value);
-            }
         )*
     }};
 }

--- a/src/wrappers/mj_editing/utility.rs
+++ b/src/wrappers/mj_editing/utility.rs
@@ -414,7 +414,7 @@ macro_rules! find_x_method_direct {
 /// exchanging two elements would leave each specification holding pointers that the other owns.
 /// Do not give the handle a field of type `$raw`, and do not add [`DerefMut`](std::ops::DerefMut).
 macro_rules! mjs_opaque {
-    ($handle:ident, $raw:ident, $doc:expr) => {
+    ($handle:ident <= $raw:ident, $doc:expr) => {
         #[doc = $doc]
         #[repr(C)]
         pub struct $handle {
@@ -488,18 +488,42 @@ macro_rules! nested_handle {
 }
 
 
-/// Creates a wrapper around a mjs$ffi_name item. It also implements the methods `info()` and
-/// `set_info()`, and the traits `Sealed` and [`SpecItem`](super::traits::SpecItem).
+/// Creates the wrapper `$handle` around the FFI struct `$raw`. It also implements the methods
+/// `info()` and `set_info()`, and the traits `Sealed` and [`SpecItem`](super::traits::SpecItem).
 /// The handles are deliberately neither [`Send`] nor [`Sync`].
-/// 
-/// When `[SpecObject]` is given to the right of `ffi_name`, the SpecObject trait also gets implemented.
+///
+/// A leading `$kind with SpecObject:` also implements [`SpecObject`](super::traits::SpecObject).
+/// `$kind` is the element kind as MuJoCo camel-cases it (`Texture`, `HField`), which names both the
+/// [`MjtObj`] variant and the `mjs_as*` function. A trailing brace block adds methods to the
+/// `SpecItem` implementation.
 macro_rules! mjs_struct {
-    ($ffi_name:ident $([$SpecObject:ident])? $({ $($extra_trait_methods:tt)* })?) => {paste::paste!{
-        mjs_opaque!([<Mjs $ffi_name>], [<mjs $ffi_name>], concat!(
-            stringify!($ffi_name), " specification. An opaque handle for the FFI type [`",
-            stringify!([<mjs $ffi_name>]), "`], reached through [`ffi`](Self::ffi)."));
+    (
+        $kind:ident with SpecObject: $handle:ident <= $raw:ident
+        $({ $($extra_trait_methods:tt)* })?
+    ) => {paste::paste!{
+        mjs_struct!($handle <= $raw $({ $($extra_trait_methods)* })?);
 
-        impl [<Mjs $ffi_name>] {
+        impl SpecObject for $handle {
+            const OBJ_TYPE: MjtObj = MjtObj::[<mjOBJ_ $kind:upper>];
+            unsafe fn from_element_as_ptr_mut(element: *mut mjsElement) -> *mut Self {
+                // The annotation ties the conversion function to `$raw`, so a call site cannot
+                // pair the handle with another element's kind.
+                let raw: *mut $raw = unsafe { [<mjs_as $kind>](element) };
+                // SAFETY: the handle stands at the address of the struct that mjs_as returns.
+                raw.cast::<Self>()
+            }
+        }
+    }};
+
+    (
+        $handle:ident <= $raw:ident
+        $({ $($extra_trait_methods:tt)* })?
+    ) => {
+        mjs_opaque!($handle <= $raw, concat!(
+            stringify!($handle), " specification. An opaque handle for the FFI type [`",
+            stringify!($raw), "`], reached through [`ffi`](Self::ffi)."));
+
+        impl $handle {
             /// Return the message appended to compiler errors.
             /// # Panics
             /// Panics if it contains invalid UTF-8.
@@ -517,9 +541,9 @@ macro_rules! mjs_struct {
             }
         }
 
-        impl crate::wrappers::mj_editing::traits::sealed::Sealed for [<Mjs $ffi_name>] {}
+        impl crate::wrappers::mj_editing::traits::sealed::Sealed for $handle {}
 
-        impl SpecItem for [<Mjs $ffi_name>] {
+        impl SpecItem for $handle {
             fn element_pointer(&self) -> *const mjsElement {
                 self.ffi().element
             }
@@ -528,29 +552,7 @@ macro_rules! mjs_struct {
                 $extra_trait_methods
             )*)?
         }
-
-
-        $(
-            impl $SpecObject for [<Mjs $ffi_name>] {
-                const OBJ_TYPE: MjtObj = MjtObj::[<mjOBJ_ $ffi_name:upper>];
-                unsafe fn from_element_as_ptr_mut(element: *mut mjsElement) -> *mut Self {
-                    // SAFETY: the handle stands at the address of the struct that mjs_as returns.
-                    unsafe { [<mjs_as $ffi_name:camel>](element) }.cast::<Self>()
-                }
-            }
-        )?
-
-        // Mjs* handles are intentionally NEITHER Send NOR Sync. Each is a thin alias over
-        // a raw pointer into a single shared mjSpec/mjCModel arena, and its `&mut self`
-        // mutators (e.g. `SpecItem::set_name` -> `mjs_setName`) reach through that pointer
-        // to read every sibling and write model-global state (`mjCModel::CheckRepeat` and
-        // the shared `errInfo`). Letting a handle --- or a reference to one --- cross a
-        // thread boundary would let two such accesses race on the one arena from safe code.
-        // The raw-pointer field already makes the type auto-`!Send + !Sync`, so we simply
-        // do not add the impls. Do NOT add `unsafe impl Send`/`Sync` here: the owning
-        // `MjSpec` is itself `Send` (but `!Sync`), so a whole spec can still move between
-        // threads --- handles derived from it just stay on the thread that created them.
-    }};
+    };
 }
 
 /// Implements the userdata method.

--- a/src/wrappers/mj_editing/utility.rs
+++ b/src/wrappers/mj_editing/utility.rs
@@ -833,35 +833,61 @@ macro_rules! vec_vec_append {
 
 /// Generates methods for obtaining iterators to `$iter_over` spec items.
 macro_rules! spec_get_iter {
-    ($($iter_over: ident),*) => {paste::paste!{
+    (read_only: $($iter_over: ident),*) => {paste::paste!{
         $(
-            #[doc = concat!("Return an iterator over ", stringify!($iter_over)," items that allows modifying each value.")]
-            pub fn [<$iter_over _iter_mut>](&mut self) -> MjsSpecItemIterMut<'_, [<Mjs $iter_over:camel>]> {
-                MjsSpecItemIterMut::<[<Mjs $iter_over:camel>]>::new(self)
-            }
-
             #[doc = concat!("Return an immutable iterator over ", stringify!($iter_over)," items.")]
             pub fn [<$iter_over _iter>](&self) -> MjsSpecItemIter<'_, [<Mjs $iter_over:camel>]> {
                 MjsSpecItemIter::<[<Mjs $iter_over:camel>]>::new(self)
             }
         )*
     }};
+
+    ($($iter_over: ident),*) => {paste::paste!{
+        $(
+            #[doc = concat!("Return an iterator over ", stringify!($iter_over)," items that allows modifying each value.")]
+            pub fn [<$iter_over _iter_mut>](&mut self) -> MjsSpecItemIterMut<'_, [<Mjs $iter_over:camel>]> {
+                MjsSpecItemIterMut::<[<Mjs $iter_over:camel>]>::new(self)
+            }
+        )*
+
+        spec_get_iter!(read_only: $($iter_over),*);
+    }};
 }
 
 
 /// Generates methods for obtaining iterators to `$iter_over` body items.
 macro_rules! body_get_iter {
+    (read_only: [$($iter_over: ident),*]) => {paste::paste!{
+        $(
+            #[doc = concat!("Return an immutable iterator over ", stringify!($iter_over)," items.")]
+            pub fn [<$iter_over _iter>](&self, recurse: bool) -> MjsBodyItemIter<'_, [<Mjs $iter_over:camel>]> {
+                MjsBodyItemIter::<[<Mjs $iter_over:camel>]>::new(self, recurse)
+            }
+        )*
+    }};
+
+    (direct_children_mut: [$($iter_over: ident),*]) => {paste::paste!{
+        $(
+            #[doc = concat!(
+                "Return an iterator over the direct child ", stringify!($iter_over),
+                " items that allows modifying each value."
+            )]
+            pub fn [<$iter_over _iter_mut>](&mut self) -> MjsBodyItemIterMut<'_, [<Mjs $iter_over:camel>]> {
+                MjsBodyItemIterMut::<[<Mjs $iter_over:camel>]>::new(self, false)
+            }
+        )*
+
+        body_get_iter!(read_only: [$($iter_over),*]);
+    }};
+
     ([$($iter_over: ident),*]) => {paste::paste!{
         $(
             #[doc = concat!("Return an iterator over ", stringify!($iter_over)," items that allows modifying each value.")]
             pub fn [<$iter_over _iter_mut>](&mut self, recurse: bool) -> MjsBodyItemIterMut<'_, [<Mjs $iter_over:camel>]> {
                 MjsBodyItemIterMut::<[<Mjs $iter_over:camel>]>::new(self, recurse)
             }
-
-            #[doc = concat!("Return an immutable iterator over ", stringify!($iter_over)," items.")]
-            pub fn [<$iter_over _iter>](&self, recurse: bool) -> MjsBodyItemIter<'_, [<Mjs $iter_over:camel>]> {
-                MjsBodyItemIter::<[<Mjs $iter_over:camel>]>::new(self, recurse)
-            }
         )*
+
+        body_get_iter!(read_only: [$($iter_over),*]);
     }};
 }

--- a/src/wrappers/mj_logging.rs
+++ b/src/wrappers/mj_logging.rs
@@ -108,9 +108,8 @@ impl MjLogMessage {
 
     /// Maps a nullable caller-owned `&'static CStr` to the raw pointer stored in the message.
     ///
-    /// The `'static CStr` bound is what keeps the stored pointer sound: the data is
-    /// NUL-terminated (C reads `body`/`func`/`file` as C strings) and lives for the whole
-    /// program, so the pointer can never dangle and C never reads out of bounds.
+    /// The `'static CStr` bound keeps the stored pointer sound: the data is NUL-terminated and
+    /// lives for the whole program.
     fn cstr_ptr(s: Option<&'static CStr>) -> *const c_char {
         s.map_or(ptr::null(), CStr::as_ptr)
     }

--- a/src/wrappers/mj_model.rs
+++ b/src/wrappers/mj_model.rs
@@ -280,10 +280,8 @@ pub(crate) struct MjModelLayout {
 }
 
 impl PartialEq for MjModelLayout {
-    /// `signature` takes no part. `mjModel.signature` (mjmodel.h:919) belongs to no `MJMODEL_*`
-    /// macro in `mjxmacro.h`, so `mj_saveModel` does not write it and `mj_loadModel` leaves it
-    /// zero; the only writer is the compiler (`user_model.cc:5625`). Testing it would refuse a
-    /// model against its own saved copy. The entries below pin everything the hash covers.
+    /// `signature` takes no part: only the compiler writes it, so `mj_loadModel` leaves it zero
+    /// and a test would refuse a model against its own saved copy.
     fn eq(&self, other: &Self) -> bool {
             self.nexclude == other.nexclude && self.nmat == other.nmat && self.npair == other.npair && self.nskin == other.nskin &&
             self.nkey == other.nkey && self.nmocap == other.nmocap && self.nuserdata == other.nuserdata && self.nhistory == other.nhistory &&
@@ -729,15 +727,7 @@ impl MjModel {
     ///
     /// Wraps [`mj_copyModel`].
     /// # Note
-    ///
-    /// <div class="warning">
-    ///
-    /// MuJoCo cannot report a failure here: `mj_copyModel` raises `mjERROR` when it cannot make
-    /// the model, and the default error handler exits the process, so this method never returns
-    /// `Err`. Prefer [`Clone::clone`]. This method may be undeprecated in the future if MuJoCo's
-    /// upstream C code is changed to report the failure recoverably.
-    ///
-    /// </div>
+    /// MuJoCo ends the process when the allocation fails, so this never returns `Err`.
     ///
     /// # Errors
     /// Returns [`MjModelError::AllocationFailed`] if MuJoCo returns a null model.

--- a/src/wrappers/mj_rendering.rs
+++ b/src/wrappers/mj_rendering.rs
@@ -107,7 +107,7 @@ impl MjrContext {
     /// this function. Calling without an active GL context causes MuJoCo to abort the process.
     /// The same GL context must also remain current when this `MjrContext` is dropped, and must
     /// remain on the same thread for the lifetime of this value.
-    /// 
+    ///
     /// Any models used in the methods of [`MjrContext`] must be structurally
     /// compatible with the `model`. The methods will not check compatibility
     /// on their own.

--- a/src/wrappers/mj_visualization.rs
+++ b/src/wrappers/mj_visualization.rs
@@ -371,9 +371,8 @@ impl Default for MjvCamera {
 /// OpenGL camera parameters (position, forward/up vectors, frustum planes).
 pub type MjvGLCamera = mjvGLCamera;
 
-/// OpenGL camera parameters (position, forward/up vectors, frustum planes).
-/// This is the same as [`MjvGLCamera`]; this alias follows MuJoCo's internal
-/// type alias convention.
+/// OpenGL camera parameters (position, forward/up vectors, frustum planes). Alias of
+/// [`MjvGLCamera`].
 pub type MjrCamera = mjrCamera;
 
 impl MjvGLCamera {
@@ -504,8 +503,6 @@ impl MjvFigure {
     /// Every `linepnt` entry must lie within `0..=mjMAXLINEPNT`, the capacity of the matching
     /// `linedata` row. Automated checks from Rust side are too expensive.
     pub unsafe fn draw(&mut self, viewport: MjrRectangle, context: &MjrContext) {
-        // The only guard would scan all mjMAXLINE entries on a per-frame path, so the bound is a
-        // caller precondition instead (coding-conventions, FFI guard ladder).
         // SAFETY: the caller guarantees every `linepnt` entry is within the `linedata` capacity.
         unsafe { mjr_figure(viewport, self, context.ffi()) };
     }

--- a/src/wrappers/mj_visualization.rs
+++ b/src/wrappers/mj_visualization.rs
@@ -489,12 +489,6 @@ impl MjvFigure {
         }
     }
 
-    /// Instantiates a new figure with default values, allocated on the heap.
-    #[deprecated(since = "3.0.0", note = "use `new_boxed` instead")]
-    pub fn new() -> Box<Self> {
-        Self::new_boxed()
-    }
-
     /// Draws the 2D figure to the `viewport` on screen.
     ///
     /// Wraps [`mjr_figure`].

--- a/tests/model_compatibility.rs
+++ b/tests/model_compatibility.rs
@@ -148,14 +148,6 @@ fn compile_with(spec: &MjSpec, edits: &[&Edit]) -> Option<MjModel> {
     copy.compile().ok()
 }
 
-/// Finds the item of one kind by name and hands its raw element pointer back, so that the
-/// borrow on the spec ends before `delete_element` takes its own.
-macro_rules! element_pointer {
-    ($spec:expr, $iter_mut:ident, $name:expr) => {
-        $spec.$iter_mut().find(|item| item.name() == $name).map(|item| item.element_mut_pointer())
-    };
-}
-
 /// Runs `body` on the item of one kind that carries `name`, and does nothing when it is gone.
 macro_rules! on_item {
     ($spec:expr, $iter_mut:ident, $name:expr, |$item:ident| $body:expr) => {
@@ -449,10 +441,9 @@ fn deletion_edits(spec: &MjSpec) -> Vec<Edit> {
                 out.push(Edit::new(
                     format!("delete {} '{}'", $kind, name), Kind::Open,
                     move |spec: &mut MjSpec| {
-                        if let Some(pointer) = element_pointer!(spec, $iter_mut, target) {
-                            // SAFETY: the pointer names an element of this spec, found just above.
-                            let _ = unsafe { spec.delete_element(pointer) };
-                        }
+                        // SAFETY: the walk runs on the spec that the edits before it left, so it
+                        // reaches a live element only, and each edit deletes one name once.
+                        on_item!(spec, $iter_mut, target, |item| unsafe { let _ = item.delete(); });
                     },
                 ));
             }

--- a/tests/model_compatibility.rs
+++ b/tests/model_compatibility.rs
@@ -150,8 +150,8 @@ fn compile_with(spec: &MjSpec, edits: &[&Edit]) -> Option<MjModel> {
 
 /// Runs `body` on the item of one kind that carries `name`, and does nothing when it is gone.
 macro_rules! on_item {
-    ($spec:expr, $iter_mut:ident, $name:expr, |$item:ident| $body:expr) => {
-        if let Some($item) = $spec.$iter_mut().find(|item| item.name() == $name) {
+    ($spec:expr, $finder:ident, $name:expr, |$item:ident| $body:expr) => {
+        if let Some($item) = $spec.$finder(&$name[..]) {
             $body;
         }
     };
@@ -195,7 +195,7 @@ fn joint_type_edits() -> Vec<Edit> {
             // The root is a free joint, so setting it to free again changes nothing.
             let kind = if t == MjtJoint::mjJNT_FREE { Kind::Parameter } else { Kind::Structural };
             Edit::new(format!("joint type {t:?}"), kind, move |spec: &mut MjSpec| {
-                on_item!(spec, joint_iter_mut, "root", |j| j.set_type(t));
+                on_item!(spec, joint_mut, "root", |j| j.set_type(t));
             })
         })
         .collect()
@@ -218,7 +218,7 @@ fn geom_type_edits() -> Vec<Edit> {
         .map(|t| {
             let kind = if t == MjtGeom::mjGEOM_CAPSULE { Kind::Parameter } else { Kind::Structural };
             Edit::new(format!("geom type {t:?}"), kind, move |spec: &mut MjSpec| {
-                on_item!(spec, geom_iter_mut, "g_upper", |g| {
+                on_item!(spec, geom_mut, "g_upper", |g| {
                     g.set_type(t);
                     *g.size_mut() = [0.04, 0.04, 0.1];
                     // A mesh geom and a heightfield geom each need their asset named.
@@ -243,7 +243,7 @@ fn texture_type_edits() -> Vec<Edit> {
         .map(|t| {
             let kind = if t == MjtTexture::mjTEXTURE_2D { Kind::Parameter } else { Kind::Structural };
             Edit::new(format!("texture type {t:?}"), kind, move |spec: &mut MjSpec| {
-                on_item!(spec, texture_iter_mut, "tx", |tex| {
+                on_item!(spec, texture_mut, "tx", |tex| {
                     tex.set_type(t);
                     // A cube and a skybox hold six square faces, so the height follows the width.
                     if t != MjtTexture::mjTEXTURE_2D {
@@ -282,7 +282,7 @@ fn equality_type_edits() -> Vec<Edit> {
             let kind = if t == MjtEq::mjEQ_CONNECT { Kind::Parameter } else { Kind::Structural };
             Edit::new(format!("equality type {t:?}"), kind, move |spec: &mut MjSpec| {
                 let (objtype, name1, name2) = targets(t);
-                on_item!(spec, equality_iter_mut, "eq0", |eq| {
+                on_item!(spec, equality_mut, "eq0", |eq| {
                     eq.set_type(t);
                     eq.set_objtype(objtype);
                     eq.set_name1(name1);
@@ -315,7 +315,7 @@ fn actuator_kind_edits() -> Vec<Edit> {
         .map(|(name, set)| {
             let kind = if name == "motor" { Kind::Parameter } else { Kind::Structural };
             Edit::new(format!("actuator kind {name}"), kind, move |spec: &mut MjSpec| {
-                on_item!(spec, actuator_iter_mut, "a_motor", |a| set(a));
+                on_item!(spec, actuator_mut, "a_motor", |a| set(a));
             })
         })
         .collect()
@@ -425,7 +425,7 @@ fn sensor_type_edits(spec: &MjSpec) -> (Vec<Edit>, Vec<MjtSensor>) {
 fn deletion_edits(spec: &MjSpec) -> Vec<Edit> {
     let mut out = Vec::new();
     macro_rules! sweep {
-        ($($obj:ident, $kind:literal => $iter:ident, $iter_mut:ident;)+) => {
+        ($($obj:ident, $kind:literal => $iter:ident, $finder:ident;)+) => {
             // The kinds the sweep leaves out hold no element a spec can delete: markers, a whole
             // model, an xbody, and the dof and plugin kinds that belong to the compiled model.
             all_variants!(MjtObj = $($obj),+ ;
@@ -443,7 +443,7 @@ fn deletion_edits(spec: &MjSpec) -> Vec<Edit> {
                     move |spec: &mut MjSpec| {
                         // SAFETY: the walk runs on the spec that the edits before it left, so it
                         // reaches a live element only, and each edit deletes one name once.
-                        on_item!(spec, $iter_mut, target, |item| unsafe { let _ = item.delete(); });
+                        on_item!(spec, $finder, target, |item| unsafe { let _ = item.delete(); });
                     },
                 ));
             }
@@ -451,28 +451,28 @@ fn deletion_edits(spec: &MjSpec) -> Vec<Edit> {
         };
     }
     sweep! {
-        mjOBJ_BODY,     "body"     => body_iter, body_iter_mut;
-        mjOBJ_JOINT,    "joint"    => joint_iter, joint_iter_mut;
-        mjOBJ_GEOM,     "geom"     => geom_iter, geom_iter_mut;
-        mjOBJ_SITE,     "site"     => site_iter, site_iter_mut;
-        mjOBJ_CAMERA,   "camera"   => camera_iter, camera_iter_mut;
-        mjOBJ_LIGHT,    "light"    => light_iter, light_iter_mut;
-        mjOBJ_ACTUATOR, "actuator" => actuator_iter, actuator_iter_mut;
-        mjOBJ_SENSOR,   "sensor"   => sensor_iter, sensor_iter_mut;
-        mjOBJ_TENDON,   "tendon"   => tendon_iter, tendon_iter_mut;
-        mjOBJ_EQUALITY, "equality" => equality_iter, equality_iter_mut;
-        mjOBJ_PAIR,     "pair"     => pair_iter, pair_iter_mut;
-        mjOBJ_EXCLUDE,  "exclude"  => exclude_iter, exclude_iter_mut;
-        mjOBJ_FLEX,     "flex"     => flex_iter, flex_iter_mut;
-        mjOBJ_MESH,     "mesh"     => mesh_iter, mesh_iter_mut;
-        mjOBJ_HFIELD,   "hfield"   => hfield_iter, hfield_iter_mut;
-        mjOBJ_SKIN,     "skin"     => skin_iter, skin_iter_mut;
-        mjOBJ_TEXTURE,  "texture"  => texture_iter, texture_iter_mut;
-        mjOBJ_MATERIAL, "material" => material_iter, material_iter_mut;
-        mjOBJ_NUMERIC,  "numeric"  => numeric_iter, numeric_iter_mut;
-        mjOBJ_TEXT,     "text"     => text_iter, text_iter_mut;
-        mjOBJ_TUPLE,    "tuple"    => tuple_iter, tuple_iter_mut;
-        mjOBJ_KEY,      "key"      => key_iter, key_iter_mut;
+        mjOBJ_BODY,     "body"     => body_iter, body_mut;
+        mjOBJ_JOINT,    "joint"    => joint_iter, joint_mut;
+        mjOBJ_GEOM,     "geom"     => geom_iter, geom_mut;
+        mjOBJ_SITE,     "site"     => site_iter, site_mut;
+        mjOBJ_CAMERA,   "camera"   => camera_iter, camera_mut;
+        mjOBJ_LIGHT,    "light"    => light_iter, light_mut;
+        mjOBJ_ACTUATOR, "actuator" => actuator_iter, actuator_mut;
+        mjOBJ_SENSOR,   "sensor"   => sensor_iter, sensor_mut;
+        mjOBJ_TENDON,   "tendon"   => tendon_iter, tendon_mut;
+        mjOBJ_EQUALITY, "equality" => equality_iter, equality_mut;
+        mjOBJ_PAIR,     "pair"     => pair_iter, pair_mut;
+        mjOBJ_EXCLUDE,  "exclude"  => exclude_iter, exclude_mut;
+        mjOBJ_FLEX,     "flex"     => flex_iter, flex_mut;
+        mjOBJ_MESH,     "mesh"     => mesh_iter, mesh_mut;
+        mjOBJ_HFIELD,   "hfield"   => hfield_iter, hfield_mut;
+        mjOBJ_SKIN,     "skin"     => skin_iter, skin_mut;
+        mjOBJ_TEXTURE,  "texture"  => texture_iter, texture_mut;
+        mjOBJ_MATERIAL, "material" => material_iter, material_mut;
+        mjOBJ_NUMERIC,  "numeric"  => numeric_iter, numeric_mut;
+        mjOBJ_TEXT,     "text"     => text_iter, text_mut;
+        mjOBJ_TUPLE,    "tuple"    => tuple_iter, tuple_mut;
+        mjOBJ_KEY,      "key"      => key_iter, key_mut;
     }
     out
 }
@@ -608,16 +608,16 @@ fn parameter_edits() -> Vec<Edit> {
         Edit::new("solver tolerance", Kind::Parameter,
                   |spec: &mut MjSpec| spec.option_mut().tolerance = 1e-10),
         Edit::new("geom size", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, geom_iter_mut, "g_lower", |g| *g.size_mut() = [0.07, 0.0, 0.2]);
+            on_item!(spec, geom_mut, "g_lower", |g| *g.size_mut() = [0.07, 0.0, 0.2]);
         }),
         Edit::new("geom density", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, geom_iter_mut, "g_lower", |g| g.set_density(2000.0));
+            on_item!(spec, geom_mut, "g_lower", |g| g.set_density(2000.0));
         }),
         Edit::new("geom friction", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, geom_iter_mut, "g_lower", |g| *g.friction_mut() = [2.0, 0.01, 0.001]);
+            on_item!(spec, geom_mut, "g_lower", |g| *g.friction_mut() = [2.0, 0.01, 0.001]);
         }),
         Edit::new("geom rgba", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, geom_iter_mut, "g_trunk", |g| *g.rgba_mut() = [1.0, 0.0, 0.0, 0.5]);
+            on_item!(spec, geom_mut, "g_trunk", |g| *g.rgba_mut() = [1.0, 0.0, 0.0, 0.5]);
         }),
         Edit::new("body position", Kind::Parameter, |spec: &mut MjSpec| {
             if let Some(body) = spec.world_body_mut().child_mut("trunk") {
@@ -630,74 +630,74 @@ fn parameter_edits() -> Vec<Edit> {
             }
         }),
         Edit::new("joint armature", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, joint_iter_mut, "slide", |j| j.set_armature(0.1));
+            on_item!(spec, joint_mut, "slide", |j| j.set_armature(0.1));
         }),
         Edit::new("joint range", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, joint_iter_mut, "knee", |j| *j.range_mut() = [-2.0, 2.0]);
+            on_item!(spec, joint_mut, "knee", |j| *j.range_mut() = [-2.0, 2.0]);
         }),
         Edit::new("joint axis", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, joint_iter_mut, "knee", |j| *j.axis_mut() = [1.0, 0.0, 0.0]);
+            on_item!(spec, joint_mut, "knee", |j| *j.axis_mut() = [1.0, 0.0, 0.0]);
         }),
         Edit::new("joint friction loss", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, joint_iter_mut, "slide", |j| j.set_frictionloss(0.2));
+            on_item!(spec, joint_mut, "slide", |j| j.set_frictionloss(0.2));
         }),
         Edit::new("actuator gear", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, actuator_iter_mut, "a_motor", |a| *a.gear_mut() = [7.0, 0.0, 0.0, 0.0, 0.0, 0.0]);
+            on_item!(spec, actuator_mut, "a_motor", |a| *a.gear_mut() = [7.0, 0.0, 0.0, 0.0, 0.0, 0.0]);
         }),
         Edit::new("actuator control range", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, actuator_iter_mut, "a_pos", |a| *a.ctrlrange_mut() = [-2.0, 2.0]);
+            on_item!(spec, actuator_mut, "a_pos", |a| *a.ctrlrange_mut() = [-2.0, 2.0]);
         }),
         Edit::new("tendon stiffness", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, tendon_iter_mut, "td", |t| t.stiffness_mut()[0] = 4.0);
+            on_item!(spec, tendon_mut, "td", |t| t.stiffness_mut()[0] = 4.0);
         }),
         Edit::new("tendon range", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, tendon_iter_mut, "td", |t| *t.range_mut() = [0.0, 2.0]);
+            on_item!(spec, tendon_mut, "td", |t| *t.range_mut() = [0.0, 2.0]);
         }),
         Edit::new("sensor noise", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, sensor_iter_mut, "se_jp", |s| s.set_noise(0.01));
+            on_item!(spec, sensor_mut, "se_jp", |s| s.set_noise(0.01));
         }),
         Edit::new("sensor cutoff", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, sensor_iter_mut, "se_jp", |s| s.set_cutoff(3.0));
+            on_item!(spec, sensor_mut, "se_jp", |s| s.set_cutoff(3.0));
         }),
         Edit::new("equality solimp", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, equality_iter_mut, "eq0", |e| *e.solimp_mut() = [0.8, 0.9, 0.001, 0.5, 2.0]);
+            on_item!(spec, equality_mut, "eq0", |e| *e.solimp_mut() = [0.8, 0.9, 0.001, 0.5, 2.0]);
         }),
         Edit::new("pair friction", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, pair_iter_mut, "p0", |p| *p.friction_mut() = [2.0, 2.0, 0.01, 0.001, 0.001]);
+            on_item!(spec, pair_mut, "p0", |p| *p.friction_mut() = [2.0, 2.0, 0.01, 0.001, 0.001]);
         }),
         Edit::new("pair margin", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, pair_iter_mut, "p0", |p| p.set_margin(0.01));
+            on_item!(spec, pair_mut, "p0", |p| p.set_margin(0.01));
         }),
         Edit::new("numeric values", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, numeric_iter_mut, "n0", |n| n.set_data(&[9.0, 9.0, 9.0]));
+            on_item!(spec, numeric_mut, "n0", |n| n.set_data(&[9.0, 9.0, 9.0]));
         }),
         Edit::new("keyframe time", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, key_iter_mut, "k1", |k| k.set_time(5.0));
+            on_item!(spec, key_mut, "k1", |k| k.set_time(5.0));
         }),
         Edit::new("material rgba", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, material_iter_mut, "mat", |m| *m.rgba_mut() = [0.0, 1.0, 0.0, 1.0]);
+            on_item!(spec, material_mut, "mat", |m| *m.rgba_mut() = [0.0, 1.0, 0.0, 1.0]);
         }),
         Edit::new("texture colour", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, texture_iter_mut, "tx", |t| *t.rgb1_mut() = [0.0, 0.0, 1.0]);
+            on_item!(spec, texture_mut, "tx", |t| *t.rgb1_mut() = [0.0, 0.0, 1.0]);
         }),
         Edit::new("light diffuse", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, light_iter_mut, "l0", |l| *l.diffuse_mut() = [0.1, 0.2, 0.3]);
+            on_item!(spec, light_mut, "l0", |l| *l.diffuse_mut() = [0.1, 0.2, 0.3]);
         }),
         Edit::new("camera field of view", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, camera_iter_mut, "c_trunk", |c| c.set_fovy(70.0));
+            on_item!(spec, camera_mut, "c_trunk", |c| c.set_fovy(70.0));
         }),
         Edit::new("skin inflate", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, skin_iter_mut, "sk", |s| s.set_inflate(0.03));
+            on_item!(spec, skin_mut, "sk", |s| s.set_inflate(0.03));
         }),
         Edit::new("mesh scale", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, mesh_iter_mut, "ms", |m| *m.scale_mut() = [2.0, 2.0, 2.0]);
+            on_item!(spec, mesh_mut, "ms", |m| *m.scale_mut() = [2.0, 2.0, 2.0]);
         }),
         Edit::new("heightfield extent", Kind::Parameter, |spec: &mut MjSpec| {
-            on_item!(spec, hfield_iter_mut, "hf", |h| *h.size_mut() = [2.0, 2.0, 0.3, 0.05]);
+            on_item!(spec, hfield_mut, "hf", |h| *h.size_mut() = [2.0, 2.0, 0.3, 0.05]);
         }),
         Edit::new("element name", Kind::Parameter, |spec: &mut MjSpec| {
             // 'spare' carries no reference from any other element, so the rename stands alone.
-            on_item!(spec, body_iter_mut, "spare", |b| { let _ = b.set_name("spare_renamed_much_longer"); });
+            on_item!(spec, body_mut, "spare", |b| { let _ = b.set_name("spare_renamed_much_longer"); });
         }),
     ]
 }


### PR DESCRIPTION
Fixes model-editing soundness around C code.

This contains a lot of technically breaking changes, however, users who used mostly the safe API should be largely unaffected. Notably, the `Mjs*` type aliases are now zero-sized types (ZST) which are created from the FFI pointers to the `mjs*` structs. Threading is now also heavily limited for model-editing types due to how the internal C++ code is implemented (in a very threading-unsafe way; even when using Send due to weird "deep" cloning behavior). 