### PR TITLE
Model editing attachments

### DIFF
--- a/docs/guide/source/changelog.rst
+++ b/docs/guide/source/changelog.rst
@@ -42,6 +42,7 @@ update of MuJoCo alone can increase the major version.
 
 .. Each release group lives in its own fragment. Add a new release at the top of the list.
 
+.. include:: changelog/6.1.x.rst.inc
 .. include:: changelog/6.0.x.rst.inc
 .. include:: changelog/5.0.x.rst.inc
 .. include:: changelog/4.0.x.rst.inc

--- a/docs/guide/source/changelog/5.0.x.rst.inc
+++ b/docs/guide/source/changelog/5.0.x.rst.inc
@@ -158,7 +158,7 @@
 
 .. rubric:: Deprecations
 
-- Deprecated :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>delete`
+- Deprecated ``SpecItem::delete``
   due to it relying on **undefined behavior**.
   Users are expected to use
   :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>delete_element`

--- a/docs/guide/source/changelog/6.1.x.rst.inc
+++ b/docs/guide/source/changelog/6.1.x.rst.inc
@@ -5,19 +5,22 @@
 .. rubric:: New dependencies
 .. rubric:: Deprecations
 .. rubric:: Error handling
+
+- Added :docs-rs:`~~mujoco_rs::error::<enum>MjEditError::<variant>AttachFailed` :sup:`new`.
+
 .. rubric:: New features and improvements
 
 *Model editing*
 
 - Added traits:
 
-  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>Attach` :sup:`new` and
-  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>AttachTo` :sup:`new`.
-  
-  The first defines :docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>Attach::<method>attach`, which
+  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>Attach` :sup:`new` and
+  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>AttachTo` :sup:`new`.
+
+  The first defines :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach`, which
   allows elements to be attached to ``Self`` (implementor of ``Attach``) based on the ``AttachTo`` trait. For example,
   implementations of ``AttachTo<MjsFrame>`` allow the implementor elements to be attached to
-  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsFrame`.
+  |mjs_frame|.
 
 .. rubric:: Bug fixes
 .. rubric:: Other changes

--- a/docs/guide/source/changelog/6.1.x.rst.inc
+++ b/docs/guide/source/changelog/6.1.x.rst.inc
@@ -1,0 +1,23 @@
+6.1.0 (MuJoCo 3.12.0)
+======================
+
+.. rubric:: Breaking changes
+.. rubric:: New dependencies
+.. rubric:: Deprecations
+.. rubric:: Error handling
+.. rubric:: New features and improvements
+
+*Model editing*
+
+- Added traits:
+
+  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>Attach` :sup:`new` and
+  - :docs-rs:`~mujoco_rs::wrappers::mj_editing::traits::<trait>AttachTo` :sup:`new`.
+  
+  The first defines :docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>Attach::<method>attach`, which
+  allows elements to be attached to ``Self`` (implementor of ``Attach``) based on the ``AttachTo`` trait. For example,
+  implementations of ``AttachTo<MjsFrame>`` allow the implementor elements to be attached to
+  :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsFrame`.
+
+.. rubric:: Bug fixes
+.. rubric:: Other changes

--- a/docs/guide/source/changelog/6.1.x.rst.inc
+++ b/docs/guide/source/changelog/6.1.x.rst.inc
@@ -19,14 +19,18 @@
 
   The first trait defines
   :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach_by_deep_copy` and
-  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach_by_reference`, which
-  allow elements to be attached to ``Self`` (implementor of ``Attach``) based on the ``AttachTo`` trait.
-  For example, implementations of ``AttachTo<MjsFrame>`` allow the implementor elements to be attached to
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach_by_reference`
+  (:docs-rs:`~mujoco_rs::mujoco_c::<fn>mjs_attach`), which allow elements to be attached to
+  ``Self`` (implementor of ``Attach``) based on the ``AttachTo`` trait. For example,
+  implementations of ``AttachTo<MjsFrame>`` allow the implementor elements to be attached to
   |mjs_frame|.
 
   ``attach_by_deep_copy`` gives the parent a copy of every element of the child, thus both
-  specifications stay usable. ``attach_by_reference`` shares the elements, which is the default behavior in MuJoCo,
-  and is therefore ``unsafe``. The safe usage conditions are written in the method's docstring.
+  specifications stay usable. ``attach_by_reference`` shares the elements, which is the default
+  behavior in MuJoCo, and is therefore ``unsafe``. The safe usage conditions are written in the
+  method's docstring.
+
+  The prelude exports both traits.
 
 .. rubric:: Bug fixes
 .. rubric:: Other changes

--- a/docs/guide/source/changelog/6.1.x.rst.inc
+++ b/docs/guide/source/changelog/6.1.x.rst.inc
@@ -17,10 +17,16 @@
   - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>Attach` :sup:`new` and
   - :docs-rs:`~mujoco_rs::wrappers::mj_editing::<trait>AttachTo` :sup:`new`.
 
-  The first defines :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach`, which
-  allows elements to be attached to ``Self`` (implementor of ``Attach``) based on the ``AttachTo`` trait. For example,
-  implementations of ``AttachTo<MjsFrame>`` allow the implementor elements to be attached to
+  The first trait defines
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach_by_deep_copy` and
+  :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach_by_reference`, which
+  allow elements to be attached to ``Self`` (implementor of ``Attach``) based on the ``AttachTo`` trait.
+  For example, implementations of ``AttachTo<MjsFrame>`` allow the implementor elements to be attached to
   |mjs_frame|.
+
+  ``attach_by_deep_copy`` gives the parent a copy of every element of the child, thus both
+  specifications stay usable. ``attach_by_reference`` shares the elements, which is the default behavior in MuJoCo,
+  and is therefore ``unsafe``. The safe usage conditions are written in the method's docstring.
 
 .. rubric:: Bug fixes
 .. rubric:: Other changes

--- a/docs/guide/source/migration/3.0.x.rst.inc
+++ b/docs/guide/source/migration/3.0.x.rst.inc
@@ -812,7 +812,7 @@ API renames
 ``sync()`` deprecated
 ---------------------------------------
 
-:docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>sync` is deprecated.
+``MjRenderer::sync`` is deprecated.
 Use :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>sync_data`
 followed by :docs-rs:`~~mujoco_rs::renderer::<struct>MjRenderer::<method>render`
 instead. ``sync_data`` updates the scene without rendering, giving you the

--- a/docs/guide/source/migration/5.0.x.rst.inc
+++ b/docs/guide/source/migration/5.0.x.rst.inc
@@ -43,7 +43,7 @@ removed.
 
 Deprecated implementation of removing model-editing elements
 --------------------------------------------------------------
-Due to the :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>SpecItem::<method>delete`
+Due to the ``SpecItem::delete``
 method relying on undefined behavior, the said method is now deprecated.
 It's replacement --- :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>delete_element` ---
 now forces the user to drop all existing references of |mj_spec| and its

