### PR TITLE
Fix segmentation fault with flexes; Update outdated OpenGL logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ unnecessary_lazy_evaluations = "allow"
 
 [package]
 name = "mujoco-rs"
-version = "6.0.0+mj-3.12.0"
+version = "6.0.1+mj-3.12.0"
 edition = "2024"
 license.workspace = true
 description = "A high-level Rust wrapper around the MuJoCo C library, with a native viewer (re-)written in Rust."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MuJoCo-rs
 [![Guide](https://img.shields.io/badge/Guide-book-white)](https://mujoco-rs.readthedocs.io/en/v6.0.x/)
-[![docs.rs](https://img.shields.io/docsrs/mujoco-rs/6.0.0)](https://docs.rs/mujoco-rs/6.0.0/mujoco_rs/)
+[![docs.rs](https://img.shields.io/docsrs/mujoco-rs/6.0.1)](https://docs.rs/mujoco-rs/6.0.1/mujoco_rs/)
 [![CI](https://img.shields.io/github/actions/workflow/status/davidhozic/mujoco-rs/tests.yml?label=CI)](https://github.com/davidhozic/mujoco-rs/actions)
 [![Crates.io](https://img.shields.io/crates/v/mujoco-rs.svg)](https://crates.io/crates/mujoco-rs)
 
@@ -16,7 +16,7 @@ bindings to a modified C++ one.
 
 ## Documentation
 More detailed documentation is available at the:
-- [**API docs**](https://docs.rs/mujoco-rs/6.0.0/mujoco_rs/)
+- [**API docs**](https://docs.rs/mujoco-rs/6.0.1/mujoco_rs/)
 - [**Guide book**](https://mujoco-rs.readthedocs.io/en/v6.0.x/)
 
 ## MuJoCo version

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ This example requires the ``viewer`` or the ``viewer-ui`` feature
 (``cargo add mujoco-rs --features viewer``).
 It launches the viewer and prints the coordinates
 of a moving ball to the terminal.
-Other examples can be found under the ``examples/`` directory.
+Other examples are available in the
+[``examples/``](https://github.com/davidhozic/mujoco-rs/tree/v6.0.x/examples) directory.
 
 ```rust
 //! Example of using views.

--- a/docs/guide/source/changelog/6.0.x.rst.inc
+++ b/docs/guide/source/changelog/6.0.x.rst.inc
@@ -1,3 +1,11 @@
+6.0.1 (MuJoCo 3.12.0)
+======================
+
+.. rubric:: Bug fixes
+
+- Fixed `#276 <https://github.com/davidhozic/mujoco-rs/issues/276>`_ where :ref:`mj_rust_viewer`
+  crashed with models containing a flex.
+
 6.0.0 (MuJoCo 3.12.0)
 ======================
 

--- a/docs/guide/source/changelog/6.0.x.rst.inc
+++ b/docs/guide/source/changelog/6.0.x.rst.inc
@@ -1,10 +1,26 @@
 6.0.1 (MuJoCo 3.12.0)
 ======================
 
+.. rubric:: New features and improvements
+
+- :docs-rs:`~~mujoco_rs::wrappers::mj_rendering::<struct>MjrContext::<method>set_window_doublebuffer`
+  :sup:`new` overrides the color-buffer choice that
+  :docs-rs:`~mujoco_rs::mujoco_c::<fn>mjr_makeContext` derives from ``GL_DOUBLEBUFFER``.
+
 .. rubric:: Bug fixes
 
 - Fixed `#276 <https://github.com/davidhozic/mujoco-rs/issues/276>`_ where :ref:`mj_rust_viewer`
   crashed with models containing a flex.
+- The :ref:`mj_rust_viewer` no longer raises a ``GL_INVALID_OPERATION`` on every frame, which
+  `egui <https://docs.rs/egui/0.36.1/egui/>`_ reported in a debug build. The viewer now takes the
+  color buffer of its window from `glutin <https://docs.rs/glutin/0.32.3/glutin/>`_ instead of
+  MuJoCo's own detection.
+
+.. rubric:: Other changes
+
+- The :gh-example:`Rust viewer <visualization/viewer/rust_viewer.rs>` and
+  :gh-example:`threaded Rust viewer <visualization/viewer/rust_viewer_threaded.rs>` examples now
+  show a ball that bounces on a trampoline.
 
 6.0.0 (MuJoCo 3.12.0)
 ======================

--- a/docs/guide/source/index.rst
+++ b/docs/guide/source/index.rst
@@ -3,8 +3,8 @@ MuJoCo-rs
 =======================
 
 
-.. image:: https://img.shields.io/docsrs/mujoco-rs/6.0.0
-    :target: https://docs.rs/mujoco-rs/6.0.0/mujoco_rs/
+.. image:: https://img.shields.io/docsrs/mujoco-rs/6.0.1
+    :target: https://docs.rs/mujoco-rs/6.0.1/mujoco_rs/
 
 
 .. image:: https://img.shields.io/crates/v/mujoco-rs.svg

--- a/docs/guide/source/programming/logging.rst
+++ b/docs/guide/source/programming/logging.rst
@@ -33,7 +33,7 @@ at the start of the program.
 
     Installing the hook, through either function, replaces MuJoCo's own handler, so the
     ``logto_console``, ``logto_file`` and ``logfile`` fields of
-    :docs-rs:`~mujoco_rs::wrappers::mj_logging::<struct>MjLogConfig` no longer reach the output.
+    :docs-rs:`~mujoco_rs::wrappers::mj_logging::<type>MjLogConfig` no longer reach the output.
     The install also writes every topic into the global topic bitmask once, so a bitmask that the
     program set before the install is lost. The producer-side topic gate still reads that bitmask,
     so a :docs-rs:`~mujoco_rs::wrappers::mj_logging::<fn>set_log_config` call after the install

--- a/examples/visualization/viewer/rust_viewer.rs
+++ b/examples/visualization/viewer/rust_viewer.rs
@@ -10,21 +10,6 @@ use mujoco_rs::prelude::*;
 use env_logger::Env;
 
 
-const EXAMPLE_MODEL: &str = stringify! {
-<mujoco>
-  <worldbody>
-    <light ambient="0.2 0.2 0.2" pos=".2 .2 .2"/>
-    <body name="ball">
-        <geom name="green_sphere" size=".1" rgba="0 1 0 1"/>
-        <joint name="sphere_joint" type="free"/>
-    </body>
-
-    <geom name="floor" type="plane" size="10 10 1" euler="5 0 0"/>
-
-  </worldbody>
-</mujoco>
-};
-
 fn main() {
     env_logger::Builder::from_env(Env::default().default_filter_or("info,mujoco::=off")).init();
     // (Optional) The hook sends MuJoCo's messages to the `log` crate, instead of the console.
@@ -79,3 +64,57 @@ fn main() {
         std::thread::sleep(Duration::from_secs_f64(timestep));
     }
 }
+
+
+const EXAMPLE_MODEL: &str = stringify! {
+<mujoco model="ball_trampoline">
+  <option solver="CG" integrator="implicitfast"/>
+
+  <statistic center="0 0 0.8" extent="2.2"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="140" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+             markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <default>
+    <default class="rail">
+      <geom type="capsule" size="0.035" rgba="0.2 0.2 0.22 1"/>
+    </default>
+  </default>
+
+  <worldbody>
+    <light pos="0 0 3" dir="0 0 -1" directional="true"/>
+    <geom name="floor" type="plane" size="0 0 0.05" material="groundplane"/>
+
+    <geom class="rail" fromto="-0.65 -0.65 0.6 0.65 -0.65 0.6"/>
+    <geom class="rail" fromto="-0.65 0.65 0.6 0.65 0.65 0.6"/>
+    <geom class="rail" fromto="-0.65 -0.65 0.6 -0.65 0.65 0.6"/>
+    <geom class="rail" fromto="0.65 -0.65 0.6 0.65 0.65 0.6"/>
+    <geom class="rail" fromto="-0.65 -0.65 0.6 -0.65 -0.65 0"/>
+    <geom class="rail" fromto="0.65 -0.65 0.6 0.65 -0.65 0"/>
+    <geom class="rail" fromto="-0.65 0.65 0.6 -0.65 0.65 0"/>
+    <geom class="rail" fromto="0.65 0.65 0.6 0.65 0.65 0"/>
+
+    <flexcomp name="mat" type="grid" count="13 13 1" spacing="0.1 0.1 0.1" pos="0 0 0.6"
+              radius="0.015" mass="2" dim="2" rgba="0.15 0.25 0.6 1">
+      <edge damping="3"/>
+      <elasticity young="1e7" thickness="1e-2" elastic2d="stretch"/>
+      <pin gridrange="0 0 12 0 0 12 12 12 0 0 0 12 12 0 12 12"/>
+    </flexcomp>
+
+    <body name="ball" pos="0 0 1.6">
+      <freejoint/>
+      <geom type="sphere" size="0.12" mass="1" rgba="0.9 0.45 0.15 1"/>
+    </body>
+  </worldbody>
+</mujoco>
+};

--- a/examples/visualization/viewer/rust_viewer_threaded.rs
+++ b/examples/visualization/viewer/rust_viewer_threaded.rs
@@ -7,21 +7,6 @@ use mujoco_rs::prelude::*;
 use env_logger::Env;
 
 
-const EXAMPLE_MODEL: &str = stringify! {
-<mujoco>
-  <worldbody>
-    <light ambient="0.2 0.2 0.2" pos=".2 .2 .2"/>
-    <body name="ball">
-        <geom name="green_sphere" size=".1" rgba="0 1 0 1"/>
-        <joint name="sphere_joint" type="free"/>
-    </body>
-
-    <geom name="floor" type="plane" size="10 10 1" euler="5 0 0"/>
-
-  </worldbody>
-</mujoco>
-};
-
 fn main() {
     env_logger::Builder::from_env(Env::default().default_filter_or("info,mujoco::=off")).init();
     // (Optional) The hook sends MuJoCo's messages to the `log` crate, instead of the console.
@@ -69,3 +54,57 @@ fn main() {
 
     physics_thread.join().unwrap();
 }
+
+
+const EXAMPLE_MODEL: &str = stringify! {
+<mujoco model="ball_trampoline">
+  <option solver="CG" integrator="implicitfast"/>
+
+  <statistic center="0 0 0.8" extent="2.2"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="140" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+             markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <default>
+    <default class="rail">
+      <geom type="capsule" size="0.035" rgba="0.2 0.2 0.22 1"/>
+    </default>
+  </default>
+
+  <worldbody>
+    <light pos="0 0 3" dir="0 0 -1" directional="true"/>
+    <geom name="floor" type="plane" size="0 0 0.05" material="groundplane"/>
+
+    <geom class="rail" fromto="-0.65 -0.65 0.6 0.65 -0.65 0.6"/>
+    <geom class="rail" fromto="-0.65 0.65 0.6 0.65 0.65 0.6"/>
+    <geom class="rail" fromto="-0.65 -0.65 0.6 -0.65 0.65 0.6"/>
+    <geom class="rail" fromto="0.65 -0.65 0.6 0.65 0.65 0.6"/>
+    <geom class="rail" fromto="-0.65 -0.65 0.6 -0.65 -0.65 0"/>
+    <geom class="rail" fromto="0.65 -0.65 0.6 0.65 -0.65 0"/>
+    <geom class="rail" fromto="-0.65 0.65 0.6 -0.65 0.65 0"/>
+    <geom class="rail" fromto="0.65 0.65 0.6 0.65 0.65 0"/>
+
+    <flexcomp name="mat" type="grid" count="13 13 1" spacing="0.1 0.1 0.1" pos="0 0 0.6"
+              radius="0.015" mass="2" dim="2" rgba="0.15 0.25 0.6 1">
+      <edge damping="3"/>
+      <elasticity young="1e7" thickness="1e-2" elastic2d="stretch"/>
+      <pin gridrange="0 0 12 0 0 12 12 12 0 0 0 12 12 0 12 12"/>
+    </flexcomp>
+
+    <body name="ball" pos="0 0 1.6">
+      <freejoint/>
+      <geom type="sphere" size="0.12" mass="1" rgba="0.9 0.45 0.15 1"/>
+    </body>
+  </worldbody>
+</mujoco>
+};

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -16,12 +16,12 @@ use winit::event::{ElementState, KeyEvent, Modifiers, MouseButton, MouseScrollDe
 #[cfg(feature = "viewer-ui")] use glutin::display::{GetGlDisplay, GlDisplay};
 #[cfg(feature = "viewer-ui")] use egui_glow::glow::{self, HasContext};
 use winit::platform::pump_events::EventLoopExtPumpEvents;
+use glutin::surface::{GlSurface, Surface, WindowSurface};
 use glutin::prelude::PossiblyCurrentGlContext;
 use winit::keyboard::{KeyCode, PhysicalKey};
 use log::{debug, error, info, warn};
 use winit::event_loop::EventLoop;
 use winit::dpi::PhysicalPosition;
-use glutin::surface::GlSurface;
 use winit::window::Fullscreen;
 use bitflags::bitflags;
 
@@ -1286,6 +1286,18 @@ impl MjViewer {
         self.fps_smooth += FPS_SMOOTHING_FACTOR * (fps - self.fps_smooth);
     }
 
+    /// Creates the render context for the window surface `gl_surface`.
+    ///
+    /// # Safety
+    /// The OpenGL context of `gl_surface` must be current.
+    unsafe fn make_render_context(model: &MjModel, gl_surface: &Surface<WindowSurface>) -> MjrContext {
+        // SAFETY: the caller guarantees the current OpenGL context.
+        let mut context = unsafe { MjrContext::new(model) };
+
+        context.set_window_doublebuffer(!gl_surface.is_single_buffered());
+        context
+    }
+
     /// Updates the scene and draws it to the display.
     fn update_scene(&mut self) -> Result<(), MjViewerError> {
         {
@@ -1312,8 +1324,9 @@ impl MjViewer {
                 self.camera = MjvCamera::new_free(new_model);
                 // Recreate the rendering context so that GPU resources (textures,
                 // meshes, heightfields, skins) match the new model.
+                let gl_surface = &self.adapter.state.as_ref().unwrap().gl_surface;
                 // SAFETY: the GL context was made current in render() before this call.
-                self.context = unsafe { MjrContext::new(new_model) };
+                self.context = unsafe { Self::make_render_context(new_model, gl_surface) };
                 self.ncam = new_model.ffi().ncam;
                 #[cfg(feature = "viewer-ui")]
                 self.ui.update_caches(new_model);
@@ -2030,7 +2043,7 @@ impl MjViewerBuilder {
         let ngeom = model.ffi().ngeom as usize;
         let scene = MjvScene::new(&*model, ngeom + self.max_user_geoms + EXTRA_SCENE_GEOM_SPACE);
         // SAFETY: The OpenGL context was made current above via gl_surface.
-        let context = unsafe { MjrContext::new(&model) };
+        let context = unsafe { MjViewer::make_render_context(&model, gl_surface) };
         let camera  = MjvCamera::new_free(&model);
 
         // Tracking of changes made between syncs

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -2,6 +2,7 @@
 //! see [`crate::cpp_viewer::MjViewerCpp`] (enabled by the `cpp-viewer` cargo feature).
 
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+#[cfg(feature = "viewer-ui")] use std::ffi::CString;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 use std::collections::BTreeSet;
@@ -12,7 +13,8 @@ use std::fmt::Display;
 use std::borrow::Cow;
 
 use winit::event::{ElementState, KeyEvent, Modifiers, MouseButton, MouseScrollDelta, WindowEvent};
-#[cfg(feature = "viewer-ui")] use glutin::display::GetGlDisplay;
+#[cfg(feature = "viewer-ui")] use glutin::display::{GetGlDisplay, GlDisplay};
+#[cfg(feature = "viewer-ui")] use egui_glow::glow::{self, HasContext};
 use winit::platform::pump_events::EventLoopExtPumpEvents;
 use glutin::prelude::PossiblyCurrentGlContext;
 use winit::keyboard::{KeyCode, PhysicalKey};
@@ -800,7 +802,11 @@ pub struct MjViewer {
 
     /// Pending screenshot request. [`Some`] with `(viewport_only, depth)` flags when a
     /// screenshot is queued; [`None`] otherwise.
-    screenshot_pending: Option<(bool, bool)>
+    screenshot_pending: Option<(bool, bool)>,
+
+    /// Proxy for controlling OpenGL directly.
+    #[cfg(feature = "viewer-ui")]
+    gl: Arc<egui_glow::glow::Context>,
 }
 
 impl MjViewer {
@@ -1110,11 +1116,19 @@ impl MjViewer {
         // Make sure everything is done on the viewer's window
         gl_context.make_current(gl_surface)?;
 
+        // Configure OpenGL to the expected settings by MuJoCo.
+        #[cfg(feature = "viewer-ui")]
+        self.init_mujoco_gl();
+
         // Read the screen size
         self.update_rectangles(self.adapter.state.as_ref().unwrap().window.inner_size().into());
 
         // Process mouse and keyboard events
         self.process_events();
+
+        // Build the user menu and process its internal events.
+        #[cfg(feature = "viewer-ui")]
+        self.process_user_ui();
 
         // Update the scene from data and render
         self.update_scene()?;
@@ -1127,12 +1141,12 @@ impl MjViewer {
             self.capture_screenshot(depth)?;
         }
 
-        // Draw the user menu on top
-        #[cfg(feature = "viewer-ui")]
-        self.process_user_ui();
-
         // Update the user menu state and overlays
         self.update_menus();
+
+        // Draw the user UI.
+        #[cfg(feature = "viewer-ui")]
+        self.ui.paint();
 
         // Full-window screenshot: capture after all rendering (UI + overlays).
         if let Some((false, _)) = self.screenshot_pending {
@@ -1142,6 +1156,22 @@ impl MjViewer {
 
         // Flush to the GPU
         self.swap_buffers()
+    }
+
+    /// Prepares MuJoCo OpenGL for rendering in MuJoCo 3D mode.
+    #[cfg(feature = "viewer-ui")]
+    fn init_mujoco_gl(&self) {
+        let gl = &self.gl;
+        // SAFETY: the GL context is current.
+        unsafe {
+            // Disable shaders
+            gl.use_program(None);
+
+            // Unbind buffers
+            gl.bind_vertex_array(None);
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, None);
+        }
     }
 
     /// Perform OpenGL buffer swap.
@@ -1414,16 +1444,13 @@ impl MjViewer {
         self.ui.with_egui_ctx(once_fn);
     }
 
-    /// Draws the user UI
+    /// Builds the user UI and processes its internally raised events.
     #[cfg(feature = "viewer-ui")]
     fn process_user_ui(&mut self) {
-        // Draw the user interface
-
         use crate::viewer::ui::UiEvent;
         let RenderBaseGlState {window, ..} = &self.adapter.state.as_ref().unwrap();
 
         let inner_size = window.inner_size();
-        self.ui.init_2d();
         let left = self.ui.process(
             window, &mut self.status,
             &mut self.scene, &mut self.opt,
@@ -1433,9 +1460,6 @@ impl MjViewer {
         // Adjust the viewport so MuJoCo doesn't draw over the UI
         self.rect_view.left = left as i32;
         self.rect_view.width = inner_size.width as i32;
-
-        // Reset some OpenGL settings so that MuJoCo can still draw
-        self.ui.reset();
 
         // Process events made in the user UI
         while let Some(event) = self.ui.drain_events() {
@@ -2013,9 +2037,21 @@ impl MjViewerBuilder {
         let shared_state = Arc::new(Mutex::new(ViewerSharedState::new(&*model, self.max_user_geoms)));
         let running_flag = shared_state.lock_unpoison().running.clone();
 
+        // OpenGL context proxy
+        #[cfg(feature = "viewer-ui")]
+        let display = gl_surface.display();
+        #[cfg(feature = "viewer-ui")]
+        let get_addr = |s: &str| display.get_proc_address(
+            &CString::new(s).unwrap()
+        );
+        // SAFETY: the glow::Context is constructed from a loader function backed by the
+        // current glutin Display, which provides valid OpenGL proc addresses.
+        #[cfg(feature = "viewer-ui")]
+        let gl = unsafe { Arc::new(glow::Context::from_loader_function(get_addr)) };
+
         // User interface
         #[cfg(feature = "viewer-ui")]
-        let ui = ui::ViewerUI::new(&model, window, &gl_surface.display())?;
+        let ui = ui::ViewerUI::new(&model, window, &gl)?;
         let mut status = cfg_select! {
             feature = "viewer-ui" => ViewerStatusBit::UI,
             _ => ViewerStatusBit::HELP,
@@ -2049,7 +2085,8 @@ impl MjViewerBuilder {
             raw_cursor_position: (0.0, 0.0),
             #[cfg(feature = "viewer-ui")] ui,
             status,
-            screenshot_pending: None
+            screenshot_pending: None,
+            #[cfg(feature = "viewer-ui")] gl,
         })
     }
 }

--- a/src/viewer/ui.rs
+++ b/src/viewer/ui.rs
@@ -4,11 +4,9 @@ use std::collections::VecDeque;
 use std::ops::RangeInclusive;
 use std::sync::{Arc, Mutex};
 use std::f64::consts::PI;
-use std::ffi::CString;
 use std::borrow::Cow;
 use std::fmt::Debug;
 
-use glutin::display::{Display, GlDisplay};
 use egui_winit::winit::event::WindowEvent;
 use egui_glow::glow::{self, HasContext};
 use egui::{FontId, RichText, LayerId, Order, Id};
@@ -270,6 +268,14 @@ struct JointDisplayInfo {
     quat: Option<JointQuatDisplayInfo>,
 }
 
+/// Processed egui data to be painted.
+struct PendingPaint {
+    primitives: Vec<egui::ClippedPrimitive>,
+    textures_delta: egui::TexturesDelta,
+    pixels_per_point: f32,
+    screen_size: [u32; 2],
+}
+
 /// Viewer user interface context.
 pub(crate) struct ViewerUI {
     egui_ctx: egui::Context,
@@ -277,6 +283,7 @@ pub(crate) struct ViewerUI {
     painter: egui_glow::Painter,
     gl: Arc<egui_glow::glow::Context>,
     events: VecDeque<UiEvent>,
+    pending_paint: Option<PendingPaint>,
     camera_names: Vec<String>,
     actuator_info: Vec<ActuatorDisplayInfo>,
     joint_info: Vec<JointDisplayInfo>,
@@ -302,7 +309,7 @@ pub(crate) struct ViewerUI {
 
 impl ViewerUI {
     /// Create a new [`ViewerUI`] instance for the specific winit window.
-    pub(crate) fn new(model: &MjModel, window: &Window, display: &Display) -> Result<Self, MjViewerError> {
+    pub(crate) fn new(model: &MjModel, window: &Window, gl: &Arc<glow::Context>) -> Result<Self, MjViewerError> {
         let egui_ctx = egui::Context::default();
         let viewport_id = egui_ctx.viewport_id();
 
@@ -310,13 +317,6 @@ impl ViewerUI {
             egui_ctx.clone(), viewport_id, &window,
             None, None, None
         );
-
-        let get_addr = |s: &str| display.get_proc_address(
-            &CString::new(s).unwrap()
-        );
-        // SAFETY: the glow::Context is constructed from a loader function backed by the
-        // current glutin Display, which provides valid OpenGL proc addresses.
-        let gl = unsafe { Arc::new(egui_glow::glow::Context::from_loader_function(get_addr)) };
 
         let painter = egui_glow::Painter::new(
             gl.clone(),
@@ -326,7 +326,8 @@ impl ViewerUI {
         ).map_err(|e| MjViewerError::PainterInitError(e.to_string()))?;
 
         let mut viewer_ui = Self {
-            egui_ctx, state, painter, gl, events: VecDeque::new(),
+            egui_ctx, state, painter, gl: gl.clone(), events: VecDeque::new(),
+            pending_paint: None,
             camera_names: Vec::new(),
             actuator_info: Vec::new(),
             joint_info: Vec::new(),
@@ -474,7 +475,7 @@ impl ViewerUI {
 
         // Process the UI
         let raw_input = self.state.take_egui_input(window);
-        let mut full_output = self.egui_ctx.run_ui(raw_input, |ui| {
+        let full_output = self.egui_ctx.run_ui(raw_input, |ui| {
             let mut is_expanded = status.contains(ViewerStatusBit::UI);
             egui::Panel::left("interface_panel")
                 .resizable(true)
@@ -1745,20 +1746,41 @@ impl ViewerUI {
         // Apply egui's platform output (cursor icon, clipboard, IME).
         self.state.handle_platform_output(window, full_output.platform_output);
 
-        // Tessellate
+        // Tessellate. The paint waits for MuJoCo to finish the frame; see `paint`.
         let pixels_per_point = full_output.pixels_per_point;
-        let textures_delta = &mut full_output.textures_delta;
-        let clipped_primitives = self.egui_ctx.tessellate(full_output.shapes, pixels_per_point);
+        let mut textures_delta = full_output.textures_delta;
 
-        // Paint the menu
-        self.painter.paint_and_update_textures(
-            window.inner_size().into(),
+        // A render attempt that ended early between the two calls leaves its own deltas behind. They carry
+        // upload and free history that egui expects.
+        if let Some(dropped) = self.pending_paint.take() {
+            let mut merged = dropped.textures_delta;
+            merged.append(textures_delta);
+            textures_delta = merged;
+        }
+
+        self.pending_paint = Some(PendingPaint {
+            primitives: self.egui_ctx.tessellate(full_output.shapes, pixels_per_point),
+            textures_delta,
             pixels_per_point,
-            &clipped_primitives,
-            textures_delta
-        );
+            screen_size: window.inner_size().into(),
+        });
 
         left * pixels_per_point
+    }
+
+    /// Paints the interface.
+    pub(crate) fn paint(&mut self) {
+        let Some(mut pending) = self.pending_paint.take() else {
+            return;
+        };
+
+        self.init_2d();
+        self.painter.paint_and_update_textures(
+            pending.screen_size,
+            pending.pixels_per_point,
+            &pending.primitives,
+            &mut pending.textures_delta
+        );
     }
 
     /// Checks whether the UI is focused (e.g., typing).
@@ -1793,32 +1815,13 @@ impl ViewerUI {
     }
 
     /// Prepares OpenGL for drawing 2D overlays.
-    pub(crate) fn init_2d(&self) {
+    fn init_2d(&self) {
         let gl = &self.gl;
+        // `mjr_render` leaves the polygon mode on GL_LINE when the wireframe flag is set, and
+        // egui sets every other state it needs in its own `prepare_painting`.
         // SAFETY: the GL context is current (made current by the render loop before this call).
-        unsafe { 
-            gl.disable(glow::DEPTH_TEST);
-            gl.disable(glow::CULL_FACE);
-            gl.disable(glow::BLEND);
-            gl.blend_func(glow::SRC_ALPHA, glow::ONE_MINUS_SRC_ALPHA);
-            gl.polygon_mode(glow::FRONT_AND_BACK, glow::FILL);
-        }
-    }
-
-    /// Resets OpenGL state. This is needed for MuJoCo's renderer.
-    pub(crate) fn reset(&mut self) {
-        let gl = &self.gl;
-        // SAFETY: the GL context is current; unbinding programs and buffers is always safe
-        // as long as no draw calls are in flight, which is guaranteed by the render loop.
         unsafe {
-            // Disable shaders
-            gl.use_program(None);
-
-            // Unbind buffers
-            gl.bind_vertex_array(None);
-            gl.bind_buffer(glow::ARRAY_BUFFER, None);
-            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, None);
-            gl.bind_framebuffer(glow::FRAMEBUFFER, None);
+            gl.polygon_mode(glow::FRONT_AND_BACK, glow::FILL);
         }
     }
 
@@ -1841,6 +1844,16 @@ impl ViewerUI {
     /// Must be called while the GL context is still current.
     pub(crate) fn destroy_gl(&mut self) {
         self.painter.destroy();
+    }
+}
+
+impl Drop for ViewerUI {
+    fn drop(&mut self) {
+        // A render attempt that ended in between calls leaves texture deltas behind.
+        // They must be cleared due to egui panicking otherwise on its own drop.
+        if let Some(pending) = &mut self.pending_paint {
+            pending.textures_delta.clear();
+        }
     }
 }
 

--- a/src/viewer/ui.rs
+++ b/src/viewer/ui.rs
@@ -1746,7 +1746,7 @@ impl ViewerUI {
         // Apply egui's platform output (cursor icon, clipboard, IME).
         self.state.handle_platform_output(window, full_output.platform_output);
 
-        // Tessalate and store result for later drawing.
+        // Tessellate and store result for later drawing.
         let pixels_per_point = full_output.pixels_per_point;
         let mut textures_delta = full_output.textures_delta;
 
@@ -1814,7 +1814,7 @@ impl ViewerUI {
         self.egui_ctx.memory_mut(|memory| memory.areas_mut().move_to_top(scene_layer));
     }
 
-    /// Prepares OpenGL for drawing 2D overlays.
+    /// Prepares OpenGL for the egui paint pass.
     fn init_2d(&self) {
         let gl = &self.gl;
         // `mjr_render` leaves the polygon mode on GL_LINE when the wireframe flag is set, and

--- a/src/viewer/ui.rs
+++ b/src/viewer/ui.rs
@@ -1746,11 +1746,11 @@ impl ViewerUI {
         // Apply egui's platform output (cursor icon, clipboard, IME).
         self.state.handle_platform_output(window, full_output.platform_output);
 
-        // Tessellate. The paint waits for MuJoCo to finish the frame; see `paint`.
+        // Tessalate and store result for later drawing.
         let pixels_per_point = full_output.pixels_per_point;
         let mut textures_delta = full_output.textures_delta;
 
-        // A render attempt that ended early between the two calls leaves its own deltas behind. They carry
+        // A render attempt that ended early leaves its own deltas uncleared. They carry
         // upload and free history that egui expects.
         if let Some(dropped) = self.pending_paint.take() {
             let mut merged = dropped.textures_delta;

--- a/src/wrappers/mj_rendering.rs
+++ b/src/wrappers/mj_rendering.rs
@@ -384,7 +384,10 @@ impl MjrContext {
         [ffi] glInitialized: bool; "whether OpenGL is initialized.";
         [ffi] windowAvailable: bool; "whether the default/window framebuffer is available.";
         [ffi] windowStereo: bool; "whether stereo is available for the default/window framebuffer.";
-        [ffi] windowDoublebuffer: bool; "whether the default/window framebuffer is double buffered.";
+    ]}
+
+    getter_setter! {get, set, [
+        [ffi, ffi_mut] windowDoublebuffer: bool; "whether the default/window framebuffer is double buffered.";
     ]}
 
     getter_setter! {get, [


### PR DESCRIPTION
Fixes segmentation fault with flexes; Update outdated OpenGL logic. The root cause was `egui_glow` setting its vertex buffer and not restoring it. This resulted in MuJoCo's renderer using wrong pointers for drawing.

TODO:
- Update versions and links.