### PR TITLE
Fix macOS visualization context selection

### DIFF
--- a/src/winit_gl_base.rs
+++ b/src/winit_gl_base.rs
@@ -93,6 +93,9 @@ impl ApplicationHandler for RenderBase {
                 .with_alpha_size(0)
                 .with_depth_size(24)
                 .with_stencil_size(8);
+            #[cfg(target_os = "macos")]
+            // MuJoCo's OpenGL 2.0 compatibility context cannot use a core-only CGL profile.
+            let template = template.skip_cgl_profile(true);
 
             let display_builder = DisplayBuilder::new()
                 .with_preference(ApiPreference::FallbackEgl)
@@ -177,4 +180,3 @@ impl ApplicationHandler for RenderBase {
         }
     }
 }
-


### PR DESCRIPTION
## Summary

- request a legacy CGL pixel format on macOS when using the documented glutin patch
- keep the selected pixel format compatible with the OpenGL 2.0 compatibility context requested immediately afterward

This is a focused fix for part of #100. It does not remove the documented glutin dependency patch, and it does not address the separate mouse-release behavior reported in that issue.

## Problem

With the documented glutin revision, config discovery still tries macOS core profiles before the legacy profile. The config picker accepts the first available core-profile pixel format, then mujoco-rs requests an OpenGL 2.0 compatibility context. MuJoCo initialization subsequently exits with:

    OpenGL ARB_framebuffer_object required

Setting skip_cgl_profile(true) makes the patched glutin implementation select the legacy pixel format that matches the requested compatibility context.

## Validation

Tested on an Apple M3 Pro running macOS 26.6.2 with MuJoCo 3.12.0 and the glutin revision already documented by mujoco-rs.

- the viewer feature rendered a minimal MJCF successfully
- the viewer feature rendered a 16-geom articulated model for 120 frames to 2.040 seconds of simulated time
- without this change, both cases terminate during MuJoCo OpenGL initialization

The viewer-ui feature can render after this fix, but egui_glow emits FRAMEBUFFER_SRGB errors under the legacy context. That is separate from the MuJoCo context-selection failure fixed here.