--- a/docs/guide/source/programming/logging.rst
+++ b/docs/guide/source/programming/logging.rst
@@ -33,7 +33,7 @@ at the start of the program.
 
     Installing the hook, through either function, replaces MuJoCo's own handler, so the
     ``logto_console``, ``logto_file`` and ``logfile`` fields of
-    :docs-rs:`~mujoco_rs::wrappers::mj_logging::<struct>MjLogConfig` no longer reach the output.
+    :docs-rs:`~mujoco_rs::wrappers::mj_logging::<type>MjLogConfig` no longer reach the output.
     The install also writes every topic into the global topic bitmask once, so a bitmask that the
     program set before the install is lost. The producer-side topic gate still reads that bitmask,
     so a :docs-rs:`~mujoco_rs::wrappers::mj_logging::<fn>set_log_config` call after the install

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -218,10 +218,11 @@ In addition to adding elements to the specification and other elements directly,
 existing trees of elements can be *attached* directly onto a new tree.
 
 Elements can be attached to another element via the
-:docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>Attach::<method>attach` method,
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach` method,
 available on types implementing ``Attach``. Elements implementing ``Attach`` are |mjs_body|,
-|mjs_frame| and |mjs_site|. If you'd like to attach elements to a |mj_spec|, you should first
-add a ``MjsFrame`` via :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>add_frame`
+|mjs_frame| and |mjs_site|. To attach a whole specification, first
+add a frame to the parent's world body with
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>add_frame`
 and attach to the newly added frame. Here is the full mapping of what element type can be attached to
 what other element type:
 

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -10,6 +10,8 @@ Model editing
 .. |mjs_body| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsBody`
 .. |mjs_actuator| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsActuator`
 .. |mjs_flex| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsFlex`
+.. |mjs_frame| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsFrame`
+.. |mjs_site| replace:: :docs-rs:`~mujoco_rs::wrappers::mj_editing::<struct>MjsSite`
 
 The most general way to create an |mj_model| instance is by loading an XML file
 via :docs-rs:`~~mujoco_rs::wrappers::mj_model::<struct>MjModel::<method>from_xml`.
@@ -209,6 +211,65 @@ changed sensor type or a changed actuator dynamics type breaks it; ``swap_model`
 ``try_swap_model`` returns
 :docs-rs:`~~mujoco_rs::error::<enum>MjDataError::<variant>IncompatibleModel`.
 
+
+Attaching elements
+======================
+In addition to adding elements to the specification and other elements directly,
+existing trees of elements can be *attached* directly onto a new tree.
+
+Elements can be attached to another element via the
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::traits::<trait>Attach::<method>attach` method,
+available on types implementing ``Attach``. Elements implementing ``Attach`` are |mjs_body|,
+|mjs_frame| and |mjs_site|. If you'd like to attach elements to a |mj_spec|, you should first
+add a ``MjsFrame`` via :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjSpec::<method>add_frame`
+and attach to the newly added frame. Here is the full mapping of what element type can be attached to
+what other element type:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 30 70
+
+    * - Parent
+      - Child
+    * - |mjs_body|
+      - |mjs_frame|, |mj_spec|
+    * - |mjs_frame|
+      - |mjs_body|, |mjs_frame|, |mj_spec|
+    * - |mjs_site|
+      - |mjs_body|, |mjs_frame|, |mj_spec|
+
+When attaching elements, a *prefix* and a *suffix* can be given. When no prefix/suffix is desired, just pass ``""`` to
+``Attach::attach`` at its respective positions.
+
+The example below attaches a one-body specification under a frame of another specification.
+
+.. code-block:: rust
+
+    use mujoco_rs::prelude::*;
+
+    fn main() {
+        // Child specification.
+        let mut child = MjSpec::new();
+        child.world_body_mut().add_body().with_name("ball")
+            .add_geom().with_size([0.01, 0.0, 0.0]);
+
+        // Parent specification.
+        let mut parent = MjSpec::new();
+        // Add a frame onto which the child will be attached.
+        let frame = parent.world_body_mut().add_frame().with_pos([0.0, 0.0, 1.0]);
+
+        // Attach the child to the newly-created frame, giving all sub-elements
+        // of the child tree "robot_" as a prefix to all the names.
+        // This method is available by importing the `Attach` trait (already in the prelude).
+        frame.attach(&mut child, "robot_", "").unwrap();
+
+        // The child is now attached.
+        assert!(parent.body("robot_ball").is_some());
+        parent.compile().expect("failed to compile");
+    }
+
+More on attachment is available in MuJoCo's
+`official documentation on attachment <https://mujoco.readthedocs.io/en/stable/programming/modeledit.html#attachment>`__.
 
 Deleting elements
 ======================

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -217,8 +217,9 @@ Attaching elements
 In addition to adding elements to the specification and other elements directly,
 existing trees of elements can be *attached* directly onto a new tree.
 
-Elements can be attached to another element via the
-:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach` method,
+Elements can be attached to another element via
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach_by_reference` or
+:docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach_by_deep_copy`,
 available on types implementing ``Attach``. Elements implementing ``Attach`` are |mjs_body|,
 |mjs_frame| and |mjs_site|. To attach a whole specification, first
 add a frame to the parent's world body with
@@ -240,7 +241,7 @@ what other element type:
       - |mjs_body|, |mjs_frame|, |mj_spec|
 
 When attaching elements, a *prefix* and a *suffix* can be given. When no prefix/suffix is desired, just pass ``""`` to
-``Attach::attach`` at its respective positions.
+``Attach::attach_by_deep_copy`` / ``Attach::attach_by_reference`` at its respective positions.
 
 The example below attaches a one-body specification under a frame of another specification.
 
@@ -262,7 +263,7 @@ The example below attaches a one-body specification under a frame of another spe
         // Attach the child to the newly-created frame, giving all sub-elements
         // of the child tree "robot_" as a prefix to all the names.
         // This method is available by importing the `Attach` trait (already in the prelude).
-        frame.attach(&mut child, "robot_", "").unwrap();
+        frame.attach_by_deep_copy(&mut child, "robot_", "").unwrap();
 
         // The child is now attached.
         assert!(parent.body("robot_ball").is_some());

--- a/docs/guide/source/programming/model_editing.rst
+++ b/docs/guide/source/programming/model_editing.rst
@@ -221,11 +221,11 @@ Elements can be attached to another element via
 :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach_by_reference` or
 :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<trait>Attach::<method>attach_by_deep_copy`,
 available on types implementing ``Attach``. Elements implementing ``Attach`` are |mjs_body|,
-|mjs_frame| and |mjs_site|. To attach a whole specification, first
-add a frame to the parent's world body with
+|mjs_frame| and |mjs_site|. To place the attached tree at a chosen position, first add a frame
+to the parent with
 :docs-rs:`~~mujoco_rs::wrappers::mj_editing::<struct>MjsBody::<method>add_frame`
-and attach to the newly added frame. Here is the full mapping of what element type can be attached to
-what other element type:
+and attach to that frame. Here is the full mapping of what element type can be
+attached to what other element type:
 
 .. list-table::
     :header-rows: 1
@@ -240,8 +240,15 @@ what other element type:
     * - |mjs_site|
       - |mjs_body|, |mjs_frame|, |mj_spec|
 
-When attaching elements, a *prefix* and a *suffix* can be given. When no prefix/suffix is desired, just pass ``""`` to
-``Attach::attach_by_deep_copy`` / ``Attach::attach_by_reference`` at its respective positions.
+``attach_by_deep_copy`` copies every element of the child into the parent, so both specifications
+stay usable after the call. ``attach_by_reference`` makes the parent share the elements of the
+child, which is MuJoCo's default behavior. That sharing is why the method is ``unsafe``: no handle
+of the child specification, inside or outside the attached subtree, stays usable after the call.
+The method's docstring holds the full conditions.
+
+When attaching elements, a *prefix* and a *suffix* can be given. When no prefix/suffix is desired,
+just pass ``""`` to ``Attach::attach_by_deep_copy`` / ``Attach::attach_by_reference`` at its
+respective positions.
 
 The example below attaches a one-body specification under a frame of another specification.
 
@@ -271,7 +278,8 @@ The example below attaches a one-body specification under a frame of another spe
     }
 
 More on attachment is available in MuJoCo's
-`official documentation on attachment <https://mujoco.readthedocs.io/en/stable/programming/modeledit.html#attachment>`__.
+`official documentation on attachment
+<https://mujoco.readthedocs.io/en/3.12.0/programming/modeledit.html#attachment>`__.
 
 Deleting elements
 ======================

--- a/src/error.rs
+++ b/src/error.rs
@@ -315,6 +315,8 @@ pub enum MjEditError {
     /// Deleting the element failed. Carries MuJoCo's error message, or the reason the wrapper
     /// rejected the element.
     DeleteFailed(String),
+    /// Attaching the child element failed. Carries MuJoCo's error message.
+    AttachFailed(String),
     /// The output buffer passed to [`MjSpec::save_xml_string`](crate::wrappers::mj_editing::MjSpec::save_xml_string)
     /// was too small to hold the XML.
     ///
@@ -349,6 +351,7 @@ impl fmt::Display for MjEditError {
             Self::AlreadyExists => write!(f, "element with the same name already exists"),
             Self::UnsupportedOperation => write!(f, "this operation is not supported"),
             Self::DeleteFailed(msg) => write!(f, "delete failed: {msg}"),
+            Self::AttachFailed(msg) => write!(f, "attach failed: {msg}"),
             Self::XmlBufferTooSmall { required_size } => write!(
                 f,
                 "XML output buffer too small; retry with at least {} bytes",

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,7 +14,8 @@ pub use crate::wrappers::mj_logging::{
     log_config, log_error, log_info, log_message, log_warning, set_log_config,
 };
 pub use crate::wrappers::mj_editing::{
-    MjSpec, MjtConflict, MjFlexcompConfig, SpecItem, SpecObject
+    MjSpec, MjtConflict, MjFlexcompConfig,
+    SpecItem, SpecObject, Attach, AttachTo
 };
 pub use crate::logging::{install_logging_hook, set_log_handler};
 pub use crate::wrappers::mj_visualization::*;

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -456,19 +456,8 @@ impl MjSpec {
         }
 
         let result = unsafe { MjModel::from_raw( mj_compile(self.ffi.as_ptr(), ptr::null()) ) };
-        result.map_err(|_| {
-            // SAFETY: The spec is still valid after failed compilation.
-            // The error pointer is valid until the next MuJoCo call on this spec.
-            let error_msg: String = unsafe {
-                let ptr = mjs_getError(self.ffi_mut());
-                if ptr.is_null() {
-                    "Compilation failed (unknown error)".to_owned()
-                } else {
-                    CStr::from_ptr(ptr).to_string_lossy().into_owned()
-                }
-            };
-            MjEditError::CompileFailed(error_msg)
-        })
+        // SAFETY: the spec is still valid after a failed compilation.
+        result.map_err(|_| MjEditError::CompileFailed(unsafe { read_spec_error(self.ffi.as_ptr()) }))
     }
 
     /// Return the compiler timers, in seconds, in `mjtCTimer` order.

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -4128,4 +4128,142 @@ mod tests {
         assert!(unsafe { spec.world_body_mut().body_iter_mut().last().unwrap().delete() }.is_ok(), "body");
         assert_eq!(spec.body_iter().count(), 1);
     }
+
+    /// Tests the attachment mechanism (wrapper around [`mjs_attach`]).
+    #[test]
+    fn test_attachment() {
+        const BASE_MODEL: &str = r#"
+            <mujoco>
+                <worldbody>
+                    <frame name="base_frame_1">
+                        <body name="base_frame_1_body_1">
+                            <geom size="5" name="base_frame_1_body_1_sphere"/>
+                        </body>
+                    </frame>
+                </worldbody>
+            </mujoco>
+        "#;
+
+        for prefix in ["", "attached_", "added"] {
+            for suffix in ["", "_attached", "_added"] {
+                // The child spec must outlive the compilation, as the parent holds it until then.
+                let mut frame_spec = MjSpec::from_xml_string(BASE_MODEL).unwrap();
+                let mut main_spec = MjSpec::new();
+                let frame = frame_spec.frame_mut("base_frame_1").unwrap();
+                main_spec.world_body_mut().attach(frame, prefix, suffix).expect("attachment failed");
+
+                let renamed = |name: &str| format!("{prefix}{name}{suffix}");
+
+                // MuJoCo attaches by reference, thus it renames the elements of the child spec in
+                // place instead of copying them.
+                assert!(
+                    frame_spec.geom(&renamed("base_frame_1_body_1_sphere")).is_some(),
+                    "the child spec kept the old name"
+                );
+                assert_eq!(
+                    frame_spec.geom("base_frame_1_body_1_sphere").is_some(),
+                    prefix.is_empty() && suffix.is_empty(),
+                    "the old name survived in the child spec"
+                );
+
+                main_spec.frame(&renamed("base_frame_1")).expect("frame not attached");
+                main_spec.body(&renamed("base_frame_1_body_1")).expect("body not attached");
+                main_spec.geom(&renamed("base_frame_1_body_1_sphere")).expect("geom not attached");
+
+                // The original name survives only when both prefix and prefix are empty.
+                assert_eq!(
+                    main_spec.geom("base_frame_1_body_1_sphere").is_some(),
+                    prefix.is_empty() && suffix.is_empty()
+                );
+
+                // An invalid name to validate that the lookups don't just look like they work.
+                assert!(main_spec.geom("base_frame_1_body_1_sphereinvalid").is_none());
+
+                let model = main_spec.compile().expect("compilation of the attached spec failed");
+                assert_eq!(model.nbody(), 2, "the world body plus the attached one");
+                assert_eq!(model.ngeom(), 1);
+            }
+        }
+    }
+
+    /// Tests every parent/child pair that [`Attach`] and [`AttachTo`] support.
+    #[test]
+    fn test_attachment_pairs() {
+        const PARENT_MODEL: &str = r#"
+            <mujoco>
+                <worldbody>
+                    <body name="parent_body"/>
+                    <frame name="parent_frame"/>
+                    <site name="parent_site"/>
+                </worldbody>
+            </mujoco>
+        "#;
+
+        const CHILD_MODEL: &str = r#"
+            <mujoco>
+                <worldbody>
+                    <frame name="child_frame">
+                        <body name="child_body">
+                            <geom size="5" name="child_geom"/>
+                        </body>
+                    </frame>
+                </worldbody>
+            </mujoco>
+        "#;
+
+        // Compiles the parent and checks that the child subtree arrived once, under the new names.
+        #[track_caller]
+        fn assert_attached(parent: &mut MjSpec) {
+            assert!(parent.geom("p_child_geom_s").is_some(), "the geom is not namespaced");
+            let model = parent.compile().expect("cannot compile the attached spec");
+            assert_eq!((model.nbody(), model.ngeom()), (3, 1), "wrong element counts");
+        }
+
+        // A fresh pair for every attachment, as an attachment changes both specs.
+        let specs = || (
+            MjSpec::from_xml_string(PARENT_MODEL).unwrap(),
+            MjSpec::from_xml_string(CHILD_MODEL).unwrap()
+        );
+
+        /* A body as the child. */
+        let (mut parent, mut child) = specs();
+        parent.frame_mut("parent_frame").unwrap()
+            .attach(child.body_mut("child_body").unwrap(), "p_", "_s").unwrap();
+        assert_attached(&mut parent);
+
+        let (mut parent, mut child) = specs();
+        parent.site_mut("parent_site").unwrap()
+            .attach(child.body_mut("child_body").unwrap(), "p_", "_s").unwrap();
+        assert_attached(&mut parent);
+
+        /* A frame as the child. */
+        let (mut parent, mut child) = specs();
+        parent.body_mut("parent_body").unwrap()
+            .attach(child.frame_mut("child_frame").unwrap(), "p_", "_s").unwrap();
+        assert_attached(&mut parent);
+
+        let (mut parent, mut child) = specs();
+        parent.frame_mut("parent_frame").unwrap()
+            .attach(child.frame_mut("child_frame").unwrap(), "p_", "_s").unwrap();
+        assert_attached(&mut parent);
+
+        let (mut parent, mut child) = specs();
+        parent.site_mut("parent_site").unwrap()
+            .attach(child.frame_mut("child_frame").unwrap(), "p_", "_s").unwrap();
+        assert_attached(&mut parent);
+
+        /* A whole specification as the child. */
+        let (mut parent, mut child) = specs();
+        parent.body_mut("parent_body").unwrap().attach(&mut child, "p_", "_s").unwrap();
+        assert_attached(&mut parent);
+
+        let (mut parent, mut child) = specs();
+        parent.frame_mut("parent_frame").unwrap().attach(&mut child, "p_", "_s").unwrap();
+        assert_attached(&mut parent);
+
+        let (mut parent, mut child) = specs();
+        parent.site_mut("parent_site").unwrap().attach(&mut child, "p_", "_s").unwrap();
+        assert_attached(&mut parent);
+    }
 }
+

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -542,14 +542,6 @@ impl MjSpec {
             }
         }
     }
-
-    /// Configures deep-copy on or off during [`Attach::attach`].
-    /// Wraps [`mjs_setDeepCopy`].
-    pub fn set_deep_copy(&mut self, enable: bool) {
-        // SAFETY: This is inherently a always safe function as it only calls a boolean setter.
-        // Additionally,ffi_mut() is always valid.
-        unsafe { mjs_setDeepCopy(self.ffi_mut(), enable.into()) };
-    }
 }
 
 /// Children accessor methods.
@@ -4154,24 +4146,23 @@ mod tests {
 
         for prefix in ["", "attached_", "added"] {
             for suffix in ["", "_attached", "_added"] {
-                // The child spec must outlive the compilation, as the parent holds it until then.
                 let mut frame_spec = MjSpec::from_xml_string(BASE_MODEL).unwrap();
                 let mut main_spec = MjSpec::new();
                 let frame = frame_spec.frame_mut("base_frame_1").unwrap();
-                main_spec.world_body_mut().attach(frame, prefix, suffix).expect("attachment failed");
+                main_spec.world_body_mut().attach_by_deep_copy(frame, prefix, suffix).expect("attachment failed");
 
                 let renamed = |name: &str| format!("{prefix}{name}{suffix}");
 
-                // MuJoCo attaches by reference, thus it renames the elements of the child spec in
-                // place instead of copying them.
+                // Deep copy renames the copy that the parent holds, thus the child keeps its
+                // own names.
                 assert!(
-                    frame_spec.geom(&renamed("base_frame_1_body_1_sphere")).is_some(),
-                    "the child spec kept the old name"
+                    frame_spec.geom("base_frame_1_body_1_sphere").is_some(),
+                    "the child spec lost its own name"
                 );
                 assert_eq!(
-                    frame_spec.geom("base_frame_1_body_1_sphere").is_some(),
+                    frame_spec.geom(&renamed("base_frame_1_body_1_sphere")).is_some(),
                     prefix.is_empty() && suffix.is_empty(),
-                    "the old name survived in the child spec"
+                    "the renamed element appeared in the child spec"
                 );
 
                 main_spec.frame(&renamed("base_frame_1")).expect("frame not attached");
@@ -4236,41 +4227,41 @@ mod tests {
         /* A body as the child. */
         let (mut parent, mut child) = specs();
         parent.frame_mut("parent_frame").unwrap()
-            .attach(child.body_mut("child_body").unwrap(), "p_", "_s").unwrap();
+            .attach_by_deep_copy(child.body_mut("child_body").unwrap(), "p_", "_s").unwrap();
         assert_attached(&mut parent);
 
         let (mut parent, mut child) = specs();
         parent.site_mut("parent_site").unwrap()
-            .attach(child.body_mut("child_body").unwrap(), "p_", "_s").unwrap();
+            .attach_by_deep_copy(child.body_mut("child_body").unwrap(), "p_", "_s").unwrap();
         assert_attached(&mut parent);
 
         /* A frame as the child. */
         let (mut parent, mut child) = specs();
         parent.body_mut("parent_body").unwrap()
-            .attach(child.frame_mut("child_frame").unwrap(), "p_", "_s").unwrap();
+            .attach_by_deep_copy(child.frame_mut("child_frame").unwrap(), "p_", "_s").unwrap();
         assert_attached(&mut parent);
 
         let (mut parent, mut child) = specs();
         parent.frame_mut("parent_frame").unwrap()
-            .attach(child.frame_mut("child_frame").unwrap(), "p_", "_s").unwrap();
+            .attach_by_deep_copy(child.frame_mut("child_frame").unwrap(), "p_", "_s").unwrap();
         assert_attached(&mut parent);
 
         let (mut parent, mut child) = specs();
         parent.site_mut("parent_site").unwrap()
-            .attach(child.frame_mut("child_frame").unwrap(), "p_", "_s").unwrap();
+            .attach_by_deep_copy(child.frame_mut("child_frame").unwrap(), "p_", "_s").unwrap();
         assert_attached(&mut parent);
 
         /* A whole specification as the child. */
         let (mut parent, mut child) = specs();
-        parent.body_mut("parent_body").unwrap().attach(&mut child, "p_", "_s").unwrap();
+        parent.body_mut("parent_body").unwrap().attach_by_deep_copy(&mut child, "p_", "_s").unwrap();
         assert_attached(&mut parent);
 
         let (mut parent, mut child) = specs();
-        parent.frame_mut("parent_frame").unwrap().attach(&mut child, "p_", "_s").unwrap();
+        parent.frame_mut("parent_frame").unwrap().attach_by_deep_copy(&mut child, "p_", "_s").unwrap();
         assert_attached(&mut parent);
 
         let (mut parent, mut child) = specs();
-        parent.site_mut("parent_site").unwrap().attach(&mut child, "p_", "_s").unwrap();
+        parent.site_mut("parent_site").unwrap().attach_by_deep_copy(&mut child, "p_", "_s").unwrap();
         assert_attached(&mut parent);
     }
 
@@ -4280,9 +4271,11 @@ mod tests {
         // Deep attach off.
         let mut child_spec = MjSpec::new();
         let mut parent_spec = MjSpec::new();
-
-        parent_spec.world_body_mut().add_frame()
-            .attach(&mut child_spec, "", "").unwrap();
+        // SAFETY: the test takes no element handle of the child after the attachment.
+        unsafe {
+            parent_spec.world_body_mut().add_frame()
+                .attach_by_reference(&mut child_spec, "", "")
+        }.unwrap();
 
         // Should error with attached reference errors
         let result = child_spec.compile().unwrap_err();
@@ -4294,15 +4287,14 @@ mod tests {
         // Should compile regulary, both parent and attached child.
         parent_spec.compile().unwrap();
 
-        // Drop old parent and create new parent.
-        parent_spec.set_deep_copy(true);
+        // A fresh pair, which keeps the deep copy that a new specification enables.
+        let mut new_parent_spec = MjSpec::new();
         let mut new_child_spec = MjSpec::new();
-        parent_spec.world_body_mut().attach(&mut new_child_spec, "", "").unwrap();
+        new_parent_spec.world_body_mut().attach_by_deep_copy(&mut new_child_spec, "", "").unwrap();
         assert!(
             new_child_spec.compile().is_ok(),
             "child spec should not be attached by reference when deep-copy is enabled"
         );
-        parent_spec.compile().unwrap();
+        new_parent_spec.compile().unwrap();
     }
 }
-

--- a/src/wrappers/mj_editing.rs
+++ b/src/wrappers/mj_editing.rs
@@ -542,6 +542,14 @@ impl MjSpec {
             }
         }
     }
+
+    /// Configures deep-copy on or off during [`Attach::attach`].
+    /// Wraps [`mjs_setDeepCopy`].
+    pub fn set_deep_copy(&mut self, enable: bool) {
+        // SAFETY: This is inherently a always safe function as it only calls a boolean setter.
+        // Additionally,ffi_mut() is always valid.
+        unsafe { mjs_setDeepCopy(self.ffi_mut(), enable.into()) };
+    }
 }
 
 /// Children accessor methods.
@@ -4264,6 +4272,37 @@ mod tests {
         let (mut parent, mut child) = specs();
         parent.site_mut("parent_site").unwrap().attach(&mut child, "p_", "_s").unwrap();
         assert_attached(&mut parent);
+    }
+
+    /// Tests whether deep-copy works during attachment.
+    #[test]
+    fn test_deep_copy_attach() {
+        // Deep attach off.
+        let mut child_spec = MjSpec::new();
+        let mut parent_spec = MjSpec::new();
+
+        parent_spec.world_body_mut().add_frame()
+            .attach(&mut child_spec, "", "").unwrap();
+
+        // Should error with attached reference errors
+        let result = child_spec.compile().unwrap_err();
+        assert!(
+            matches!(result, MjEditError::CompileFailed(e) if e.contains("attached by reference")),
+            "a child attached by reference compiled without reference, which is wrong as the parent shares the references"
+        );
+
+        // Should compile regulary, both parent and attached child.
+        parent_spec.compile().unwrap();
+
+        // Drop old parent and create new parent.
+        parent_spec.set_deep_copy(true);
+        let mut new_child_spec = MjSpec::new();
+        parent_spec.world_body_mut().attach(&mut new_child_spec, "", "").unwrap();
+        assert!(
+            new_child_spec.compile().is_ok(),
+            "child spec should not be attached by reference when deep-copy is enabled"
+        );
+        parent_spec.compile().unwrap();
     }
 }
 

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -4,11 +4,13 @@ use std::ffi::CString;
 use crate::error::MjEditError;
 use crate::mujoco_c::*;
 
+use super::{MjSpec, MjsBody, MjsFrame, MjsSite};
 use super::default::MjsDefault;
 use super::utility::*;
 
 pub(crate) mod sealed {
-    /// Prevents external implementations of [`SpecItem`](super::SpecItem).
+    /// Prevents external implementations of [`SpecItem`](super::SpecItem) and
+    /// [`AttachTo`](super::AttachTo).
     pub trait Sealed {}
 }
 
@@ -158,3 +160,111 @@ pub trait SpecObject: SpecItem {
         unsafe { delete_element(self.element_mut_pointer()) }
     }
 }
+
+/// A child that [`mjs_attach`] accepts for a parent of type `P`.
+/// # Interpretation
+/// This can be interpreted/read as the following example shows:
+/// 
+/// `impl AttachTo<MjsFrame> for MjsBody` means a [`MjsBody`] can be attached
+/// as a child to [`MjsFrame`]. 
+///
+/// # Supported attachments
+/// | Child | Parent `P` | [`Output`](AttachTo::Output) |
+/// |---|---|---|
+/// | [`MjsBody`] | [`MjsFrame`], [`MjsSite`] | [`MjsBody`] |
+/// | [`MjsFrame`] | [`MjsBody`], [`MjsFrame`], [`MjsSite`] | [`MjsFrame`] |
+/// | [`MjSpec`] | [`MjsBody`], [`MjsFrame`], [`MjsSite`] | [`MjsFrame`] |
+/// 
+pub trait AttachTo<P>: sealed::Sealed {
+    /// Returns the `mjsElement` that MuJoCo attaches to the parent.
+    fn child_element_pointer(&self) -> *const mjsElement;
+}
+
+// A specification is no `SpecItem`, so it carries its own seal for this trait.
+impl sealed::Sealed for MjSpec {}
+
+impl AttachTo<MjsFrame> for MjsBody {
+    fn child_element_pointer(&self) -> *const mjsElement {
+        self.element_pointer()
+    }
+}
+
+impl AttachTo<MjsSite> for MjsBody {
+    fn child_element_pointer(&self) -> *const mjsElement {
+        self.element_pointer()
+    }
+}
+
+impl AttachTo<MjsBody> for MjsFrame {
+    fn child_element_pointer(&self) -> *const mjsElement {
+        self.element_pointer()
+    }
+}
+
+impl AttachTo<MjsFrame> for MjsFrame {
+    fn child_element_pointer(&self) -> *const mjsElement {
+        self.element_pointer()
+    }
+}
+
+impl AttachTo<MjsSite> for MjsFrame {
+    fn child_element_pointer(&self) -> *const mjsElement {
+        self.element_pointer()
+    }
+}
+
+impl AttachTo<MjsBody> for MjSpec {
+    fn child_element_pointer(&self) -> *const mjsElement {
+        self.ffi().element.cast_const()
+    }
+}
+
+impl AttachTo<MjsFrame> for MjSpec {
+    fn child_element_pointer(&self) -> *const mjsElement {
+        self.ffi().element.cast_const()
+    }
+}
+
+impl AttachTo<MjsSite> for MjSpec {
+    fn child_element_pointer(&self) -> *const mjsElement {
+        self.ffi().element.cast_const()
+    }
+}
+
+/// A parent that [`mjs_attach`] accepts.
+/// The trait is sealed (cannot be implemented by the user).
+///
+/// The [`AttachTo`] trait (also sealed) is used for providing
+/// supported attachment combinations.
+pub trait Attach: SpecItem {
+    /// Attaches the `child` to [`Self`].
+    /// 
+    /// # Panics
+    /// Panics when `prefix` or `suffix` contain NULL bytes.
+    fn attach<C>(&mut self, child: &mut C, prefix: &str, suffix: &str) -> Result<(), MjEditError>
+        where C: AttachTo<Self>
+    {
+        let c_prefix = CString::new(prefix).unwrap();  // panics on interior NUL bytes only.
+        let c_suffix = CString::new(suffix).unwrap();
+        // MuJoCo writes the namespace into the child before it copies the subtree, so the
+        // child is borrowed uniquely even though the C parameter is const.
+        let child_element = child.child_element_pointer();
+
+        // SAFETY: both elements belong to a live spec, the two strings outlive the call,
+        // and the trait implementations of AttachTo are properly implemented.
+        let element = unsafe { mjs_attach(
+            self.element_mut_pointer(), child_element,
+            c_prefix.as_ptr(), c_suffix.as_ptr()
+        ) };
+
+        if element.is_null() {
+            let spec = unsafe { mjs_getSpec(self.element_pointer()) };
+            return Err(MjEditError::AttachFailed(unsafe { read_spec_error(spec) }));
+        }
+        Ok(())
+    }
+}
+
+impl Attach for MjsBody {}
+impl Attach for MjsFrame {}
+impl Attach for MjsSite {}

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -169,11 +169,11 @@ pub trait SpecObject: SpecItem {
 /// as a child to [`MjsFrame`]. 
 ///
 /// # Supported attachments
-/// | Child | Parent `P` | [`Output`](AttachTo::Output) |
-/// |---|---|---|
-/// | [`MjsBody`] | [`MjsFrame`], [`MjsSite`] | [`MjsBody`] |
-/// | [`MjsFrame`] | [`MjsBody`], [`MjsFrame`], [`MjsSite`] | [`MjsFrame`] |
-/// | [`MjSpec`] | [`MjsBody`], [`MjsFrame`], [`MjsSite`] | [`MjsFrame`] |
+/// | Child | Parent `P` |
+/// |---|---|
+/// | [`MjsBody`] | [`MjsFrame`], [`MjsSite`] |
+/// | [`MjsFrame`] | [`MjsBody`], [`MjsFrame`], [`MjsSite`] |
+/// | [`MjSpec`] | [`MjsBody`], [`MjsFrame`], [`MjsSite`] |
 /// 
 pub trait AttachTo<P>: sealed::Sealed {
     /// Returns the `mjsElement` that MuJoCo attaches to the parent.

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -241,13 +241,24 @@ pub trait Attach: SpecItem {
     /// 
     /// # Panics
     /// Panics when `prefix` or `suffix` contain NULL bytes.
+    ///
+    /// # Examples
+    /// ```
+    /// # use mujoco_rs::prelude::*;
+    /// let mut child = MjSpec::new();
+    /// child.world_body_mut().add_body().with_name("ball");
+    ///
+    /// let mut parent = MjSpec::new();
+    /// parent.world_body_mut().attach(&mut child, "robot_", "").unwrap();
+    /// assert!(parent.body("robot_ball").is_some());
+    /// ```
     fn attach<C>(&mut self, child: &mut C, prefix: &str, suffix: &str) -> Result<(), MjEditError>
         where C: AttachTo<Self>
     {
         let c_prefix = CString::new(prefix).unwrap();  // panics on interior NUL bytes only.
         let c_suffix = CString::new(suffix).unwrap();
-        // MuJoCo writes the namespace into the child before it copies the subtree, so the
-        // child is borrowed uniquely even though the C parameter is const.
+
+        // NOTE: The const on the C parameter is wrong/misleading as mjs_attach can modify it internally regardless.
         let child_element = child.child_element_pointer();
 
         // SAFETY: both elements belong to a live spec, the two strings outlive the call,

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -162,11 +162,6 @@ pub trait SpecObject: SpecItem {
 }
 
 /// A child that [`mjs_attach`] accepts for a parent of type `P`.
-/// # Interpretation
-/// This can be interpreted/read as the following example shows:
-/// 
-/// `impl AttachTo<MjsFrame> for MjsBody` means a [`MjsBody`] can be attached
-/// as a child to [`MjsFrame`]. 
 ///
 /// # Supported attachments
 /// | Child | Parent `P` |
@@ -174,7 +169,6 @@ pub trait SpecObject: SpecItem {
 /// | [`MjsBody`] | [`MjsFrame`], [`MjsSite`] |
 /// | [`MjsFrame`] | [`MjsBody`], [`MjsFrame`], [`MjsSite`] |
 /// | [`MjSpec`] | [`MjsBody`], [`MjsFrame`], [`MjsSite`] |
-/// 
 pub trait AttachTo<P>: sealed::Sealed {
     /// Returns the `mjsElement` that MuJoCo attaches to the parent. The pointer is mutable,
     /// because [`mjs_attach`] renames and reparents the child that it receives.
@@ -238,7 +232,7 @@ impl AttachTo<MjsSite> for MjSpec {
 /// The [`AttachTo`] trait (also sealed) is used for providing
 /// supported attachment combinations.
 pub trait Attach: SpecItem {
-    /// Attaches a **deep-copy** of the `child` to `Self`.
+    /// Attaches a **deep-copy** of the `child` to `Self`. Wraps [`mjs_attach`].
     /// For faster attachments, call [`Attach::attach_by_reference`], which is
     /// MuJoCo's default behavior. However, the latter requires `unsafe` due to
     /// possible UBs it allows.
@@ -247,7 +241,7 @@ pub trait Attach: SpecItem {
     /// MuJoCo mutates the `child` even with deep-copying enabled.
     /// When the child is a [`MjSpec`], it will create a new [`MjsFrame`] in its world body
     /// on every attachment, to which all the sub-elements of `child` will be copied.
-    /// 
+    ///
     /// # Errors
     /// Returns [`MjEditError::AttachFailed`] when MuJoCo rejects the attachment.
     ///
@@ -276,16 +270,16 @@ pub trait Attach: SpecItem {
         }
     }
 
-    /// Attaches the `child` to `Self` by reference.
+    /// Attaches the `child` to `Self` by reference. Wraps [`mjs_attach`].
     /// Attachment-by-reference is the default behavior in MuJoCo (C library).
-    /// 
+    ///
     /// # Safety
     /// This method is safe as long as the following conditions are met:
     /// - no element of the [`MjSpec`] in which the `child` lives is used anymore,
-    /// including the elements outside the attached subtree;
+    ///   including the elements outside the attached subtree;
     /// - no further element of that [`MjSpec`] is attached anywhere;
     /// - no existing references to the child (or other tree elements of child's [`MjSpec`])
-    ///   can be used further. 
+    ///   can be used further.
     ///
     /// # Note
     /// An attachment that returns an error still marks the `child` specification as attached, thus

--- a/src/wrappers/mj_editing/traits.rs
+++ b/src/wrappers/mj_editing/traits.rs
@@ -176,58 +176,59 @@ pub trait SpecObject: SpecItem {
 /// | [`MjSpec`] | [`MjsBody`], [`MjsFrame`], [`MjsSite`] |
 /// 
 pub trait AttachTo<P>: sealed::Sealed {
-    /// Returns the `mjsElement` that MuJoCo attaches to the parent.
-    fn child_element_pointer(&self) -> *const mjsElement;
+    /// Returns the `mjsElement` that MuJoCo attaches to the parent. The pointer is mutable,
+    /// because [`mjs_attach`] renames and reparents the child that it receives.
+    fn child_element_mut_pointer(&mut self) -> *mut mjsElement;
 }
 
 // A specification is no `SpecItem`, so it carries its own seal for this trait.
 impl sealed::Sealed for MjSpec {}
 
 impl AttachTo<MjsFrame> for MjsBody {
-    fn child_element_pointer(&self) -> *const mjsElement {
-        self.element_pointer()
+    fn child_element_mut_pointer(&mut self) -> *mut mjsElement {
+        self.element_mut_pointer()
     }
 }
 
 impl AttachTo<MjsSite> for MjsBody {
-    fn child_element_pointer(&self) -> *const mjsElement {
-        self.element_pointer()
+    fn child_element_mut_pointer(&mut self) -> *mut mjsElement {
+        self.element_mut_pointer()
     }
 }
 
 impl AttachTo<MjsBody> for MjsFrame {
-    fn child_element_pointer(&self) -> *const mjsElement {
-        self.element_pointer()
+    fn child_element_mut_pointer(&mut self) -> *mut mjsElement {
+        self.element_mut_pointer()
     }
 }
 
 impl AttachTo<MjsFrame> for MjsFrame {
-    fn child_element_pointer(&self) -> *const mjsElement {
-        self.element_pointer()
+    fn child_element_mut_pointer(&mut self) -> *mut mjsElement {
+        self.element_mut_pointer()
     }
 }
 
 impl AttachTo<MjsSite> for MjsFrame {
-    fn child_element_pointer(&self) -> *const mjsElement {
-        self.element_pointer()
+    fn child_element_mut_pointer(&mut self) -> *mut mjsElement {
+        self.element_mut_pointer()
     }
 }
 
 impl AttachTo<MjsBody> for MjSpec {
-    fn child_element_pointer(&self) -> *const mjsElement {
-        self.ffi().element.cast_const()
+    fn child_element_mut_pointer(&mut self) -> *mut mjsElement {
+        self.ffi().element
     }
 }
 
 impl AttachTo<MjsFrame> for MjSpec {
-    fn child_element_pointer(&self) -> *const mjsElement {
-        self.ffi().element.cast_const()
+    fn child_element_mut_pointer(&mut self) -> *mut mjsElement {
+        self.ffi().element
     }
 }
 
 impl AttachTo<MjsSite> for MjSpec {
-    fn child_element_pointer(&self) -> *const mjsElement {
-        self.ffi().element.cast_const()
+    fn child_element_mut_pointer(&mut self) -> *mut mjsElement {
+        self.ffi().element
     }
 }
 
@@ -237,8 +238,19 @@ impl AttachTo<MjsSite> for MjSpec {
 /// The [`AttachTo`] trait (also sealed) is used for providing
 /// supported attachment combinations.
 pub trait Attach: SpecItem {
-    /// Attaches the `child` to [`Self`].
+    /// Attaches a **deep-copy** of the `child` to `Self`.
+    /// For faster attachments, call [`Attach::attach_by_reference`], which is
+    /// MuJoCo's default behavior. However, the latter requires `unsafe` due to
+    /// possible UBs it allows.
+    ///
+    /// # Note
+    /// MuJoCo mutates the `child` even with deep-copying enabled.
+    /// When the child is a [`MjSpec`], it will create a new [`MjsFrame`] in its world body
+    /// on every attachment, to which all the sub-elements of `child` will be copied.
     /// 
+    /// # Errors
+    /// Returns [`MjEditError::AttachFailed`] when MuJoCo rejects the attachment.
+    ///
     /// # Panics
     /// Panics when `prefix` or `suffix` contain NULL bytes.
     ///
@@ -249,33 +261,104 @@ pub trait Attach: SpecItem {
     /// child.world_body_mut().add_body().with_name("ball");
     ///
     /// let mut parent = MjSpec::new();
-    /// parent.world_body_mut().attach(&mut child, "robot_", "").unwrap();
+    /// parent.world_body_mut().attach_by_deep_copy(&mut child, "robot_", "").unwrap();
     /// assert!(parent.body("robot_ball").is_some());
     /// ```
-    fn attach<C>(&mut self, child: &mut C, prefix: &str, suffix: &str) -> Result<(), MjEditError>
+    fn attach_by_deep_copy<C>(&mut self, child: &mut C, prefix: &str, suffix: &str)
+        -> Result<(), MjEditError>
         where C: AttachTo<Self>
     {
-        let c_prefix = CString::new(prefix).unwrap();  // panics on interior NUL bytes only.
-        let c_suffix = CString::new(suffix).unwrap();
-
-        // NOTE: The const on the C parameter is wrong/misleading as mjs_attach can modify it internally regardless.
-        let child_element = child.child_element_pointer();
-
-        // SAFETY: both elements belong to a live spec, the two strings outlive the call,
-        // and the trait implementations of AttachTo are properly implemented.
-        let element = unsafe { mjs_attach(
-            self.element_mut_pointer(), child_element,
-            c_prefix.as_ptr(), c_suffix.as_ptr()
-        ) };
-
-        if element.is_null() {
-            let spec = unsafe { mjs_getSpec(self.element_pointer()) };
-            return Err(MjEditError::AttachFailed(unsafe { read_spec_error(spec) }));
+        // SAFETY: all pointers are valid always.
+        unsafe {
+            attach_element(
+                self.element_mut_pointer(), child.child_element_mut_pointer(), prefix, suffix, true
+            )
         }
-        Ok(())
+    }
+
+    /// Attaches the `child` to `Self` by reference.
+    /// Attachment-by-reference is the default behavior in MuJoCo (C library).
+    /// 
+    /// # Safety
+    /// This method is safe as long as the following conditions are met:
+    /// - no element of the [`MjSpec`] in which the `child` lives is used anymore,
+    /// including the elements outside the attached subtree;
+    /// - no further element of that [`MjSpec`] is attached anywhere;
+    /// - no existing references to the child (or other tree elements of child's [`MjSpec`])
+    ///   can be used further. 
+    ///
+    /// # Note
+    /// An attachment that returns an error still marks the `child` specification as attached, thus
+    /// the conditions above hold also for a failed attachment.
+    ///
+    /// # Errors
+    /// Returns [`MjEditError::AttachFailed`] when MuJoCo rejects the attachment.
+    ///
+    /// # Panics
+    /// Panics when `prefix` or `suffix` contain NULL bytes.
+    ///
+    /// # Examples
+    /// ```
+    /// # use mujoco_rs::prelude::*;
+    /// let mut child = MjSpec::new();
+    /// child.world_body_mut().add_body().with_name("ball");
+    ///
+    /// let mut parent = MjSpec::new();
+    /// // SAFETY: no element handle of the child is used after the attachment.
+    /// unsafe { parent.world_body_mut().attach_by_reference(&mut child, "robot_", "") }.unwrap();
+    /// assert!(parent.body("robot_ball").is_some());
+    /// ```
+    unsafe fn attach_by_reference<C>(&mut self, child: &mut C, prefix: &str, suffix: &str)
+        -> Result<(), MjEditError>
+        where C: AttachTo<Self>
+    {
+        // SAFETY: the parent element is live, AttachTo permits the pair, and the caller keeps
+        // every handle of the child unused.
+        unsafe {
+            attach_element(
+                self.element_mut_pointer(), child.child_element_mut_pointer(), prefix, suffix, false
+            )
+        }
     }
 }
 
 impl Attach for MjsBody {}
 impl Attach for MjsFrame {}
 impl Attach for MjsSite {}
+
+/// Attaches the `child` element to the `parent` element. `deep_copy` selects whether the parent
+/// deep-copies the elements of the child or "copies" by-reference.
+/// Wraps [`mjs_attach`].
+///
+/// # Errors
+/// Returns [`MjEditError::AttachFailed`] when MuJoCo rejects the attachment.
+///
+/// # Panics
+/// Panics when `prefix` or `suffix` contain NULL bytes.
+///
+/// # Safety
+/// Both pointers must stand at a live element of a specification.
+/// With `deep_copy` false, the parent shares the elements of the child.
+unsafe fn attach_element(
+    parent: *mut mjsElement, child: *mut mjsElement,
+    prefix: &str, suffix: &str, deep_copy: bool
+) -> Result<(), MjEditError>
+{
+    let c_prefix = CString::new(prefix).unwrap();  // panics on interior NUL bytes only.
+    let c_suffix = CString::new(suffix).unwrap();
+
+    // SAFETY: the caller guarantees a live parent element, which belongs to a live specification.
+    let spec = unsafe { mjs_getSpec(parent) };
+    // MuJoCo keeps the flag on the parent, so every attachment sets the value that it needs.
+    unsafe { mjs_setDeepCopy(spec, deep_copy.into()) };
+
+    // The const on the C child parameter is misleading, because mjs_attach renames and reparents
+    // the child regardless, so the pointer that reaches here is mutable.
+    // SAFETY: both elements stand at a live specification and the two strings outlive the call.
+    let element = unsafe { mjs_attach(parent, child, c_prefix.as_ptr(), c_suffix.as_ptr()) };
+    if element.is_null() {
+        // SAFETY: spec stands at the live specification of the parent.
+        return Err(MjEditError::AttachFailed(unsafe { read_spec_error(spec) }));
+    }
+    Ok(())
+}

--- a/src/wrappers/mj_editing/utility.rs
+++ b/src/wrappers/mj_editing/utility.rs
@@ -188,18 +188,23 @@ pub(crate) unsafe fn delete_element(element: *mut mjsElement) -> Result<(), MjEd
 
     match unsafe { mjs_delete(spec, element) } {
         0 => Ok(()),
-        _ => {
-            // SAFETY: the message belongs to the spec and lives until the next call on it.
-            let error_msg = unsafe {
-                let ptr = mjs_getError(spec);
-                if ptr.is_null() {
-                    "Unknown error".to_owned()
-                } else {
-                    CStr::from_ptr(ptr).to_string_lossy().into_owned()
-                }
-            };
-            Err(MjEditError::DeleteFailed(error_msg))
-        }
+        // SAFETY: the spec stays live after a refused deletion.
+        _ => Err(MjEditError::DeleteFailed(unsafe { read_spec_error(spec) })),
+    }
+}
+
+
+/// Reads the last error message that `spec` recorded, or a placeholder when it holds none.
+///
+/// # Safety
+/// `spec` must address a live specification.
+pub(crate) unsafe fn read_spec_error(spec: *mut mjSpec) -> String {
+    // SAFETY: the message belongs to the spec and lives until the next call on it.
+    let ptr = unsafe { mjs_getError(spec) };
+    if ptr.is_null() {
+        "Unknown error".to_owned()
+    } else {
+        unsafe { CStr::from_ptr(ptr) }.to_string_lossy().into_owned()
     }
 }
 


### PR DESCRIPTION
Implement wrappers around `mjs_attach` and thus creating type-safe and idiomatic options for attaching model elements.